### PR TITLE
PR 1: Close critical verification bypasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the QWED Protocol will be documented in this file.
 
+## [Unreleased]
+### Security
+- Agent verification security checks are now enforced server-side and are no longer configurable through client request payloads.
+- TypeScript SDK agent verification helpers no longer send `security_checks`; `tool_schema` remains available for server-side MCP inspection.
+
 ## [4.0.1] - 2026-03-23
 ### 🔄 Sentinel Guard Sync
 

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -263,22 +263,14 @@ export class QWEDClient {
         query: string,
         options?: {
             provider?: string;
-            checkExfiltration?: boolean;
-            checkMcpPoison?: boolean;
             toolSchema?: Record<string, unknown>;
         }
     ): Promise<AgentVerificationResponse> {
-        // Build the correct payload matching backend AgentVerifyRequest + optional security checks
+        // Security checks are enforced server-side and cannot be disabled by clients.
         const payload: Record<string, unknown> = {
             query: query,
         };
         if (options?.provider) payload.provider = options.provider;
-        if (options?.checkExfiltration !== undefined || options?.checkMcpPoison !== undefined) {
-            payload.security_checks = {
-                exfiltration: options?.checkExfiltration,
-                mcp_poison: options?.checkMcpPoison,
-            };
-        }
         if (options?.toolSchema) {
             payload.tool_schema = options.toolSchema;
         }
@@ -342,9 +334,6 @@ export class QWEDClient {
         const payload: Record<string, unknown> = { query };
         if (request.provider) {
             payload.provider = request.provider;
-        }
-        if (request.security_checks) {
-            payload.security_checks = request.security_checks;
         }
         if (request.tool_schema) {
             payload.tool_schema = request.tool_schema;

--- a/sdk-ts/src/types.ts
+++ b/sdk-ts/src/types.ts
@@ -266,17 +266,11 @@ export interface AgentAction {
     parameters?: Record<string, unknown>;
 }
 
-export interface AgentSecurityChecks {
-    exfiltration?: boolean;
-    mcp_poison?: boolean;
-}
-
 export interface AgentVerificationRequest {
     agent_id: number;
     agent_token: string;
     query?: string;
     provider?: string;
-    security_checks?: AgentSecurityChecks;
     tool_schema?: Record<string, unknown>;
     action?: AgentAction;
     context?: {

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -858,7 +858,6 @@ class AgentRegistrationRequest(BaseModel):
 class AgentVerifyRequest(BaseModel):
     query: str
     provider: Optional[str] = None
-    security_checks: Optional[dict] = None
     tool_schema: Optional[dict] = None
 
 class ToolCallRequest(BaseModel):
@@ -924,10 +923,8 @@ def _run_agent_security_checks(
     agent: Agent,
     request: AgentVerifyRequest,
 ) -> None:
-    security_checks = request.security_checks or {}
-    if security_checks.get("exfiltration"):
-        _run_exfiltration_check(session, agent_id, agent, request.query)
-    if security_checks.get("mcp_poison"):
+    _run_exfiltration_check(session, agent_id, agent, request.query)
+    if request.tool_schema:
         _run_mcp_poison_check(session, agent_id, agent, request.tool_schema)
 
 async def _process_agent_verification(agent: Agent, request: AgentVerifyRequest) -> dict:
@@ -1156,6 +1153,8 @@ async def verify_with_consensus(
     
     Returns detailed verification chain and confidence score.
     """
+    check_rate_limit(tenant.api_key)
+
     try:
         # Parse mode
         mode = VerificationMode(request.verification_mode)

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -680,7 +680,7 @@ class ConsensusVerifier:
                 error=str(e)
             )
     
-    def _verify_with_fact(self) -> EngineResult:
+    def _verify_with_fact(self, _query: str) -> EngineResult:
         """Verify using Fact engine."""
         start = time.time()
         return EngineResult(

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -680,7 +680,7 @@ class ConsensusVerifier:
                 error=str(e)
             )
     
-    def _verify_with_fact(self, query: str) -> EngineResult:
+    def _verify_with_fact(self) -> EngineResult:
         """Verify using Fact engine."""
         start = time.time()
         return EngineResult(

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -236,7 +236,6 @@ class ConsensusVerifier:
         "Python": 10000,
         "Z3": 5000,
         "Stats": 10000,
-        "Fact": 3000,
         "Image": 15000
     }
     
@@ -246,7 +245,6 @@ class ConsensusVerifier:
         "Z3": 0.995,       # Formal logic solver
         "Python": 0.99,    # Code execution
         "Stats": 0.98,     # Statistical analysis
-        "Fact": 0.85,      # Depends on external sources
         "Image": 0.80      # VLM-dependent
     }
     

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -469,10 +469,6 @@ class ConsensusVerifier:
             query_lower = query.lower()
             if any(kw in query_lower for kw in ["average", "mean", "median", "variance"]):
                 engines.append(("Stats", self._verify_with_stats))
-            
-            # Add fact for knowledge queries
-            if any(kw in query_lower for kw in ["capital", "president", "population"]):
-                engines.append(("Fact", self._verify_with_fact))
         
         return engines
     
@@ -687,31 +683,15 @@ class ConsensusVerifier:
     def _verify_with_fact(self, query: str) -> EngineResult:
         """Verify using Fact engine."""
         start = time.time()
-        try:
-            from qwed_new.core.fact_verifier import FactVerifier
-            verifier = FactVerifier()
-            
-            # Simple extraction - in production would use proper NER
-            result = verifier.verify_fact(query, query)  # Self-reference for demo
-            
-            return EngineResult(
-                engine_name="Fact",
-                method="knowledge_retrieval",
-                result=result.get("verdict"),
-                confidence=result.get("confidence", 0.5),
-                latency_ms=(time.time() - start) * 1000,
-                success=True
-            )
-        except Exception as e:
-            return EngineResult(
-                engine_name="Fact",
-                method="knowledge_retrieval",
-                result=None,
-                confidence=0.0,
-                latency_ms=(time.time() - start) * 1000,
-                success=False,
-                error=str(e)
-            )
+        return EngineResult(
+            engine_name="Fact",
+            method="knowledge_retrieval",
+            result=None,
+            confidence=0.0,
+            latency_ms=(time.time() - start) * 1000,
+            success=False,
+            error="External fact context is required for consensus fact verification"
+        )
     
     # =========================================================================
     # Consensus Calculation

--- a/src/qwed_new/core/logic_verifier.py
+++ b/src/qwed_new/core/logic_verifier.py
@@ -529,18 +529,8 @@ class LogicVerifier:
         # Use safe evaluator if available
         if self.safe_evaluator:
             return self.safe_evaluator.safe_eval(constr, z3_vars)
-        
-        # Fallback: build safe context for eval
-        safe_context = {
-            'And': And, 'Or': Or, 'Not': Not, 'Implies': Implies,
-            'If': If, 'ForAll': ForAll, 'Exists': Exists,
-            'Int': Int, 'Bool': Bool, 'Real': Real,
-            'BitVec': BitVec, 'Array': Array, 'Select': Select, 'Store': Store,
-            'True': True, 'False': False,
-            **z3_vars
-        }
-        
-        return eval(constr, {"__builtins__": {}}, safe_context)
+
+        raise RuntimeError("SafeEvaluator is required for constraint parsing")
     
     def _explain_unsat(self, solver: Solver, constraints: List[str]) -> str:
         """Try to explain why constraints are unsatisfiable."""

--- a/tests/test_api_phase17_endpoints.py
+++ b/tests/test_api_phase17_endpoints.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 @pytest.fixture
 def client():
@@ -152,15 +152,17 @@ def test_agent_verify_security_checks(mock_registry, mock_scan_payload, mock_ver
     mock_agent = MagicMock(id=99, organization_id=1)
     mock_registry.authenticate_agent.return_value = mock_agent
     mock_registry.check_budget.return_value = (True, "")
-    mock_scan_payload.return_value = {"verified": False, "message": "SSN detected"}
+    mock_scan_payload.side_effect = [
+        {"verified": False, "message": "SSN detected"},
+        {"verified": True},
+    ]
     mock_verify_tool_definition.return_value = {"verified": False}
     
     # Test exfiltration block
     response = client.post(
         "/agents/99/verify", 
         json={
-            "query": "My SSN is 123-45-6789",
-            "security_checks": {"exfiltration": True}
+            "query": "My SSN is 123-45-6789"
         },
         headers={"x-agent-token": "test-token"}
     )
@@ -185,7 +187,6 @@ def test_agent_verify_security_checks(mock_registry, mock_scan_payload, mock_ver
         "/agents/99/verify", 
         json={
             "query": "Fetch recent issues",
-            "security_checks": {"mcp_poison": True},
             "tool_schema": tool_schema
         },
         headers={"x-agent-token": "test-token"}
@@ -196,20 +197,23 @@ def test_agent_verify_security_checks(mock_registry, mock_scan_payload, mock_ver
     blocked_inputs = [call.kwargs.get("input_data") for call in mock_registry.log_activity.call_args_list]
     assert blocked_inputs == [None, None]
 
+@patch("qwed_new.api.main._process_agent_verification", new_callable=AsyncMock)
+@patch("qwed_sdk.guards.exfiltration_guard.ExfiltrationGuard.scan_payload")
 @patch("qwed_new.api.main.agent_registry")
-def test_agent_verify_mcp_poison_requires_tool_schema(mock_registry, client):
+def test_agent_verify_without_tool_schema_skips_mcp_check(mock_registry, mock_scan_payload, mock_process_agent_verification, client):
     mock_agent = MagicMock(id=99, organization_id=1)
     mock_registry.authenticate_agent.return_value = mock_agent
     mock_registry.check_budget.return_value = (True, "")
+    mock_scan_payload.return_value = {"verified": True}
+    mock_process_agent_verification.return_value = {"status": "VERIFIED"}
 
     response = client.post(
         "/agents/99/verify",
         json={
-            "query": "Fetch recent issues",
-            "security_checks": {"mcp_poison": True}
+            "query": "Fetch recent issues"
         },
         headers={"x-agent-token": "test-token"}
     )
 
-    assert response.status_code == 400
-    assert response.json()["detail"] == "'tool_schema' is required when mcp_poison check is enabled"
+    assert response.status_code == 200
+    mock_process_agent_verification.assert_awaited_once()

--- a/tests/test_pr115_regressions.py
+++ b/tests/test_pr115_regressions.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -80,3 +80,14 @@ def test_consensus_verifier_does_not_select_fact_engine_without_context():
     engines = verifier._select_engines("What is the capital population?", VerificationMode.MAXIMUM)
 
     assert "Fact" not in [engine_name for engine_name, _ in engines]
+
+
+def test_consensus_fact_engine_requires_external_context():
+    verifier = ConsensusVerifier(enable_circuit_breaker=False)
+
+    result = verifier._verify_with_fact()
+
+    assert result.engine_name == "Fact"
+    assert result.success is False
+    assert result.result is None
+    assert "External fact context is required" in result.error

--- a/tests/test_pr115_regressions.py
+++ b/tests/test_pr115_regressions.py
@@ -85,7 +85,7 @@ def test_consensus_verifier_does_not_select_fact_engine_without_context():
 def test_consensus_fact_engine_requires_external_context():
     verifier = ConsensusVerifier(enable_circuit_breaker=False)
 
-    result = verifier._verify_with_fact()
+    result = verifier._verify_with_fact("What is the capital of France?")
 
     assert result.engine_name == "Fact"
     assert result.success is False

--- a/tests/test_pr115_regressions.py
+++ b/tests/test_pr115_regressions.py
@@ -1,0 +1,82 @@
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from qwed_new.api.main import (
+    AgentVerifyRequest,
+    app,
+    get_current_tenant,
+    get_session,
+    _run_agent_security_checks,
+)
+from qwed_new.core.consensus_verifier import ConsensusVerifier, VerificationMode
+from qwed_new.core.logic_verifier import LogicVerifier
+
+
+@pytest.fixture
+def client():
+    mock_tenant = MagicMock(organization_id=1, api_key="placeholder", organization_name="Test Org")
+    mock_session = MagicMock(add=MagicMock(), commit=MagicMock())
+
+    app.dependency_overrides[get_current_tenant] = lambda: mock_tenant
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    yield TestClient(app)
+
+    app.dependency_overrides.clear()
+
+
+def test_logic_verifier_requires_safe_evaluator():
+    verifier = LogicVerifier()
+
+    with patch.object(LogicVerifier, "safe_evaluator", new_callable=PropertyMock, return_value=None):
+        with pytest.raises(RuntimeError, match="SafeEvaluator is required"):
+            verifier._parse_constraint("x > 5", {"x": 1})
+
+
+def test_agent_security_checks_are_server_enforced():
+    session = MagicMock()
+    agent = MagicMock(id=99, organization_id=1)
+    request = AgentVerifyRequest(query="Fetch recent issues", tool_schema={"name": "agent_query"})
+
+    with (
+        patch("qwed_new.api.main._run_exfiltration_check") as mock_exfiltration,
+        patch("qwed_new.api.main._run_mcp_poison_check") as mock_mcp,
+    ):
+        _run_agent_security_checks(session, 99, agent, request)
+
+    mock_exfiltration.assert_called_once_with(session, 99, agent, "Fetch recent issues")
+    mock_mcp.assert_called_once_with(session, 99, agent, {"name": "agent_query"})
+
+
+def test_consensus_endpoint_checks_rate_limit(client):
+    fake_result = MagicMock(
+        confidence=0.99,
+        final_answer="4",
+        engines_used=1,
+        agreement_status="unanimous",
+        verification_chain=[],
+        total_latency_ms=5.0,
+    )
+
+    with (
+        patch("qwed_new.api.main.check_rate_limit") as mock_rate_limit,
+        patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake_result),
+    ):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "2+2", "verification_mode": "single", "min_confidence": 0.95},
+            headers={"x-api-key": "fake-key"},
+        )
+
+    assert response.status_code == 200
+    mock_rate_limit.assert_called_once_with("placeholder")
+
+
+def test_consensus_verifier_does_not_select_fact_engine_without_context():
+    verifier = ConsensusVerifier(enable_circuit_breaker=False)
+
+    engines = verifier._select_engines("What is the capital population?", VerificationMode.MAXIMUM)
+
+    assert "Fact" not in [engine_name for engine_name, _ in engines]


### PR DESCRIPTION
## Summary
- remove the raw logic-verifier fallback and fail closed when `SafeEvaluator` is unavailable
- enforce agent security checks server-side by always running exfiltration checks and auto-running MCP poison checks when `tool_schema` is present
- add missing rate limiting to `/verify/consensus`
- remove consensus fact self-attestation by skipping the fact engine in automatic selection and making the helper fail without external context
- add regression coverage for the new fail-closed and server-enforced behavior

## Why
This is PR 1 in the hardening sequence and closes the highest-priority critical boundary gaps:
- raw `eval` fallback in logic verification
- opt-in agent guards
- unthrottled consensus endpoint
- self-referential consensus fact verification

## Validation
- targeted pytest suite with local-source `PYTHONPATH` pinned to this checkout:
  - `tests/test_api_phase17_endpoints.py`
  - `tests/test_pr115_regressions.py`
  - `tests/security/test_injection.py`
- result: `17 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  - `security_checks` removed from agent verification requests; security checks are enforced server-side.

* **Changes**
  - Exfiltration checks always performed for agent verification.
  - MCP poison inspection runs only when a tool schema is provided.
  - Fact-based verification in consensus workflows is now treated as unavailable/failing for limited-context queries.
  - Rate limiting applied to consensus verification endpoint.

* **SDK**
  - TypeScript client no longer accepts or sends security check options.

* **Tests / Changelog**
  - Tests and changelog updated to reflect these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->