### PR TITLE
PR 2: Disable unsafe execution fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the QWED Protocol will be documented in this file.
 ### Security
 - Agent verification security checks are now enforced server-side and are no longer configurable through client request payloads.
 - TypeScript SDK agent verification helpers no longer send `security_checks`; `tool_schema` remains available for server-side MCP inspection.
+- Statistical verification now requires the secure Docker sandbox; Wasm and restricted in-process fallback execution paths are disabled.
+- Consensus Python verification now uses the secure Docker executor instead of same-process code execution.
 
 ## [4.0.1] - 2026-03-23
 ### 🔄 Sentinel Guard Sync

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -184,6 +184,8 @@ async def verify_stats(
         verifier = StatsVerifier()
         
         result = verifier.verify_stats(query, df, provider=None)
+        if result.get("status") == "BLOCKED":
+            raise HTTPException(status_code=503, detail="Service temporarily unavailable")
         
         log = VerificationLog(
             organization_id=tenant.organization_id,
@@ -196,6 +198,8 @@ async def verify_stats(
         session.commit()
         
         return result
+    except HTTPException:
+        raise
         
     except Exception as e:
         logger.error(f"Stats verification error: {redact_pii(str(e))}", exc_info=False)

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -160,7 +160,13 @@ async def verify_logic(
             "provider_used": provider_used,
         }
 
-@app.post("/verify/stats")
+@app.post(
+    "/verify/stats",
+    responses={
+        403: {"description": "Verification blocked by security policy."},
+        503: {"description": "Secure execution runtime unavailable."},
+    },
+)
 async def verify_stats(
     file: UploadFile = File(...),
     query: str = Form(...),
@@ -1143,7 +1149,14 @@ class ConsensusVerifyRequest(BaseModel):
     verification_mode: str = "single"  # "single", "high", "maximum"
     min_confidence: float = 0.95  # 0.0 to 1.0
 
-@app.post("/verify/consensus")
+@app.post(
+    "/verify/consensus",
+    responses={
+        400: {"description": "Invalid verification mode."},
+        422: {"description": "Consensus confidence below requested minimum."},
+        503: {"description": "Secure execution runtime unavailable for required consensus depth."},
+    },
+)
 async def verify_with_consensus(
     request: ConsensusVerifyRequest,
     tenant: TenantContext = Depends(get_current_tenant),

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -180,12 +180,14 @@ async def verify_stats(
         import pandas as pd
         df = pd.read_csv(file.file)
         
-        from qwed_new.core.stats_verifier import StatsVerifier
+        from qwed_new.core.stats_verifier import StatsVerifier, SECURE_STATS_BLOCKED_CODE
         verifier = StatsVerifier()
         
         result = verifier.verify_stats(query, df, provider=None)
-        if result.get("status") == "BLOCKED":
+        if result.get("status") == "BLOCKED" and result.get("error") == SECURE_STATS_BLOCKED_CODE:
             raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+        if result.get("status") == "BLOCKED":
+            raise HTTPException(status_code=403, detail="Verification blocked by security policy")
         
         log = VerificationLog(
             organization_id=tenant.organization_id,
@@ -1174,6 +1176,9 @@ async def verify_with_consensus(
         mode=mode,
         min_confidence=request.min_confidence
     )
+
+    if result.agreement_status == "blocked_secure_execution":
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
     
     # Check if confidence meets requirement
     if result.confidence < request.min_confidence:

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -17,12 +17,12 @@ import time
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from collections import Counter
 import threading
 
 
 logger = logging.getLogger(__name__)
 SECURE_EXECUTION_REQUIRED = "SECURE_EXECUTION_REQUIRED"
+_NONE_CONSENSUS_KEY = "__QWED_NONE__"
 
 
 class VerificationMode(str, Enum):
@@ -610,7 +610,7 @@ class ConsensusVerifier:
             # Execute only through the secure Docker sandbox.
             success, error, output = self.secure_executor.execute(code, {})
             if not success:
-                if error and "Cannot execute code securely" in error:
+                if error == "SECURE_RUNTIME_UNAVAILABLE":
                     error = SECURE_EXECUTION_REQUIRED
                 return EngineResult(
                     engine_name="Python",
@@ -737,10 +737,12 @@ class ConsensusVerifier:
         
         # Weight answers by engine reliability
         weighted_answers: Dict[str, float] = {}
+        answer_values: Dict[str, Any] = {}
         for r in successful:
-            answer_key = str(r.result)
+            answer_key = self._consensus_answer_key(r.result)
             weight = self.ENGINE_WEIGHTS.get(r.engine_name, 0.5) * r.confidence
             weighted_answers[answer_key] = weighted_answers.get(answer_key, 0) + weight
+            answer_values.setdefault(answer_key, r.result)
         
         # Find best answer
         best_answer = max(weighted_answers, key=weighted_answers.get)
@@ -748,7 +750,7 @@ class ConsensusVerifier:
         best_weight = weighted_answers[best_answer]
         
         # Determine agreement status
-        if len(set(str(r.result) for r in successful)) == 1:
+        if len({self._consensus_answer_key(r.result) for r in successful}) == 1:
             status = "unanimous"
             confidence = min(0.999, best_weight / len(successful))
         elif best_weight > total_weight / 2:
@@ -759,10 +761,17 @@ class ConsensusVerifier:
             confidence = min(0.7, best_weight / total_weight)
         
         return {
-            "answer": best_answer,
+            "answer": answer_values[best_answer],
             "confidence": confidence,
             "status": status
         }
+
+    @staticmethod
+    def _consensus_answer_key(result: Any) -> str:
+        """Normalize consensus answer keys without collapsing null to the string 'None'."""
+        if result is None:
+            return _NONE_CONSENSUS_KEY
+        return str(result)
     
     # =========================================================================
     # Helper Methods

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -270,6 +270,7 @@ class ConsensusVerifier:
         self._math_verifier = None
         self._logic_verifier = None
         self._code_verifier = None
+        self._secure_executor = None
         self._stats_verifier = None
         self._reasoning_verifier = None
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
@@ -295,6 +296,13 @@ class ConsensusVerifier:
             from qwed_new.core.code_verifier import CodeVerifier
             self._code_verifier = CodeVerifier()
         return self._code_verifier
+
+    @property
+    def secure_executor(self):
+        if self._secure_executor is None:
+            from qwed_new.core.secure_code_executor import SecureCodeExecutor
+            self._secure_executor = SecureCodeExecutor()
+        return self._secure_executor
     
     @property
     def stats_verifier(self):
@@ -591,9 +599,7 @@ class ConsensusVerifier:
                 )
             
             # Execute only through the secure Docker sandbox.
-            from qwed_new.core.secure_code_executor import SecureCodeExecutor
-            executor = SecureCodeExecutor()
-            success, error, output = executor.execute(code, {})
+            success, error, output = self.secure_executor.execute(code, {})
             if not success:
                 return EngineResult(
                     engine_name="Python",
@@ -776,7 +782,7 @@ class ConsensusVerifier:
             from qwed_new.core.translator import TranslationLayer
             translator = TranslationLayer()
             task = translator.translate(query)
-            return f"print({task.expression})"
+            return f"result = {task.expression}"
         except Exception as e:
             raise ValueError(f"Verification code generation failed: {e}") from e
     

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -22,6 +22,7 @@ import threading
 
 
 logger = logging.getLogger(__name__)
+SECURE_EXECUTION_REQUIRED = "SECURE_EXECUTION_REQUIRED"
 
 
 class VerificationMode(str, Enum):
@@ -272,6 +273,7 @@ class ConsensusVerifier:
         self._code_verifier = None
         self._secure_executor = None
         self._stats_verifier = None
+        self._translator = None
         self._reasoning_verifier = None
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
     
@@ -282,6 +284,13 @@ class ConsensusVerifier:
             from qwed_new.core.verifier import VerificationEngine
             self._math_verifier = VerificationEngine()
         return self._math_verifier
+
+    @property
+    def translator(self):
+        if self._translator is None:
+            from qwed_new.core.translator import TranslationLayer
+            self._translator = TranslationLayer()
+        return self._translator
     
     @property
     def logic_verifier(self):
@@ -601,6 +610,8 @@ class ConsensusVerifier:
             # Execute only through the secure Docker sandbox.
             success, error, output = self.secure_executor.execute(code, {})
             if not success:
+                if error and "Cannot execute code securely" in error:
+                    error = SECURE_EXECUTION_REQUIRED
                 return EngineResult(
                     engine_name="Python",
                     method="code_execution",
@@ -715,6 +726,9 @@ class ConsensusVerifier:
         """Calculate weighted consensus from engine results."""
         if not results:
             return {"answer": None, "confidence": 0.0, "status": "no_results"}
+
+        if any(r.error == SECURE_EXECUTION_REQUIRED for r in results):
+            return {"answer": None, "confidence": 0.0, "status": "blocked_secure_execution"}
         
         successful = [r for r in results if r.success]
         
@@ -779,9 +793,7 @@ class ConsensusVerifier:
     def _generate_verification_code(self, query: str) -> str:
         """Generate Python code for verification."""
         try:
-            from qwed_new.core.translator import TranslationLayer
-            translator = TranslationLayer()
-            task = translator.translate(query)
+            task = self.translator.translate(query)
             return f"result = {task.expression}"
         except Exception as e:
             raise ValueError(f"Verification code generation failed: {e}") from e

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -572,7 +572,7 @@ class ConsensusVerifier:
             )
     
     def _verify_with_code(self, query: str) -> EngineResult:
-        """Verify by executing Python code."""
+        """Verify by executing Python code in the secure Docker sandbox."""
         start = time.time()
         try:
             code = self._generate_verification_code(query)
@@ -590,10 +590,20 @@ class ConsensusVerifier:
                     error=f"Unsafe code: {safety_result['issues']}"
                 )
             
-            # Execute
-            from qwed_new.core.code_executor import CodeExecutor
-            executor = CodeExecutor()
-            output = executor.execute(code)
+            # Execute only through the secure Docker sandbox.
+            from qwed_new.core.secure_code_executor import SecureCodeExecutor
+            executor = SecureCodeExecutor()
+            success, error, output = executor.execute(code, {})
+            if not success:
+                return EngineResult(
+                    engine_name="Python",
+                    method="code_execution",
+                    result=None,
+                    confidence=0.0,
+                    latency_ms=(time.time() - start) * 1000,
+                    success=False,
+                    error=error
+                )
             
             return EngineResult(
                 engine_name="Python",

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -307,7 +307,7 @@ except Exception as e:
     
     def is_available(self) -> bool:
         """Check if Docker is currently available."""
-        if not self.docker_available or self.client is None:
+        if self.client is None:
             return False
 
         try:
@@ -315,7 +315,6 @@ except Exception as e:
             return True
         except Exception as e:
             logger.warning("Docker availability check failed: %s", e)
-            self.docker_available = False
             return False
 
 

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -37,6 +37,7 @@ class SecureCodeExecutor:
     """
     
     def __init__(self):
+        self.client = None
         try:
             self.client = docker.from_env()
             self.docker_available = True
@@ -65,7 +66,7 @@ class SecureCodeExecutor:
         Returns:
             (success, error_message, result)
         """
-        if not self.docker_available:
+        if not self.is_available():
             return False, "Docker is not available. Cannot execute code securely.", None
         
         # 1. Pre-execution validation using AST
@@ -304,8 +305,17 @@ except Exception as e:
         return self.execution_count
     
     def is_available(self) -> bool:
-        """Check if Docker is available."""
-        return self.docker_available
+        """Check if Docker is currently available."""
+        if not self.docker_available or self.client is None:
+            return False
+
+        try:
+            self.client.ping()
+            return True
+        except Exception as e:
+            logger.warning("Docker availability check failed: %s", e)
+            self.docker_available = False
+            return False
 
 
 class ExecutionError(Exception):

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Tuple, Optional
 
 
 logger = logging.getLogger(__name__)
+SECURE_RUNTIME_UNAVAILABLE = "SECURE_RUNTIME_UNAVAILABLE"
 
 def _sanitize_log_msg(msg: str) -> str:
     """Strip newline characters to prevent log injection."""
@@ -67,7 +68,7 @@ class SecureCodeExecutor:
             (success, error_message, result)
         """
         if not self.is_available():
-            return False, "Docker is not available. Cannot execute code securely.", None
+            return False, SECURE_RUNTIME_UNAVAILABLE, None
         
         # 1. Pre-execution validation using AST
         is_safe, safety_reason = self._is_safe_code(code)

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -24,6 +24,7 @@ SECURE_STATS_SANDBOX_REQUIRED = (
     "Statistical verification requires the secure Docker sandbox. "
     "In-process fallback execution is disabled."
 )
+SECURE_STATS_BLOCKED_CODE = "SERVICE_UNAVAILABLE"
 
 
 @dataclass
@@ -387,10 +388,9 @@ class StatsVerifier:
             logger.warning("Blocked stats execution because secure Docker sandbox is unavailable")
             return {
                 "status": "BLOCKED",
-                "error": SECURE_STATS_SANDBOX_REQUIRED,
+                "error": SECURE_STATS_BLOCKED_CODE,
                 "code": code,
                 "columns": columns,
-                "risk_level": "critical",
                 "execution_time_ms": (time.time() - start_time) * 1000
             }
         

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -25,6 +25,7 @@ SECURE_STATS_SANDBOX_REQUIRED = (
     "In-process fallback execution is disabled."
 )
 SECURE_STATS_BLOCKED_CODE = "SERVICE_UNAVAILABLE"
+SECURE_STATS_RUNTIME_UNAVAILABLE = "SECURE_RUNTIME_UNAVAILABLE"
 
 
 @dataclass
@@ -415,6 +416,16 @@ class StatsVerifier:
                 "execution_time_ms": exec_result.execution_time_ms,
                 "total_time_ms": total_time
             }
+        if exec_result.error == SECURE_STATS_RUNTIME_UNAVAILABLE:
+            logger.warning("Blocked stats execution because secure Docker sandbox became unavailable")
+            return {
+                "status": "BLOCKED",
+                "error": SECURE_STATS_BLOCKED_CODE,
+                "code": code,
+                "columns": columns,
+                "execution_time_ms": exec_result.execution_time_ms,
+                "total_time_ms": total_time
+            }
         else:
             return {
                 "status": "EXECUTION_FAILED",
@@ -484,6 +495,8 @@ class StatsVerifier:
         
         try:
             success, error, result = self.docker_executor.execute(code, context)
+            if error == "SECURE_RUNTIME_UNAVAILABLE":
+                error = SECURE_STATS_RUNTIME_UNAVAILABLE
             
             return ExecutionResult(
                 success=success,

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -1,13 +1,10 @@
 """
 Enterprise Statistical Verification Engine.
 
-Verifies claims about tabular data with secure execution options:
-1. Docker sandbox (production)
-2. Wasm sandbox (portable)
-3. Restricted executor (fallback)
+Verifies claims about tabular data using a secure Docker sandbox.
+In-process execution fallbacks are intentionally disabled.
 
 Enhanced Features:
-- Multiple sandbox options
 - Pre-execution security validation
 - Memory and CPU limits
 - Timeout enforcement
@@ -22,6 +19,11 @@ from dataclasses import dataclass, field
 import ast
 
 logger = logging.getLogger(__name__)
+
+SECURE_STATS_SANDBOX_REQUIRED = (
+    "Statistical verification requires the secure Docker sandbox. "
+    "In-process fallback execution is disabled."
+)
 
 
 @dataclass
@@ -46,10 +48,10 @@ class SecurityReport:
 
 class WasmSandbox:
     """
-    WebAssembly-based sandbox for portable secure execution.
-    
-    Uses Pyodide (Python in Wasm) for sandboxed execution.
-    More portable than Docker, works in any environment.
+    Deprecated Wasm fallback.
+
+    This class is retained only to preserve explicit fail-closed behavior for
+    older call sites. It never executes model-generated code in-process.
 
     Attributes:
         memory_limit_mb (int): Memory limit in MB.
@@ -105,8 +107,8 @@ class WasmSandbox:
         """
         Execute code in Wasm sandbox.
         
-        Since Pyodide requires async/browser context, this implementation
-        uses a restricted Python executor with similar security properties.
+        The Wasm fallback is intentionally disabled. QWED requires Docker
+        isolation for model-generated statistical code.
 
         Args:
             code: Python code to execute.
@@ -117,82 +119,25 @@ class WasmSandbox:
 
         Example:
             >>> result = sandbox.execute("result = 1 + 1", {})
-            >>> print(result.result)
-            2
+            >>> print(result.success)
+            False
         """
+        del code, context
         start_time = time.time()
-        
-        # For now, use a restricted executor since true Wasm requires
-        # browser context or specific runtime
-        try:
-            result = self._execute_restricted(code, context)
-            return ExecutionResult(
-                success=True,
-                result=result,
-                execution_time_ms=(time.time() - start_time) * 1000,
-                sandbox_type="wasm_restricted"
-            )
-        except Exception as e:
-            return ExecutionResult(
-                success=False,
-                error=str(e),
-                execution_time_ms=(time.time() - start_time) * 1000,
-                sandbox_type="wasm_restricted"
-            )
-    
-    def _execute_restricted(self, code: str, context: Dict[str, Any]) -> Any:
-        """Execute code in restricted Python environment."""
-        # Create very restricted namespace
-        import statistics
-        import math
-        
-        safe_builtins = {
-            'abs': abs,
-            'all': all,
-            'any': any,
-            'bool': bool,
-            'float': float,
-            'int': int,
-            'len': len,
-            'list': list,
-            'max': max,
-            'min': min,
-            'print': print,
-            'range': range,
-            'round': round,
-            'sorted': sorted,
-            'str': str,
-            'sum': sum,
-            'tuple': tuple,
-            'zip': zip,
-            'enumerate': enumerate,
-            'dict': dict,
-            'set': set,
-            'True': True,
-            'False': False,
-            'None': None,
-        }
-        
-        safe_namespace = {
-            '__builtins__': safe_builtins,
-            'pd': pd,
-            'statistics': statistics,
-            'math': math,
-            **context
-        }
-        
-        # Execute with timeout (basic implementation)
-        exec(code, safe_namespace)
-        
-        # Return last computed value if stored in 'result'
-        return safe_namespace.get('result', safe_namespace.get('answer', None))
+        return ExecutionResult(
+            success=False,
+            error=SECURE_STATS_SANDBOX_REQUIRED,
+            execution_time_ms=(time.time() - start_time) * 1000,
+            sandbox_type="wasm_disabled"
+        )
 
 
 class RestrictedExecutor:
     """
-    Fallback executor with AST-based security restrictions.
-    
-    Analyzes code AST to block dangerous operations before execution.
+    Restricted AST validator for generated statistical code.
+
+    Execution is intentionally disabled; the class only retains AST validation
+    helpers so QWED can block unsafe code before Docker execution.
 
     Attributes:
         timeout_seconds (float): Execution timeout in seconds.
@@ -267,7 +212,7 @@ class RestrictedExecutor:
     
     def execute(self, code: str, context: Dict[str, Any]) -> ExecutionResult:
         """
-        Execute code if it passes safety checks.
+        Execution is intentionally disabled.
 
         Args:
             code: Python code to execute.
@@ -278,69 +223,24 @@ class RestrictedExecutor:
 
         Example:
             >>> result = executor.execute("result = 5 * 5", {})
-            >>> print(result.result)
-            25
+            >>> print(result.success)
+            False
         """
+        del code, context
         start_time = time.time()
-        
-        is_safe, issues = self.is_code_safe(code)
-        if not is_safe:
-            return ExecutionResult(
-                success=False,
-                error=f"Code failed safety check: {issues}",
-                execution_time_ms=(time.time() - start_time) * 1000,
-                sandbox_type="restricted"
-            )
-        
-        # Create restricted namespace
-        import statistics
-        import math
-        
-        safe_builtins = {
-            'abs': abs, 'all': all, 'any': any, 'bool': bool,
-            'float': float, 'int': int, 'len': len, 'list': list,
-            'max': max, 'min': min, 'print': print, 'range': range,
-            'round': round, 'sorted': sorted, 'str': str, 'sum': sum,
-            'tuple': tuple, 'zip': zip, 'enumerate': enumerate,
-            'dict': dict, 'set': set,
-            'True': True, 'False': False, 'None': None,
-        }
-        
-        namespace = {
-            '__builtins__': safe_builtins,
-            'pd': pd,
-            'statistics': statistics,
-            'math': math,
-            **context
-        }
-        
-        try:
-            exec(code, namespace)
-            result = namespace.get('result', namespace.get('answer', None))
-            
-            return ExecutionResult(
-                success=True,
-                result=result,
-                execution_time_ms=(time.time() - start_time) * 1000,
-                sandbox_type="restricted"
-            )
-        except Exception as e:
-            return ExecutionResult(
-                success=False,
-                error=str(e),
-                execution_time_ms=(time.time() - start_time) * 1000,
-                sandbox_type="restricted"
-            )
+        return ExecutionResult(
+            success=False,
+            error=SECURE_STATS_SANDBOX_REQUIRED,
+            execution_time_ms=(time.time() - start_time) * 1000,
+            sandbox_type="restricted_disabled"
+        )
 
 
 class StatsVerifier:
     """
     Enterprise Statistical Verification Engine.
     
-    Verifies claims about tabular data with multiple sandbox options:
-    1. Docker (most secure, requires Docker)
-    2. Wasm (portable, works anywhere)
-    3. Restricted (fallback, AST-validated)
+    Verifies claims about tabular data using the secure Docker sandbox only.
 
     Attributes:
         preferred_sandbox (str): Preferred sandbox type.
@@ -359,11 +259,12 @@ class StatsVerifier:
         
         Args:
             preferred_sandbox: "docker", "wasm", "restricted", or "auto".
+                Non-Docker choices are blocked for model-generated code.
             timeout_seconds: Execution timeout in seconds.
             memory_limit_mb: Memory limit in megabytes.
 
         Example:
-            >>> verifier = StatsVerifier(preferred_sandbox="restricted")
+            >>> verifier = StatsVerifier(preferred_sandbox="docker")
         """
         self.preferred_sandbox = preferred_sandbox
         self.timeout_seconds = timeout_seconds
@@ -421,25 +322,11 @@ class StatsVerifier:
         return self._restricted_executor
     
     def _select_sandbox(self) -> Tuple[str, Any]:
-        """Select best available sandbox."""
-        if self.preferred_sandbox == "docker":
-            if self.docker_executor and self.docker_executor.is_available():
-                return "docker", self.docker_executor
-        
-        if self.preferred_sandbox == "wasm":
-            return "wasm", self.wasm_sandbox
-        
-        if self.preferred_sandbox == "restricted":
-            return "restricted", self.restricted_executor
-        
-        # Auto: try Docker first, then Wasm, then restricted
+        """Select the secure sandbox or fail closed."""
         if self.docker_executor and self.docker_executor.is_available():
             return "docker", self.docker_executor
-        
-        if self.wasm_sandbox.is_available():
-            return "wasm", self.wasm_sandbox
-        
-        return "restricted", self.restricted_executor
+
+        return "blocked", None
     
     def verify_stats(
         self,
@@ -496,15 +383,20 @@ class StatsVerifier:
         
         # 3. Select sandbox and execute
         sandbox_type, sandbox = self._select_sandbox()
+        if sandbox_type != "docker" or sandbox is None:
+            logger.warning("Blocked stats execution because secure Docker sandbox is unavailable")
+            return {
+                "status": "BLOCKED",
+                "error": SECURE_STATS_SANDBOX_REQUIRED,
+                "code": code,
+                "columns": columns,
+                "risk_level": "critical",
+                "execution_time_ms": (time.time() - start_time) * 1000
+            }
         
         context = {"df": df}
         
-        if sandbox_type == "docker":
-            exec_result = self._execute_docker(code, context)
-        elif sandbox_type == "wasm":
-            exec_result = self.wasm_sandbox.execute(code, context)
-        else:
-            exec_result = self.restricted_executor.execute(code, context)
+        exec_result = self._execute_docker(code, context)
         
         total_time = (time.time() - start_time) * 1000
         
@@ -697,7 +589,7 @@ class StatsVerifier:
         return {
             "preferred": self.preferred_sandbox,
             "docker_available": docker_available,
-            "wasm_available": self.wasm_sandbox.is_available(),
-            "restricted_available": True,  # Always available
+            "wasm_available": False,
+            "restricted_available": False,
             "current": self._select_sandbox()[0]
         }

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -494,8 +494,9 @@ class StatsVerifier:
         start_time = time.time()
         
         try:
+            from qwed_new.core.secure_code_executor import SECURE_RUNTIME_UNAVAILABLE
             success, error, result = self.docker_executor.execute(code, context)
-            if error == "SECURE_RUNTIME_UNAVAILABLE":
+            if error == SECURE_RUNTIME_UNAVAILABLE:
                 error = SECURE_STATS_RUNTIME_UNAVAILABLE
             
             return ExecutionResult(

--- a/tests/test_pr117_regressions.py
+++ b/tests/test_pr117_regressions.py
@@ -1,14 +1,31 @@
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
 
+from qwed_new.api.main import app, get_current_tenant, get_session
 from qwed_new.core.consensus_verifier import ConsensusVerifier
 from qwed_new.core.stats_verifier import (
+    SECURE_STATS_BLOCKED_CODE,
     SECURE_STATS_SANDBOX_REQUIRED,
     RestrictedExecutor,
     StatsVerifier,
     WasmSandbox,
 )
+
+
+@pytest.fixture
+def client():
+    mock_tenant = MagicMock(organization_id=1, api_key="placeholder", organization_name="Test Org")
+    mock_session = MagicMock(add=MagicMock(), commit=MagicMock())
+
+    app.dependency_overrides[get_current_tenant] = lambda: mock_tenant
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    yield TestClient(app)
+
+    app.dependency_overrides.clear()
 
 
 def test_wasm_stats_fallback_is_fail_closed():
@@ -43,8 +60,7 @@ def test_stats_verifier_blocks_without_secure_docker_runtime():
     result = verifier.verify_stats("What is the mean of value?", df)
 
     assert result["status"] == "BLOCKED"
-    assert result["error"] == SECURE_STATS_SANDBOX_REQUIRED
-    assert result["risk_level"] == "critical"
+    assert result["error"] == SECURE_STATS_BLOCKED_CODE
 
 
 def test_stats_sandbox_info_reports_fail_closed_without_docker():
@@ -58,6 +74,23 @@ def test_stats_sandbox_info_reports_fail_closed_without_docker():
     assert info["wasm_available"] is False
     assert info["restricted_available"] is False
     assert info["current"] == "blocked"
+
+
+def test_stats_api_masks_secure_runtime_unavailability(client):
+    with patch("qwed_new.core.stats_verifier.StatsVerifier.verify_stats") as mock_verify_stats:
+        mock_verify_stats.return_value = {
+            "status": "BLOCKED",
+            "error": SECURE_STATS_BLOCKED_CODE,
+        }
+        response = client.post(
+            "/verify/stats",
+            files={"file": ("data.csv", b"value\n1\n2\n", "text/csv")},
+            data={"query": "What is the mean of value?"},
+            headers={"x-api-key": "fake-key"},
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Service temporarily unavailable"
 
 
 def test_consensus_code_engine_requires_secure_executor():
@@ -98,3 +131,13 @@ def test_consensus_code_engine_uses_secure_executor_output():
     assert result.success is True
     assert result.result == "4"
     assert result.engine_name == "Python"
+
+
+def test_consensus_codegen_assigns_result_variable():
+    verifier = ConsensusVerifier(enable_circuit_breaker=False)
+    with patch("qwed_new.core.translator.TranslationLayer") as mock_translator_cls:
+        mock_translator = mock_translator_cls.return_value
+        mock_translator.translate.return_value = MagicMock(expression="2 + 2")
+        code = verifier._generate_verification_code("What is 2+2?")
+
+    assert code == "result = 2 + 2"

--- a/tests/test_pr117_regressions.py
+++ b/tests/test_pr117_regressions.py
@@ -177,3 +177,24 @@ def test_consensus_blocks_when_secure_execution_is_required():
     assert consensus["answer"] is None
     assert consensus["confidence"] == 0.0
     assert consensus["status"] == "blocked_secure_execution"
+
+
+def test_consensus_api_masks_secure_execution_block(client):
+    fake_result = MagicMock(
+        confidence=0.0,
+        final_answer=None,
+        engines_used=2,
+        agreement_status="blocked_secure_execution",
+        verification_chain=[],
+        total_latency_ms=5.0,
+    )
+
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake_result):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "2+2", "verification_mode": "high", "min_confidence": 0.95},
+            headers={"x-api-key": "fake-key"},
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Service temporarily unavailable"

--- a/tests/test_pr117_regressions.py
+++ b/tests/test_pr117_regressions.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from qwed_new.core.consensus_verifier import ConsensusVerifier
+from qwed_new.core.stats_verifier import (
+    SECURE_STATS_SANDBOX_REQUIRED,
+    RestrictedExecutor,
+    StatsVerifier,
+    WasmSandbox,
+)
+
+
+def test_wasm_stats_fallback_is_fail_closed():
+    result = WasmSandbox().execute("result = 1", {})
+
+    assert result.success is False
+    assert result.result is None
+    assert result.sandbox_type == "wasm_disabled"
+    assert result.error == SECURE_STATS_SANDBOX_REQUIRED
+
+
+def test_restricted_stats_fallback_is_fail_closed():
+    result = RestrictedExecutor().execute("result = 1", {})
+
+    assert result.success is False
+    assert result.result is None
+    assert result.sandbox_type == "restricted_disabled"
+    assert result.error == SECURE_STATS_SANDBOX_REQUIRED
+
+
+def test_stats_verifier_blocks_without_secure_docker_runtime():
+    verifier = StatsVerifier()
+    verifier._translator = MagicMock()
+    verifier._translator.translate_stats.return_value = "result = df['value'].mean()"
+    verifier._code_verifier = MagicMock()
+    verifier._code_verifier.verify_code.return_value = {"is_safe": True}
+    verifier._docker_executor = MagicMock()
+    verifier._docker_executor.is_available.return_value = False
+
+    df = pd.DataFrame({"value": [1, 2, 3]})
+
+    result = verifier.verify_stats("What is the mean of value?", df)
+
+    assert result["status"] == "BLOCKED"
+    assert result["error"] == SECURE_STATS_SANDBOX_REQUIRED
+    assert result["risk_level"] == "critical"
+
+
+def test_stats_sandbox_info_reports_fail_closed_without_docker():
+    verifier = StatsVerifier()
+    verifier._docker_executor = MagicMock()
+    verifier._docker_executor.is_available.return_value = False
+
+    info = verifier.get_sandbox_info()
+
+    assert info["docker_available"] is False
+    assert info["wasm_available"] is False
+    assert info["restricted_available"] is False
+    assert info["current"] == "blocked"
+
+
+def test_consensus_code_engine_requires_secure_executor():
+    verifier = ConsensusVerifier(enable_circuit_breaker=False)
+    verifier._code_verifier = MagicMock()
+    verifier._code_verifier.verify_code.return_value = {"is_safe": True}
+
+    with (
+        patch.object(ConsensusVerifier, "_generate_verification_code", return_value="result = 4"),
+        patch("qwed_new.core.secure_code_executor.SecureCodeExecutor") as mock_executor_cls,
+    ):
+        mock_executor = mock_executor_cls.return_value
+        mock_executor.execute.return_value = (
+            False,
+            "Docker is not available. Cannot execute code securely.",
+            None,
+        )
+        result = verifier._verify_with_code("What is 2+2?")
+
+    assert result.success is False
+    assert result.result is None
+    assert "Docker is not available" in result.error
+
+
+def test_consensus_code_engine_uses_secure_executor_output():
+    verifier = ConsensusVerifier(enable_circuit_breaker=False)
+    verifier._code_verifier = MagicMock()
+    verifier._code_verifier.verify_code.return_value = {"is_safe": True}
+
+    with (
+        patch.object(ConsensusVerifier, "_generate_verification_code", return_value="result = 4"),
+        patch("qwed_new.core.secure_code_executor.SecureCodeExecutor") as mock_executor_cls,
+    ):
+        mock_executor = mock_executor_cls.return_value
+        mock_executor.execute.return_value = (True, None, "4")
+        result = verifier._verify_with_code("What is 2+2?")
+
+    assert result.success is True
+    assert result.result == "4"
+    assert result.engine_name == "Python"

--- a/tests/test_pr117_regressions.py
+++ b/tests/test_pr117_regressions.py
@@ -10,6 +10,7 @@ from qwed_new.core.consensus_verifier import (
     ConsensusVerifier,
     EngineResult,
 )
+from qwed_new.core.secure_code_executor import SECURE_RUNTIME_UNAVAILABLE
 from qwed_new.core.stats_verifier import (
     SECURE_STATS_BLOCKED_CODE,
     SECURE_STATS_SANDBOX_REQUIRED,
@@ -128,7 +129,7 @@ def test_consensus_code_engine_requires_secure_executor():
         mock_executor = mock_executor_cls.return_value
         mock_executor.execute.return_value = (
             False,
-            "SECURE_RUNTIME_UNAVAILABLE",
+            SECURE_RUNTIME_UNAVAILABLE,
             None,
         )
         result = verifier._verify_with_code("What is 2+2?")
@@ -209,7 +210,7 @@ def test_stats_verifier_blocks_if_docker_drops_after_selection():
     verifier._code_verifier.verify_code.return_value = {"is_safe": True}
     verifier._docker_executor = MagicMock()
     verifier._docker_executor.is_available.return_value = True
-    verifier._docker_executor.execute.return_value = (False, "SECURE_RUNTIME_UNAVAILABLE", None)
+    verifier._docker_executor.execute.return_value = (False, SECURE_RUNTIME_UNAVAILABLE, None)
 
     df = pd.DataFrame({"value": [1, 2, 3]})
 
@@ -222,7 +223,7 @@ def test_stats_verifier_blocks_if_docker_drops_after_selection():
 def test_stats_execute_docker_marks_runtime_unavailable():
     verifier = StatsVerifier()
     verifier._docker_executor = MagicMock()
-    verifier._docker_executor.execute.return_value = (False, "SECURE_RUNTIME_UNAVAILABLE", None)
+    verifier._docker_executor.execute.return_value = (False, SECURE_RUNTIME_UNAVAILABLE, None)
 
     result = verifier._execute_docker("result = 1", {"df": pd.DataFrame({"value": [1]})})
 

--- a/tests/test_pr117_regressions.py
+++ b/tests/test_pr117_regressions.py
@@ -5,7 +5,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 from qwed_new.api.main import app, get_current_tenant, get_session
-from qwed_new.core.consensus_verifier import ConsensusVerifier
+from qwed_new.core.consensus_verifier import (
+    SECURE_EXECUTION_REQUIRED,
+    ConsensusVerifier,
+    EngineResult,
+)
 from qwed_new.core.stats_verifier import (
     SECURE_STATS_BLOCKED_CODE,
     SECURE_STATS_SANDBOX_REQUIRED,
@@ -17,6 +21,7 @@ from qwed_new.core.stats_verifier import (
 
 @pytest.fixture
 def client():
+    previous_overrides = app.dependency_overrides.copy()
     mock_tenant = MagicMock(organization_id=1, api_key="placeholder", organization_name="Test Org")
     mock_session = MagicMock(add=MagicMock(), commit=MagicMock())
 
@@ -25,7 +30,7 @@ def client():
 
     yield TestClient(app)
 
-    app.dependency_overrides.clear()
+    app.dependency_overrides = previous_overrides
 
 
 def test_wasm_stats_fallback_is_fail_closed():
@@ -93,6 +98,23 @@ def test_stats_api_masks_secure_runtime_unavailability(client):
     assert response.json()["detail"] == "Service temporarily unavailable"
 
 
+def test_stats_api_preserves_security_policy_blocks(client):
+    with patch("qwed_new.core.stats_verifier.StatsVerifier.verify_stats") as mock_verify_stats:
+        mock_verify_stats.return_value = {
+            "status": "BLOCKED",
+            "error": "Code failed security validation",
+        }
+        response = client.post(
+            "/verify/stats",
+            files={"file": ("data.csv", b"value\n1\n2\n", "text/csv")},
+            data={"query": "What is the mean of value?"},
+            headers={"x-api-key": "fake-key"},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Verification blocked by security policy"
+
+
 def test_consensus_code_engine_requires_secure_executor():
     verifier = ConsensusVerifier(enable_circuit_breaker=False)
     verifier._code_verifier = MagicMock()
@@ -112,7 +134,7 @@ def test_consensus_code_engine_requires_secure_executor():
 
     assert result.success is False
     assert result.result is None
-    assert "Docker is not available" in result.error
+    assert result.error == SECURE_EXECUTION_REQUIRED
 
 
 def test_consensus_code_engine_uses_secure_executor_output():
@@ -135,9 +157,23 @@ def test_consensus_code_engine_uses_secure_executor_output():
 
 def test_consensus_codegen_assigns_result_variable():
     verifier = ConsensusVerifier(enable_circuit_breaker=False)
-    with patch("qwed_new.core.translator.TranslationLayer") as mock_translator_cls:
-        mock_translator = mock_translator_cls.return_value
-        mock_translator.translate.return_value = MagicMock(expression="2 + 2")
-        code = verifier._generate_verification_code("What is 2+2?")
+    verifier._translator = MagicMock()
+    verifier._translator.translate.return_value = MagicMock(expression="2 + 2")
+
+    code = verifier._generate_verification_code("What is 2+2?")
 
     assert code == "result = 2 + 2"
+
+
+def test_consensus_blocks_when_secure_execution_is_required():
+    verifier = ConsensusVerifier(enable_circuit_breaker=False)
+    results = [
+        EngineResult("SymPy", "symbolic_math", "4", 1.0, 1.0, True),
+        EngineResult("Python", "code_execution", None, 0.0, 1.0, False, SECURE_EXECUTION_REQUIRED),
+    ]
+
+    consensus = verifier._calculate_consensus(results)
+
+    assert consensus["answer"] is None
+    assert consensus["confidence"] == 0.0
+    assert consensus["status"] == "blocked_secure_execution"

--- a/tests/test_pr117_regressions.py
+++ b/tests/test_pr117_regressions.py
@@ -13,6 +13,7 @@ from qwed_new.core.consensus_verifier import (
 from qwed_new.core.stats_verifier import (
     SECURE_STATS_BLOCKED_CODE,
     SECURE_STATS_SANDBOX_REQUIRED,
+    SECURE_STATS_RUNTIME_UNAVAILABLE,
     RestrictedExecutor,
     StatsVerifier,
     WasmSandbox,
@@ -127,7 +128,7 @@ def test_consensus_code_engine_requires_secure_executor():
         mock_executor = mock_executor_cls.return_value
         mock_executor.execute.return_value = (
             False,
-            "Docker is not available. Cannot execute code securely.",
+            "SECURE_RUNTIME_UNAVAILABLE",
             None,
         )
         result = verifier._verify_with_code("What is 2+2?")
@@ -198,3 +199,45 @@ def test_consensus_api_masks_secure_execution_block(client):
 
     assert response.status_code == 503
     assert response.json()["detail"] == "Service temporarily unavailable"
+
+
+def test_stats_verifier_blocks_if_docker_drops_after_selection():
+    verifier = StatsVerifier()
+    verifier._translator = MagicMock()
+    verifier._translator.translate_stats.return_value = "result = df['value'].mean()"
+    verifier._code_verifier = MagicMock()
+    verifier._code_verifier.verify_code.return_value = {"is_safe": True}
+    verifier._docker_executor = MagicMock()
+    verifier._docker_executor.is_available.return_value = True
+    verifier._docker_executor.execute.return_value = (False, "SECURE_RUNTIME_UNAVAILABLE", None)
+
+    df = pd.DataFrame({"value": [1, 2, 3]})
+
+    result = verifier.verify_stats("What is the mean of value?", df)
+
+    assert result["status"] == "BLOCKED"
+    assert result["error"] == SECURE_STATS_BLOCKED_CODE
+
+
+def test_stats_execute_docker_marks_runtime_unavailable():
+    verifier = StatsVerifier()
+    verifier._docker_executor = MagicMock()
+    verifier._docker_executor.execute.return_value = (False, "SECURE_RUNTIME_UNAVAILABLE", None)
+
+    result = verifier._execute_docker("result = 1", {"df": pd.DataFrame({"value": [1]})})
+
+    assert result.success is False
+    assert result.error == SECURE_STATS_RUNTIME_UNAVAILABLE
+
+
+def test_consensus_preserves_none_answer_value():
+    verifier = ConsensusVerifier(enable_circuit_breaker=False)
+    results = [
+        EngineResult("SymPy", "symbolic_math", None, 1.0, 1.0, True),
+        EngineResult("Stats", "statistical_analysis", None, 0.98, 1.0, True),
+    ]
+
+    consensus = verifier._calculate_consensus(results)
+
+    assert consensus["answer"] is None
+    assert consensus["status"] == "unanimous"

--- a/tests/test_secure_executor.py
+++ b/tests/test_secure_executor.py
@@ -9,7 +9,6 @@ import pandas as pd
 from qwed_new.core.secure_code_executor import (
     SECURE_RUNTIME_UNAVAILABLE,
     SecureCodeExecutor,
-    ExecutionError,
 )
 
 

--- a/tests/test_secure_executor.py
+++ b/tests/test_secure_executor.py
@@ -6,7 +6,11 @@ Note: Requires Docker to be running for these tests to pass.
 
 import pytest
 import pandas as pd
-from qwed_new.core.secure_code_executor import SecureCodeExecutor, ExecutionError
+from qwed_new.core.secure_code_executor import (
+    SECURE_RUNTIME_UNAVAILABLE,
+    SecureCodeExecutor,
+    ExecutionError,
+)
 
 
 class TestSecureCodeExecutor:
@@ -167,7 +171,7 @@ class TestSecureExecutorFallback:
         code = "result = 2 + 2"
         success, error, result = executor.execute(code, {})
         assert not success
-        assert "Docker" in error
+        assert error == SECURE_RUNTIME_UNAVAILABLE
 
 
 if __name__ == "__main__":

--- a/tests/test_secure_executor_coverage.py
+++ b/tests/test_secure_executor_coverage.py
@@ -33,7 +33,17 @@ class TestSecureExecutorCoverage(unittest.TestCase):
         executor.client.ping.side_effect = Exception("Docker daemon unavailable")
 
         self.assertFalse(executor.is_available())
-        self.assertFalse(executor.docker_available)
+        self.assertTrue(executor.docker_available)
+
+    def test_is_available_recovers_after_transient_ping_failure(self):
+        """Test Docker availability check recovers once ping succeeds again."""
+        executor = SecureCodeExecutor()
+        executor.docker_available = True
+        executor.client = MagicMock()
+        executor.client.ping.side_effect = [Exception("Temporary Docker issue"), None]
+
+        self.assertFalse(executor.is_available())
+        self.assertTrue(executor.is_available())
 
     def test_execute_os_error_tempdir(self):
         """Test execute when tempfile creation fails."""

--- a/tests/test_secure_executor_coverage.py
+++ b/tests/test_secure_executor_coverage.py
@@ -2,7 +2,11 @@
 import unittest
 import docker
 from unittest.mock import MagicMock, patch
-from src.qwed_new.core.secure_code_executor import SecureCodeExecutor, ExecutionError
+from src.qwed_new.core.secure_code_executor import (
+    SECURE_RUNTIME_UNAVAILABLE,
+    SecureCodeExecutor,
+    ExecutionError,
+)
 
 class TestSecureExecutorCoverage(unittest.TestCase):
     """Targeted tests to improve coverage of secure_code_executor.py"""
@@ -19,7 +23,7 @@ class TestSecureExecutorCoverage(unittest.TestCase):
             executor = SecureCodeExecutor()
             success, error, _ = executor.execute("print(1)", {})
             self.assertFalse(success)
-            self.assertIn("Docker is not available", error)
+            self.assertEqual(SECURE_RUNTIME_UNAVAILABLE, error)
 
     def test_is_available_rechecks_docker_health(self):
         """Test live Docker health check instead of relying on cached startup state."""

--- a/tests/test_secure_executor_coverage.py
+++ b/tests/test_secure_executor_coverage.py
@@ -21,6 +21,16 @@ class TestSecureExecutorCoverage(unittest.TestCase):
             self.assertFalse(success)
             self.assertIn("Docker is not available", error)
 
+    def test_is_available_rechecks_docker_health(self):
+        """Test live Docker health check instead of relying on cached startup state."""
+        executor = SecureCodeExecutor()
+        executor.docker_available = True
+        executor.client = MagicMock()
+        executor.client.ping.side_effect = Exception("Docker daemon unavailable")
+
+        self.assertFalse(executor.is_available())
+        self.assertFalse(executor.docker_available)
+
     def test_execute_os_error_tempdir(self):
         """Test execute when tempfile creation fails."""
         with patch("tempfile.TemporaryDirectory", side_effect=OSError("Disk full")):

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -133,6 +133,8 @@ class TestSecurityFixes(unittest.TestCase):
             executor = SecureCodeExecutor()
             # Force docker_available to True so we don't return early
             executor.docker_available = True
+            executor.client = MagicMock()
+            executor.client.ping.return_value = True
             
             # Mock tempfile.TemporaryDirectory to raise OSError
             with patch('tempfile.TemporaryDirectory', side_effect=OSError("Permission denied")):


### PR DESCRIPTION
## Summary
- make statistical verification fail closed unless the secure Docker sandbox is available
- disable Wasm and restricted in-process stats execution fallbacks
- move consensus Python verification off same-process `CodeExecutor` onto `SecureCodeExecutor`
- add regression coverage for the new fail-closed execution behavior

## Why
QWED cannot allow model-generated Python to execute in-process when the secure runtime is unavailable. This PR removes those downgrade paths and keeps execution behind the Docker isolation boundary.

## Validation
- `pytest tests/test_pr117_regressions.py tests/test_pr115_regressions.py tests/test_api_phase17_endpoints.py -q`
- `python -m py_compile src/qwed_new/core/stats_verifier.py src/qwed_new/core/consensus_verifier.py tests/test_pr117_regressions.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Statistical verification now requires the secure Docker sandbox; Wasm and in-process fallbacks are disabled. Consensus verification for Python is forced through the secure executor and is blocked when sandboxing is unavailable. Executor now does live Docker health checks and reports runtime-unavailable when Docker is down.
* **Bug Fixes**
  * Endpoints surface secure-runtime blocks as HTTP 503 and other policy blocks as HTTP 403.
* **Tests**
  * Added regression and unit tests for fail-closed sandbox gating, executor health checks, and API masking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->