### PR TITLE
PR 0: Add QWED governance rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,15 +1,33 @@
 # Root of qwed-verification
 language: en-US
 reviews:
+  instructions: |
+    Follow QWED_RULES.md strictly.
+
+    QWED is a deterministic verification and enforcement boundary, not a
+    conventional application. Do not suggest changes that weaken enforcement in
+    exchange for convenience, usability, or availability.
+
+    Reject suggestions that introduce or recommend:
+    - fallback execution
+    - graceful degradation past failed verification
+    - raw eval/exec as backup behavior
+    - user-configurable security guards
+    - retries or auto-correction that bypass verification
+    - trust in model output as proof
+
+    Prefer fail-closed behavior and default-deny handling.
   auto_review:
     enabled: true
   path_instructions:
     - path: "**/*.py"
       instructions: |
         You are a security auditor for QWED (Deterministic AI Verification).
+
+        Follow QWED_RULES.md strictly.
         
         CRITICAL RULES:
         1. NO NON-DETERMINISM: Flag usage of 'random', 'uuid.uuid4()', or 'datetime.now()' inside verification logic. Inputs must be injected.
         2. SYMBOLIC MATH: Flag floating-point math (e.g., 0.1 + 0.2). Suggest 'decimal.Decimal' or 'sympy'.
-        3. SECURITY: Block 'eval()', 'exec()', or 'subprocess' unless wrapped in CodeGuard.
+        3. SECURITY: Reject fallback execution, graceful degradation, or retries that bypass verification. Block 'eval()', 'exec()', or 'subprocess' unless wrapped in CodeGuard and still compliant with QWED_RULES.md.
         4. IRAC: Ensure new legal guards follow Issue-Rule-Application-Conclusion structure [Source: MSLR].

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,14 @@
+# Copilot Instructions for QWED
+
+Read and follow [QWED_RULES.md](../QWED_RULES.md) for every suggestion.
+
+Additional repository-specific rules:
+
+- Do not suggest fallback execution paths.
+- Do not suggest graceful degradation that continues past failed verification.
+- Do not suggest retries that weaken enforcement.
+- Do not trust model output as proof of correctness.
+- Prefer fail-closed behavior over convenience or availability.
+
+If a suggestion conflicts with QWED enforcement rules, the suggestion must be
+rejected.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## QWED Enforcement Checklist
+
+- [ ] No fallback execution added
+- [ ] No new raw `eval` / `exec` usage introduced
+- [ ] Verification is enforced before execution
+- [ ] No silent error handling or bypass-oriented retries added
+- [ ] No trust placed in LLM-provided expected values, reasoning, or confidence
+- [ ] Failure paths remain fail-closed
+
+## Summary
+
+Describe the intent of the change and the verification boundary it touches.
+
+## Validation
+
+List the checks, tests, or scans used to validate this PR.
+
+## Notes
+
+If this change affects enforcement behavior, explain why it is still compliant
+with [QWED_RULES.md](../QWED_RULES.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for your interest in contributing! Before you start, please read this 
 | File | Why It Matters |
 |------|----------------|
 | [README.md](./README.md) | Understand what QWED is |
+| [QWED_RULES.md](./QWED_RULES.md) | Canonical enforcement rules for contributors and tools |
 | [docs/architecture.md](./docs/architecture.md) | System design and engine architecture |
 | [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) | Community standards |
 | [SECURITY.md](./SECURITY.md) | How to report vulnerabilities |
@@ -26,7 +27,10 @@ QWED is NOT just another LLM wrapper. Our philosophy:
 1. **LLMs are untrusted translators** - They convert natural language to structured queries
 2. **Symbolic engines are trusted verifiers** - SymPy, Z3, SQLGlot, etc. do the actual verification
 3. **Determinism is required** - Given the same input, output must be identical every time
-4. **LLM fallback is last resort** - Only when deterministic methods cannot handle the query
+4. **LLM output is never proof** - Models may assist with translation or enrichment, but they must not weaken deterministic enforcement
+
+When contributor guidance and enforcement guidance appear to conflict, follow
+`QWED_RULES.md` as the authoritative source for boundary behavior.
 
 ### ❌ Common Misunderstandings
 

--- a/QWED_RULES.md
+++ b/QWED_RULES.md
@@ -1,0 +1,60 @@
+# QWED Enforcement Rules
+
+QWED is not a conventional application. It is a deterministic verification and
+enforcement boundary.
+
+These rules are non-negotiable for contributors, reviewers, and automation
+tools operating on this repository.
+
+## Core Principles
+
+1. No fallback execution
+   - If verification fails, execution must stop.
+   - Do not add `eval`, `exec`, or fallback logic as a backup path.
+
+2. Fail closed
+   - Block on verification or enforcement failure.
+   - Availability is secondary to correctness and containment.
+
+3. Verification before execution
+   - No execution path may bypass verification.
+   - No exceptions for "safe enough" shortcuts.
+
+4. No trust in model output
+   - LLM outputs are untrusted inputs.
+   - Do not trust model-provided expected values, reasoning, confidence, or
+     metadata as proof.
+
+5. Security is mandatory
+   - Guards must be server-side and mandatory.
+   - User input must not decide whether enforcement runs.
+
+6. No silent handling
+   - Do not suppress verification or enforcement errors.
+   - Do not auto-correct, auto-retry, or continue in ways that weaken the
+     boundary.
+
+7. Default deny
+   - Unknown tools, inputs, and flows must be treated as high risk and blocked
+     until explicitly verified.
+
+## Forbidden Suggestions
+
+- "Add fallback for reliability"
+- "Gracefully handle failure by continuing execution"
+- "Use eval/exec as backup"
+- "Trust model output if confidence is high"
+- "Retry automatically until success"
+- "Allow temporary bypass until the verifier is available"
+
+## Decision Rule
+
+If a change improves usability, convenience, or availability but weakens
+enforcement, reject the change.
+
+Priority order:
+
+1. Determinism
+2. Safety
+3. Control
+4. Everything else


### PR DESCRIPTION
## Summary
- add a canonical `QWED_RULES.md` enforcement rules file at the repo root
- add repo-level Copilot instructions and a PR template aligned with QWED fail-closed philosophy
- strengthen existing CodeRabbit guidance to reject fallback execution and enforcement-weakening suggestions
- add a short contributor-doc pointer to the canonical rules file

## Why
This is PR 0 for the hardening sequence. It constrains review assistants and contributor guidance before we begin the code-level security PRs.

## Scope
- governance/docs/config only
- no runtime behavior changes
- no CI-blocking policy checks added in this PR

## Validation
- confirmed new governance files are present in expected repo locations
- confirmed `QWED_RULES.md` is referenced from Copilot instructions, CodeRabbit config, PR template, and contributor guidance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new enforcement and verification rules documentation.
  * Created pull request template with compliance requirements.
  * Updated contributor guidelines.

* **Chores**
  * Enhanced code review guidelines with updated requirements.
  * Added Copilot-specific instructions for repository consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->