### PR TITLE
Potential fix for code scanning alert no. 264: Wrong number of arguments in a call

### DIFF
--- a/src/qwed_new/core/observability.py
+++ b/src/qwed_new/core/observability.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     PROMETHEUS_AVAILABLE = False
     logger.warning("prometheus-client not installed. Prometheus metrics disabled.")
-    generate_latest = lambda r: b""
+    generate_latest = lambda: b""
     CONTENT_TYPE_LATEST = "text/plain"
 
 # Prometheus metric definitions

--- a/src/qwed_new/core/observability.py
+++ b/src/qwed_new/core/observability.py
@@ -24,7 +24,8 @@ try:
 except ImportError:
     PROMETHEUS_AVAILABLE = False
     logger.warning("prometheus-client not installed. Prometheus metrics disabled.")
-    generate_latest = lambda: b""
+    def generate_latest() -> bytes:
+        return b""
     CONTENT_TYPE_LATEST = "text/plain"
 
 # Prometheus metric definitions

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,28 @@
+import builtins
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def test_observability_falls_back_without_prometheus(monkeypatch):
+    module_path = Path(__file__).resolve().parents[1] / "src" / "qwed_new" / "core" / "observability.py"
+    spec = importlib.util.spec_from_file_location("observability_no_prometheus", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "prometheus_client":
+            raise ImportError("prometheus_client unavailable in test")
+        return real_import(name, globals, locals, fromlist, level)
+
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    spec.loader.exec_module(module)
+
+    assert module.PROMETHEUS_AVAILABLE is False
+    assert module.generate_latest() == b""
+    assert module.get_prometheus_metrics() == b"# Prometheus client not installed\n"
+    assert module.get_prometheus_content_type() == "text/plain"

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -12,10 +12,10 @@ def test_observability_falls_back_without_prometheus(monkeypatch):
 
     real_import = builtins.__import__
 
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    def fake_import(name, globals_=None, locals_=None, fromlist=(), level=0):
         if name == "prometheus_client":
             raise ImportError("prometheus_client unavailable in test")
-        return real_import(name, globals, locals, fromlist, level)
+        return real_import(name, globals_, locals_, fromlist, level)
 
     module = importlib.util.module_from_spec(spec)
     monkeypatch.setitem(sys.modules, spec.name, module)


### PR DESCRIPTION
Potential fix for [https://github.com/QWED-AI/qwed-verification/security/code-scanning/264](https://github.com/QWED-AI/qwed-verification/security/code-scanning/264)

To fix the problem, the fallback `generate_latest` defined in the `except ImportError` block must be callable with zero arguments, matching how it is used in `get_prometheus_metrics`. The simplest way is to change the lambda to accept no parameters, returning the same dummy byte string, so its signature is compatible with the real `prometheus_client.generate_latest` usage pattern in this file.

Concretely, in `src/qwed_new/core/observability.py`, around line 27, replace `generate_latest = lambda r: b""` with `generate_latest = lambda: b""`. No other behavior in the module needs to change: `get_prometheus_metrics` already calls `generate_latest()` without arguments, and the rest of the observability logic is unaffected. No new imports or helper functions are required; we only adjust the lambda’s parameter list.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed observability module to correctly handle missing Prometheus client dependency and prevent runtime errors during metrics generation.

* **Tests**
  * Added test coverage for observability fallback behavior when Prometheus client is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->