### PR TITLE
docs: add v4.0.1 changelog entry for Sentinel Guard Sync release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the QWED Protocol will be documented in this file.
 
+## [4.0.1] - 2026-03-23
+### 🔄 Sentinel Guard Sync
+
+#### 🆕 New Endpoints
+- **`POST /verify/process`**: Glass-box reasoning process verifier — IRAC structural compliance and custom milestone validation with decimal scoring.
+- **Agent Security Checks**: `POST /agents/{id}/verify` now accepts `security_checks: { exfiltration, mcp_poison }` to run `ExfiltrationGuard` and `MCPPoisonGuard` before verification.
+
+#### 🔒 Security Fixes
+- **Information Disclosure**: Removed raw `str(e)` from `/verify/rag` error responses; exceptions logged via `redact_pii()`, clients receive only `INTERNAL_VERIFICATION_ERROR`. (Sentry + CodeQL)
+- **Symbolic Precision**: `RAGVerifyRequest.max_drm_rate` changed from `float | str` → `str` with `field_validator` enforcing Fraction-compatible values.
+
+#### 🛠️ SDK Changes (`@qwed-ai/sdk@4.0.1`)
+- **`verifyProcess()`**: Validates AI reasoning traces using IRAC or custom milestone lists.
+- **`verifyRAG()`**: `maxDrmRate` type changed from `number` to `string` for symbolic precision.
+- **`verifyAgent()`**: Returns `AgentVerificationResponse`, payload aligned with backend schema. Agent IDs URL-encoded.
+- **Type Fixes**: `VerificationResultData.risk` and `risk_level` separated. Added `Process`, `RAG`, `Security` to `VerificationType` enum.
+
+#### 🧪 Tests
+- `test_api_phase17_endpoints.py` — covers `/verify/process`, `/verify/rag` exception masking, and agent security check blocking.
+
 ## [4.0.0] - 2026-03-12
 ### 🛡️ Sentinel Edition
 


### PR DESCRIPTION
## Summary

Adds the `v4.0.1` changelog entry to [CHANGELOG.md](cci:7://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/CHANGELOG.md:0:0-0:0) ahead of the GitHub release. This must be merged **before** publishing the release so that automated docs at `docs.qwedai.com` reflect the latest changes.

## What's in v4.0.1

### New Endpoints
- `POST /verify/process` — IRAC structural compliance + milestone verification
- Agent [security_checks](cci:1://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/src/qwed_new/api/main.py:920:0-930:76) support ([exfiltration](cci:1://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/src/qwed_new/api/main.py:884:0-897:109), [mcp_poison](cci:1://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/src/qwed_new/api/main.py:899:0-918:97)) in `POST /agents/{id}/verify`

### Security Fixes
- Removed [str(e)](cci:1://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/sdk-ts/src/client.ts:34:4-37:5) leak from `/verify/rag` exception handler (Sentry + CodeQL)
- [max_drm_rate](cci:1://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/src/qwed_new/api/main.py:613:4-622:20) restricted to [str](cci:1://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/sdk-ts/src/client.ts:34:4-37:5) only with `field_validator` (symbolic precision)

### SDK Changes (`@qwed-ai/sdk@4.0.1`)
- Added [verifyProcess()](cci:1://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/sdk-ts/src/client.ts:236:4-245:5), fixed [verifyRAG()](cci:1://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/sdk-ts/src/client.ts:247:4-257:5) and [verifyAgent()](cci:1://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/sdk-ts/src/client.ts:259:4-291:5) signatures
- `VerificationResultData.risk` / `risk_level` type separation

### Tests
- [test_api_phase17_endpoints.py](cci:7://file:///c:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/tests/test_api_phase17_endpoints.py:0:0-0:0) covering all new endpoints

## Why v4.0.1?

v4.0.0 shipped the Sentinel Edition guards (RAG, Exfiltration, MCP Poison). This patch release syncs the TypeScript SDK methods, backend API schemas, and security fixes identified during PR #97 code review by Sentry, CodeRabbit, and SonarCloud.

## Checklist
- [x] CHANGELOG.md updated
- [ ] GitHub Release (`v4.0.1`) — will be created after this PR merges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new verification endpoint for validating reasoning processes with milestone-based scoring.
  * Extended agent verification to include security checks for exfiltration and poison detection.

* **Security**
  * Enhanced error response masking to prevent exposure of internal details.
  * Strengthened validation for rate-limiting configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->