### PR TITLE
Potential fix for code scanning alert no. 194: Log Injection

### DIFF
--- a/src/qwed_new/core/key_rotation.py
+++ b/src/qwed_new/core/key_rotation.py
@@ -90,7 +90,7 @@ class KeyManager:
             session.add(old_key)
             session.commit()
             
-            logger.info(f"Rotated key {old_key_id} -> {new_key.id}")
+            logger.info("Rotated key %d -> %d", int(old_key_id), int(new_key.id))
             return new_key, raw_new_key
 
     def check_expiring_keys(self):


### PR DESCRIPTION
Potential fix for [https://github.com/QWED-AI/qwed-verification/security/code-scanning/194](https://github.com/QWED-AI/qwed-verification/security/code-scanning/194)

In general, to fix log injection issues, any data that ultimately comes from user input should be sanitized or strongly typed before being logged: remove control characters (like `\r` and `\n`), or ensure the value is an integer/UUID and logged in a format that does not permit embedded control characters.

For this specific code, the best low-impact fix is to ensure the potentially tainted `old_key_id` is treated as a plain integer when logged, rather than as an arbitrary string that might include control characters. Since `old_key_id` is already typed as `int` in `rotate_key`, we can make the logging explicit and non-tainted by:
- Casting `old_key_id` and `new_key.id` to `int` (defensive, emphasizes the constraint).
- Logging them using numeric formatting (`%d`) instead of f-strings, which CodeQL often treats as more obviously safe for primitive types.

This keeps behavior identical (it still logs the IDs) but clarifies that only integer IDs are logged, not arbitrary strings. All changes are in `src/qwed_new/core/key_rotation.py`, limited to the logging call in `rotate_key`.

Concretely:
- In `KeyManager.rotate_key`, replace `logger.info(f"Rotated key {old_key_id} -> {new_key.id}")` with `logger.info("Rotated key %d -> %d", int(old_key_id), int(new_key.id))`. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal logging implementation for key rotation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->