### PR TITLE
PR 4: Harden runtime and agent controls

### DIFF
--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -115,6 +115,8 @@ def get_optional_current_user(
     """Resolve a JWT-authenticated user when present."""
     if not authorization:
         return None
+    if not authorization.startswith("Bearer "):
+        return None
 
     payload = get_current_user_token(authorization)
     user_id = payload.get("sub")
@@ -152,7 +154,7 @@ def get_optional_api_key_record(
 
 def _has_metrics_admin_role(user: Optional[User]) -> bool:
     """Return True when the user can access global operational metrics."""
-    return user is not None and user.role in {"owner", "admin"}
+    return user is not None and user.is_active and user.role in {"owner", "admin"}
 
 
 def require_metrics_access(

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException, Depends, Header, UploadFile, File, F
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, field_validator
 from typing import Optional, Annotated
-from sqlmodel import Session
+from sqlmodel import Session, select
 import os
 import logging
 from fractions import Fraction
@@ -26,7 +26,7 @@ from qwed_new.core.rate_limiter import check_rate_limit
 from qwed_new.auth import auth_router
 from qwed_new.auth.audit_routes import router as audit_router
 from qwed_new.auth.middleware import get_api_key
-from qwed_new.auth.routes import get_current_user, get_current_user_token
+from qwed_new.auth.routes import get_current_user_token
 from qwed_new.auth.security import hash_api_key
 
 TenantDependency = Annotated[TenantContext, Depends(get_current_tenant)]
@@ -108,7 +108,7 @@ async def root():
     return {"message": "QWED OS is Running", "version": "1.0.0"}
 
 
-async def get_optional_current_user(
+def get_optional_current_user(
     authorization: Optional[str] = Header(None),
     session: Session = Depends(get_session),
 ) -> Optional[User]:
@@ -118,7 +118,13 @@ async def get_optional_current_user(
 
     payload = get_current_user_token(authorization)
     user_id = payload.get("sub")
-    user = session.get(User, int(user_id))
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="Missing sub claim in token")
+
+    try:
+        user = session.get(User, int(user_id))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=401, detail="Invalid token subject") from exc
 
     if not user:
         raise HTTPException(status_code=401, detail="User not found")
@@ -126,7 +132,7 @@ async def get_optional_current_user(
     return user
 
 
-async def get_optional_api_key_record(
+def get_optional_api_key_record(
     x_api_key: Optional[str] = Header(None),
     session: Session = Depends(get_session),
 ) -> Optional[ApiKey]:
@@ -135,7 +141,7 @@ async def get_optional_api_key_record(
         return None
 
     hashed_key = hash_api_key(x_api_key)
-    statement = select(ApiKey).where(ApiKey.key_hash == hashed_key, ApiKey.is_active == True)
+    statement = select(ApiKey).where(ApiKey.key_hash == hashed_key, ApiKey.is_active)
     api_key = session.exec(statement).first()
 
     if not api_key:
@@ -144,17 +150,29 @@ async def get_optional_api_key_record(
     return api_key
 
 
+def _has_metrics_admin_role(user: Optional[User]) -> bool:
+    """Return True when the user can access global operational metrics."""
+    return user is not None and user.role in {"owner", "admin"}
+
+
 def require_metrics_access(
     current_user: Annotated[Optional[User], Depends(get_optional_current_user)],
     api_key_record: Annotated[Optional[ApiKey], Depends(get_optional_api_key_record)],
+    session: Annotated[Session, Depends(get_session)],
 ) -> None:
-    """Restrict operational metrics to admin JWT users or authenticated API-key clients."""
-    if current_user and current_user.role in {"owner", "admin"}:
+    """Restrict operational metrics to admin JWT users or admin-linked API keys."""
+    if _has_metrics_admin_role(current_user):
         return
+
     if api_key_record is not None:
-        return
+        api_key_user = session.get(User, api_key_record.user_id) if api_key_record.user_id else None
+        if _has_metrics_admin_role(api_key_user):
+            return
+        raise HTTPException(status_code=403, detail="Admin access required")
+
     if current_user is not None:
         raise HTTPException(status_code=403, detail="Admin access required")
+
     raise HTTPException(status_code=401, detail="Authentication required")
 
 @app.post("/verify/natural_language")

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -5,7 +5,6 @@ from typing import Optional, Annotated
 from sqlmodel import Session
 import os
 import logging
-import site
 from fractions import Fraction
 
 from qwed_new.core.security import redact_pii
@@ -27,7 +26,8 @@ from qwed_new.core.rate_limiter import check_rate_limit
 from qwed_new.auth import auth_router
 from qwed_new.auth.audit_routes import router as audit_router
 from qwed_new.auth.middleware import get_api_key
-from qwed_new.auth.routes import get_current_user
+from qwed_new.auth.routes import get_current_user, get_current_user_token
+from qwed_new.auth.security import hash_api_key
 
 TenantDependency = Annotated[TenantContext, Depends(get_current_tenant)]
 SessionDependency = Annotated[Session, Depends(get_session)]
@@ -55,32 +55,28 @@ app.include_router(auth_router)
 app.include_router(audit_router)
 
 STARTUP_ALLOWED_PTH_FILES = {
+    "__editable__.qwed_a2a-0.1.0.pth",
+    "__editable__.qwed_finance-2.0.1.pth",
+    "__editable__.qwed_mcp-0.2.0.pth",
+    "_qwed.pth",
+    "_qwed_legal.pth",
+    "_qwed_new.pth",
+    "_qwed_ucp.pth",
     "a1_coverage.pth",
     "pywin32.pth",
 }
 
 
+def _get_env_allowlisted_pth_files() -> set[str]:
+    """Parse deployment-provided exact startup hook allowlist entries."""
+    extra = os.environ.get("QWED_ALLOWED_STARTUP_PTH_FILES", "")
+    return {name.strip() for name in extra.split(",") if name.strip()}
+
+
 def _get_startup_hook_allowlist() -> set[str]:
     """Return additional expected startup hook files for this deployment."""
     allowlist = set(STARTUP_ALLOWED_PTH_FILES)
-    extra = os.environ.get("QWED_ALLOWED_STARTUP_PTH_FILES", "")
-    allowlist.update({name.strip() for name in extra.split(",") if name.strip()})
-    try:
-        site_dirs = list(site.getsitepackages())
-    except AttributeError:
-        site_dirs = []
-    if getattr(site, "ENABLE_USER_SITE", False):
-        user_site = getattr(site, "getusersitepackages", lambda: None)()
-        if user_site:
-            site_dirs.append(user_site)
-    for site_dir in site_dirs:
-        if not os.path.isdir(site_dir):
-            continue
-        for filename in os.listdir(site_dir):
-            if not filename.endswith(".pth"):
-                continue
-            if filename.startswith("_qwed") or filename.startswith("__editable__.qwed"):
-                allowlist.add(filename)
+    allowlist.update(_get_env_allowlisted_pth_files())
     return allowlist
 
 
@@ -112,13 +108,54 @@ async def root():
     return {"message": "QWED OS is Running", "version": "1.0.0"}
 
 
-def require_metrics_admin(
-    current_user: User = Depends(get_current_user),
-) -> User:
-    """Restrict operational metrics to owner/admin users."""
-    if current_user.role not in {"owner", "admin"}:
+async def get_optional_current_user(
+    authorization: Optional[str] = Header(None),
+    session: Session = Depends(get_session),
+) -> Optional[User]:
+    """Resolve a JWT-authenticated user when present."""
+    if not authorization:
+        return None
+
+    payload = get_current_user_token(authorization)
+    user_id = payload.get("sub")
+    user = session.get(User, int(user_id))
+
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+
+    return user
+
+
+async def get_optional_api_key_record(
+    x_api_key: Optional[str] = Header(None),
+    session: Session = Depends(get_session),
+) -> Optional[ApiKey]:
+    """Resolve an API key record when the caller provides x-api-key."""
+    if not x_api_key:
+        return None
+
+    hashed_key = hash_api_key(x_api_key)
+    statement = select(ApiKey).where(ApiKey.key_hash == hashed_key, ApiKey.is_active == True)
+    api_key = session.exec(statement).first()
+
+    if not api_key:
+        raise HTTPException(status_code=403, detail="Invalid or revoked API Key")
+
+    return api_key
+
+
+def require_metrics_access(
+    current_user: Annotated[Optional[User], Depends(get_optional_current_user)],
+    api_key_record: Annotated[Optional[ApiKey], Depends(get_optional_api_key_record)],
+) -> None:
+    """Restrict operational metrics to admin JWT users or authenticated API-key clients."""
+    if current_user and current_user.role in {"owner", "admin"}:
+        return
+    if api_key_record is not None:
+        return
+    if current_user is not None:
         raise HTTPException(status_code=403, detail="Admin access required")
-    return current_user
+    raise HTTPException(status_code=401, detail="Authentication required")
 
 @app.post("/verify/natural_language")
 async def verify_natural_language(
@@ -837,7 +874,7 @@ async def health_check():
 
 @app.get("/metrics")
 async def get_global_metrics(
-    current_user: User = Depends(require_metrics_admin),
+    current_user: Annotated[None, Depends(require_metrics_access)],
 ):
     """
     Get system-wide metrics.
@@ -853,7 +890,7 @@ async def get_global_metrics(
 
 @app.get("/metrics/prometheus", tags=["Observability"])
 async def prometheus_metrics(
-    current_user: User = Depends(require_metrics_admin),
+    current_user: Annotated[None, Depends(require_metrics_access)],
 ):
     """
     Prometheus-compatible metrics endpoint.

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -5,6 +5,7 @@ from typing import Optional, Annotated
 from sqlmodel import Session
 import os
 import logging
+import site
 from fractions import Fraction
 
 from qwed_new.core.security import redact_pii
@@ -18,7 +19,7 @@ INTERNAL_PROCESSING_ERROR = "Internal processing error"
 from qwed_new.core.control_plane import ControlPlane
 from qwed_new.core.tenant_context import get_current_tenant, TenantContext
 from qwed_new.core.database import create_db_and_tables, get_session
-from qwed_new.core.models import VerificationLog, ApiKey
+from qwed_new.core.models import VerificationLog, ApiKey, User
 from qwed_new.core.rate_limiter import check_rate_limit
 
 # Import auth router
@@ -26,6 +27,7 @@ from qwed_new.core.rate_limiter import check_rate_limit
 from qwed_new.auth import auth_router
 from qwed_new.auth.audit_routes import router as audit_router
 from qwed_new.auth.middleware import get_api_key
+from qwed_new.auth.routes import get_current_user
 
 TenantDependency = Annotated[TenantContext, Depends(get_current_tenant)]
 SessionDependency = Annotated[Session, Depends(get_session)]
@@ -52,8 +54,50 @@ app.add_middleware(
 app.include_router(auth_router)
 app.include_router(audit_router)
 
+STARTUP_ALLOWED_PTH_FILES = {
+    "a1_coverage.pth",
+    "pywin32.pth",
+}
+
+
+def _get_startup_hook_allowlist() -> set[str]:
+    """Return additional expected startup hook files for this deployment."""
+    allowlist = set(STARTUP_ALLOWED_PTH_FILES)
+    extra = os.environ.get("QWED_ALLOWED_STARTUP_PTH_FILES", "")
+    allowlist.update({name.strip() for name in extra.split(",") if name.strip()})
+    try:
+        site_dirs = list(site.getsitepackages())
+    except AttributeError:
+        site_dirs = []
+    if getattr(site, "ENABLE_USER_SITE", False):
+        user_site = getattr(site, "getusersitepackages", lambda: None)()
+        if user_site:
+            site_dirs.append(user_site)
+    for site_dir in site_dirs:
+        if not os.path.isdir(site_dir):
+            continue
+        for filename in os.listdir(site_dir):
+            if not filename.endswith(".pth"):
+                continue
+            if filename.startswith("_qwed") or filename.startswith("__editable__.qwed"):
+                allowlist.add(filename)
+    return allowlist
+
+
+def _enforce_environment_integrity() -> None:
+    """Fail startup if Python startup hooks cannot be verified as safe."""
+    from qwed_sdk.guards.environment_guard import StartupHookGuard
+
+    guard = StartupHookGuard(allowed_pth_files=_get_startup_hook_allowlist())
+    result = guard.verify_environment_integrity()
+    if not result.get("verified"):
+        logger.critical("Startup environment integrity check failed")
+        raise RuntimeError("Environment integrity verification failed")
+
+
 @app.on_event("startup")
 def on_startup():
+    _enforce_environment_integrity()
     create_db_and_tables()
 
 # Initialize Kernel (Control Plane)
@@ -66,6 +110,15 @@ class VerifyRequest(BaseModel):
 @app.get("/")
 async def root():
     return {"message": "QWED OS is Running", "version": "1.0.0"}
+
+
+def require_metrics_admin(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Restrict operational metrics to owner/admin users."""
+    if current_user.role not in {"owner", "admin"}:
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return current_user
 
 @app.post("/verify/natural_language")
 async def verify_natural_language(
@@ -761,7 +814,11 @@ async def verify_process(
 # OBSERVABILITY ENDPOINTS
 # ============================================================
 
-from qwed_new.core.observability import metrics_collector
+from qwed_new.core.observability import (
+    get_prometheus_content_type,
+    get_prometheus_metrics,
+    metrics_collector,
+)
 from datetime import datetime
 from sqlmodel import select
 
@@ -779,12 +836,13 @@ async def health_check():
     }
 
 @app.get("/metrics")
-async def get_global_metrics():
+async def get_global_metrics(
+    current_user: User = Depends(require_metrics_admin),
+):
     """
     Get system-wide metrics.
-    
-    Note: In production, this should require admin authentication.
     """
+    del current_user
     global_metrics = metrics_collector.get_global_metrics()
     all_tenant_metrics = metrics_collector.get_all_tenant_metrics()
     
@@ -792,6 +850,22 @@ async def get_global_metrics():
         "global": global_metrics,
         "tenants": all_tenant_metrics
     }
+
+@app.get("/metrics/prometheus", tags=["Observability"])
+async def prometheus_metrics(
+    current_user: User = Depends(require_metrics_admin),
+):
+    """
+    Prometheus-compatible metrics endpoint.
+    
+    Returns metrics in Prometheus text format for scraping.
+    """
+    del current_user
+    content = get_prometheus_metrics()
+    return Response(
+        content=content,
+        media_type=get_prometheus_content_type()
+    )
 
 @app.get("/metrics/{organization_id}")
 async def get_tenant_metrics(
@@ -1410,18 +1484,3 @@ async def get_batch_status(
 # ============================================================
 # PROMETHEUS METRICS ENDPOINT
 # ============================================================
-
-from qwed_new.core.observability import get_prometheus_metrics, get_prometheus_content_type
-
-@app.get("/metrics/prometheus", tags=["Observability"])
-async def prometheus_metrics():
-    """
-    Prometheus-compatible metrics endpoint.
-    
-    Returns metrics in Prometheus text format for scraping.
-    """
-    content = get_prometheus_metrics()
-    return Response(
-        content=content,
-        media_type=get_prometheus_content_type()
-    )

--- a/src/qwed_new/core/agent_service.py
+++ b/src/qwed_new/core/agent_service.py
@@ -10,6 +10,7 @@ import uuid
 import hmac
 import json
 import threading
+import math
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, Dict, Any, List, Set
@@ -176,6 +177,7 @@ class AgentService:
         self._activity_logs: List[ActivityLog] = []
         self._suspended_agents: Set[str] = set()
         self._conversation_state: Dict[tuple[str, str], Dict[str, Any]] = {}
+        self._conversation_reservations: Dict[tuple[str, str], Dict[str, Any]] = {}
         self._conversation_state_lock = threading.Lock()
     
     def _generate_agent_id(self) -> str:
@@ -308,6 +310,7 @@ class AgentService:
         # Check budget
         budget_check = self._check_budget(agent)
         if not budget_check["passed"]:
+            self._release_action_context(context_state)
             return {
                 "decision": AgentDecision.BUDGET_EXCEEDED.value,
                 "error": {
@@ -339,6 +342,8 @@ class AgentService:
         # Commit approved or pending steps so loop/replay tracking cannot be bypassed.
         if decision in {AgentDecision.APPROVED, AgentDecision.PENDING}:
             self._commit_action_context(context, context_state)
+        else:
+            self._release_action_context(context_state)
 
         # Update budget tracking
         if decision == AgentDecision.APPROVED:
@@ -407,6 +412,13 @@ class AgentService:
         fingerprint = self._action_fingerprint(action)
 
         with self._conversation_state_lock:
+            reservation = self._conversation_reservations.get(state_key)
+            if reservation and context.step_number <= reservation["step_number"]:
+                return ({
+                    "code": "QWED-AGENT-LOOP-002",
+                    "message": "Replay or in-flight action step detected",
+                }, None)
+
             state = self._conversation_state.get(
                 state_key,
                 {"last_step": 0, "last_fingerprint": None, "repeat_count": 0},
@@ -435,8 +447,17 @@ class AgentService:
                 "last_fingerprint": fingerprint,
                 "repeat_count": repeat_count,
             }
+            reservation_id = uuid.uuid4().hex
+            self._conversation_reservations[state_key] = {
+                "step_number": context.step_number,
+                "reservation_id": reservation_id,
+            }
 
-        return None, {"state_key": state_key, "next_state": next_state}
+        return None, {
+            "state_key": state_key,
+            "next_state": next_state,
+            "reservation_id": reservation_id,
+        }
 
     def _commit_action_context(
         self,
@@ -449,15 +470,31 @@ class AgentService:
 
         state_key = context_state["state_key"]
         next_state = context_state["next_state"]
+        reservation_id = context_state["reservation_id"]
 
         with self._conversation_state_lock:
-            state = self._conversation_state.get(
-                state_key,
-                {"last_step": 0},
-            )
+            reservation = self._conversation_reservations.get(state_key)
+            if reservation is None or reservation["reservation_id"] != reservation_id:
+                return
+            state = self._conversation_state.get(state_key, {"last_step": 0})
             if context.step_number <= state["last_step"]:
+                self._conversation_reservations.pop(state_key, None)
                 return
             self._conversation_state[state_key] = next_state
+            self._conversation_reservations.pop(state_key, None)
+
+    def _release_action_context(self, context_state: Optional[Dict[str, Any]]) -> None:
+        """Release an in-flight context reservation when execution does not proceed."""
+        if context_state is None:
+            return
+
+        state_key = context_state["state_key"]
+        reservation_id = context_state["reservation_id"]
+
+        with self._conversation_state_lock:
+            reservation = self._conversation_reservations.get(state_key)
+            if reservation and reservation["reservation_id"] == reservation_id:
+                self._conversation_reservations.pop(state_key, None)
 
     @staticmethod
     def _action_fingerprint(action: AgentAction) -> str:
@@ -467,9 +504,31 @@ class AgentService:
             "query": action.query,
             "code": action.code,
             "target": action.target,
-            "parameters": action.parameters,
+            "parameters": AgentService._sanitize_fingerprint_value(action.parameters),
         }
-        return json.dumps(payload, sort_keys=True, default=str)
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def _sanitize_fingerprint_value(value: Any) -> Any:
+        """Allow only deterministic JSON-compatible values in action fingerprints."""
+        if value is None or isinstance(value, (str, bool, int)):
+            return value
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise TypeError("Non-finite floats are not allowed in action parameters")
+            return value
+        if isinstance(value, list):
+            return [AgentService._sanitize_fingerprint_value(item) for item in value]
+        if isinstance(value, tuple):
+            return [AgentService._sanitize_fingerprint_value(item) for item in value]
+        if isinstance(value, dict):
+            sanitized: Dict[str, Any] = {}
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise TypeError("Action parameter keys must be strings")
+                sanitized[key] = AgentService._sanitize_fingerprint_value(item)
+            return sanitized
+        raise TypeError(f"Unsupported action parameter type: {type(value).__name__}")
 
     def _risk_exceeds_threshold(self, risk_level: RiskLevel, threshold: RiskLevel) -> bool:
         """Compare risk levels by their enforcement rank, not string value."""

--- a/src/qwed_new/core/agent_service.py
+++ b/src/qwed_new/core/agent_service.py
@@ -9,6 +9,7 @@ import time
 import uuid
 import hmac
 import json
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, Dict, Any, List, Set
@@ -169,6 +170,7 @@ class AgentService:
         self._activity_logs: List[ActivityLog] = []
         self._suspended_agents: Set[str] = set()
         self._conversation_state: Dict[tuple[str, str], Dict[str, Any]] = {}
+        self._conversation_state_lock = threading.Lock()
     
     def _generate_agent_id(self) -> str:
         return f"agent_{uuid.uuid4().hex[:12]}"
@@ -265,7 +267,7 @@ class AgentService:
         self,
         agent_id: str,
         action: AgentAction,
-        context: Optional[ActionContext] = None,
+        context: ActionContext,
         require_attestation: bool = False,
         risk_threshold: str = "medium",
     ) -> Dict[str, Any]:
@@ -392,29 +394,36 @@ class AgentService:
             }
 
         state_key = (agent_id, context.conversation_id)
-        state = self._conversation_state.get(
-            state_key,
-            {"last_step": 0, "last_fingerprint": None, "repeat_count": 0},
-        )
-
-        if context.step_number <= state["last_step"]:
-            return {
-                "code": "QWED-AGENT-LOOP-002",
-                "message": "Replay or out-of-order action step detected",
-            }
-
         fingerprint = self._action_fingerprint(action)
-        repeat_count = state["repeat_count"] + 1 if fingerprint == state["last_fingerprint"] else 1
-        self._conversation_state[state_key] = {
-            "last_step": context.step_number,
-            "last_fingerprint": fingerprint,
-            "repeat_count": repeat_count,
-        }
 
-        if repeat_count > self.MAX_CONSECUTIVE_IDENTICAL_ACTIONS:
-            return {
-                "code": "QWED-AGENT-LOOP-003",
-                "message": "Repetitive action loop detected",
+        with self._conversation_state_lock:
+            state = self._conversation_state.get(
+                state_key,
+                {"last_step": 0, "last_fingerprint": None, "repeat_count": 0},
+            )
+
+            if context.step_number <= state["last_step"]:
+                return {
+                    "code": "QWED-AGENT-LOOP-002",
+                    "message": "Replay or out-of-order action step detected",
+                }
+
+            repeat_count = (
+                state["repeat_count"] + 1
+                if fingerprint == state["last_fingerprint"]
+                else 1
+            )
+
+            if repeat_count > self.MAX_CONSECUTIVE_IDENTICAL_ACTIONS:
+                return {
+                    "code": "QWED-AGENT-LOOP-003",
+                    "message": "Repetitive action loop detected",
+                }
+
+            self._conversation_state[state_key] = {
+                "last_step": context.step_number,
+                "last_fingerprint": fingerprint,
+                "repeat_count": repeat_count,
             }
 
         return None

--- a/src/qwed_new/core/agent_service.py
+++ b/src/qwed_new/core/agent_service.py
@@ -289,7 +289,7 @@ class AgentService:
                 "error": {"code": "QWED-AGENT-003", "message": "Agent suspended"},
             }
 
-        context_error = self._enforce_action_context(agent_id, action, context)
+        context_error, context_state = self._enforce_action_context(agent_id, action, context)
         if context_error:
             return {
                 "decision": AgentDecision.DENIED.value,
@@ -332,6 +332,7 @@ class AgentService:
         
         # Update budget tracking
         if decision == AgentDecision.APPROVED:
+            self._commit_action_context(context, context_state)
             estimated_cost = 0.01  # Base cost
             agent.budget.current_daily_cost_usd += estimated_cost
             agent.budget.current_hour_requests += 1
@@ -373,25 +374,25 @@ class AgentService:
         agent_id: str,
         action: AgentAction,
         context: Optional[ActionContext],
-    ) -> Optional[Dict[str, str]]:
+    ) -> tuple[Optional[Dict[str, str]], Optional[Dict[str, Any]]]:
         """Require deterministic action context and detect replay/loop patterns."""
         if context is None or not context.conversation_id or context.step_number is None:
-            return {
+            return ({
                 "code": "QWED-AGENT-CTX-001",
                 "message": "Action context with conversation_id and step_number is required",
-            }
+            }, None)
 
         if context.step_number < 1:
-            return {
+            return ({
                 "code": "QWED-AGENT-CTX-002",
                 "message": "step_number must be >= 1",
-            }
+            }, None)
 
         if context.step_number > self.MAX_CONVERSATION_STEPS:
-            return {
+            return ({
                 "code": "QWED-AGENT-LOOP-001",
                 "message": "Conversation step limit exceeded",
-            }
+            }, None)
 
         state_key = (agent_id, context.conversation_id)
         fingerprint = self._action_fingerprint(action)
@@ -403,10 +404,10 @@ class AgentService:
             )
 
             if context.step_number <= state["last_step"]:
-                return {
+                return ({
                     "code": "QWED-AGENT-LOOP-002",
                     "message": "Replay or out-of-order action step detected",
-                }
+                }, None)
 
             repeat_count = (
                 state["repeat_count"] + 1
@@ -415,18 +416,39 @@ class AgentService:
             )
 
             if repeat_count > self.MAX_CONSECUTIVE_IDENTICAL_ACTIONS:
-                return {
+                return ({
                     "code": "QWED-AGENT-LOOP-003",
                     "message": "Repetitive action loop detected",
-                }
+                }, None)
 
-            self._conversation_state[state_key] = {
+            next_state = {
                 "last_step": context.step_number,
                 "last_fingerprint": fingerprint,
                 "repeat_count": repeat_count,
             }
 
-        return None
+        return None, {"state_key": state_key, "next_state": next_state}
+
+    def _commit_action_context(
+        self,
+        context: ActionContext,
+        context_state: Optional[Dict[str, Any]],
+    ) -> None:
+        """Persist conversation progress only after the action is approved."""
+        if context_state is None:
+            return
+
+        state_key = context_state["state_key"]
+        next_state = context_state["next_state"]
+
+        with self._conversation_state_lock:
+            state = self._conversation_state.get(
+                state_key,
+                {"last_step": 0},
+            )
+            if context.step_number <= state["last_step"]:
+                return
+            self._conversation_state[state_key] = next_state
 
     @staticmethod
     def _action_fingerprint(action: AgentAction) -> str:

--- a/src/qwed_new/core/agent_service.py
+++ b/src/qwed_new/core/agent_service.py
@@ -7,6 +7,8 @@ Provides registration, verification, budget management, and audit logging.
 
 import time
 import uuid
+import hmac
+import json
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, Dict, Any, List, Set
@@ -159,11 +161,14 @@ class AgentService:
         "verify_logic": "logic",
         "verify_fact": "fact",
     }
+    MAX_CONVERSATION_STEPS = 50
+    MAX_CONSECUTIVE_IDENTICAL_ACTIONS = 2
     
     def __init__(self):
         self._agents: Dict[str, AgentInfo] = {}
         self._activity_logs: List[ActivityLog] = []
         self._suspended_agents: Set[str] = set()
+        self._conversation_state: Dict[tuple[str, str], Dict[str, Any]] = {}
     
     def _generate_agent_id(self) -> str:
         return f"agent_{uuid.uuid4().hex[:12]}"
@@ -251,7 +256,10 @@ class AgentService:
     def verify_agent_token(self, agent_id: str, agent_token: str) -> bool:
         """Verify agent authentication"""
         agent = self._agents.get(agent_id)
-        return agent is not None and agent.agent_token == agent_token
+        return (
+            agent is not None
+            and hmac.compare_digest(agent.agent_token, agent_token)
+        )
     
     def verify_action(
         self,
@@ -277,6 +285,13 @@ class AgentService:
             return {
                 "decision": AgentDecision.DENIED.value,
                 "error": {"code": "QWED-AGENT-003", "message": "Agent suspended"},
+            }
+
+        context_error = self._enforce_action_context(agent_id, action, context)
+        if context_error:
+            return {
+                "decision": AgentDecision.DENIED.value,
+                "error": context_error,
             }
         
         # Reset budget counters if needed
@@ -350,6 +365,71 @@ class AgentService:
         }
         
         return response
+
+    def _enforce_action_context(
+        self,
+        agent_id: str,
+        action: AgentAction,
+        context: Optional[ActionContext],
+    ) -> Optional[Dict[str, str]]:
+        """Require deterministic action context and detect replay/loop patterns."""
+        if context is None or not context.conversation_id or context.step_number is None:
+            return {
+                "code": "QWED-AGENT-CTX-001",
+                "message": "Action context with conversation_id and step_number is required",
+            }
+
+        if context.step_number < 1:
+            return {
+                "code": "QWED-AGENT-CTX-002",
+                "message": "step_number must be >= 1",
+            }
+
+        if context.step_number > self.MAX_CONVERSATION_STEPS:
+            return {
+                "code": "QWED-AGENT-LOOP-001",
+                "message": "Conversation step limit exceeded",
+            }
+
+        state_key = (agent_id, context.conversation_id)
+        state = self._conversation_state.get(
+            state_key,
+            {"last_step": 0, "last_fingerprint": None, "repeat_count": 0},
+        )
+
+        if context.step_number <= state["last_step"]:
+            return {
+                "code": "QWED-AGENT-LOOP-002",
+                "message": "Replay or out-of-order action step detected",
+            }
+
+        fingerprint = self._action_fingerprint(action)
+        repeat_count = state["repeat_count"] + 1 if fingerprint == state["last_fingerprint"] else 1
+        self._conversation_state[state_key] = {
+            "last_step": context.step_number,
+            "last_fingerprint": fingerprint,
+            "repeat_count": repeat_count,
+        }
+
+        if repeat_count > self.MAX_CONSECUTIVE_IDENTICAL_ACTIONS:
+            return {
+                "code": "QWED-AGENT-LOOP-003",
+                "message": "Repetitive action loop detected",
+            }
+
+        return None
+
+    @staticmethod
+    def _action_fingerprint(action: AgentAction) -> str:
+        """Create a deterministic fingerprint for loop detection."""
+        payload = {
+            "action_type": action.action_type,
+            "query": action.query,
+            "code": action.code,
+            "target": action.target,
+            "parameters": action.parameters,
+        }
+        return json.dumps(payload, sort_keys=True, default=str)
     
     def _check_budget(self, agent: AgentInfo) -> Dict[str, Any]:
         """Check if agent is within budget"""

--- a/src/qwed_new/core/agent_service.py
+++ b/src/qwed_new/core/agent_service.py
@@ -164,6 +164,12 @@ class AgentService:
     }
     MAX_CONVERSATION_STEPS = 50
     MAX_CONSECUTIVE_IDENTICAL_ACTIONS = 2
+    RISK_RANKS = {
+        RiskLevel.LOW: 0,
+        RiskLevel.MEDIUM: 1,
+        RiskLevel.HIGH: 2,
+        RiskLevel.CRITICAL: 3,
+    }
     
     def __init__(self):
         self._agents: Dict[str, AgentInfo] = {}
@@ -322,7 +328,7 @@ class AgentService:
         # Determine decision
         if failed:
             decision = AgentDecision.DENIED
-        elif risk_level.value > RiskLevel[risk_threshold.upper()].value:
+        elif self._risk_exceeds_threshold(risk_level, RiskLevel[risk_threshold.upper()]):
             if agent.trust_level.value < TrustLevel.AUTONOMOUS.value:
                 decision = AgentDecision.PENDING
             else:
@@ -330,9 +336,12 @@ class AgentService:
         else:
             decision = AgentDecision.APPROVED
         
+        # Commit approved or pending steps so loop/replay tracking cannot be bypassed.
+        if decision in {AgentDecision.APPROVED, AgentDecision.PENDING}:
+            self._commit_action_context(context, context_state)
+
         # Update budget tracking
         if decision == AgentDecision.APPROVED:
-            self._commit_action_context(context, context_state)
             estimated_cost = 0.01  # Base cost
             agent.budget.current_daily_cost_usd += estimated_cost
             agent.budget.current_hour_requests += 1
@@ -461,6 +470,10 @@ class AgentService:
             "parameters": action.parameters,
         }
         return json.dumps(payload, sort_keys=True, default=str)
+
+    def _risk_exceeds_threshold(self, risk_level: RiskLevel, threshold: RiskLevel) -> bool:
+        """Compare risk levels by their enforcement rank, not string value."""
+        return self.RISK_RANKS[risk_level] > self.RISK_RANKS[threshold]
     
     def _check_budget(self, agent: AgentInfo) -> Dict[str, Any]:
         """Check if agent is within budget"""

--- a/src/qwed_new/core/models.py
+++ b/src/qwed_new/core/models.py
@@ -23,7 +23,7 @@ class User(SQLModel, table=True):
     email: str = Field(index=True, unique=True)
     password_hash: str
     organization_id: int = Field(foreign_key="organization.id")
-    role: str = Field(default="member")  # admin, member, viewer
+    role: str = Field(default="member")  # owner, admin, member, viewer
     permissions: Optional[str] = None  # JSON string of permissions
     is_active: bool = Field(default=True)
     created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/src/qwed_new/core/policy.py
+++ b/src/qwed_new/core/policy.py
@@ -73,10 +73,8 @@ class RedisSlidingWindowLimiter:
         from qwed_new.core.redis_config import get_redis_client
         self._client = get_redis_client()
         
-        # Fallback to in-memory if Redis unavailable
-        self._fallback: Optional[RateLimiter] = None
-        if self._client is None:
-            self._fallback = RateLimiter(rate=rate, per=per)
+        # Always keep a local fallback so Redis outages do not fail open.
+        self._fallback: Optional[RateLimiter] = RateLimiter(rate=rate, per=per)
     
     def _get_key(self, identifier: str) -> str:
         """Generate Redis key for the rate limit bucket."""
@@ -93,7 +91,7 @@ class RedisSlidingWindowLimiter:
             True if request is allowed, False if rate limited
         """
         # Fallback to in-memory
-        if self._fallback:
+        if self._client is None and self._fallback:
             return self._fallback.allow()
         
         now = time.time()
@@ -130,13 +128,12 @@ class RedisSlidingWindowLimiter:
             return True
             
         except Exception as e:
-            logger.warning(f"Redis rate limit error: {e}. Allowing request.")
-            # Fail-open: allow request if Redis errors
-            return True
+            logger.warning(f"Redis rate limit error: {e}. Falling back to local limiter.")
+            return self._fallback.allow()
     
     def get_remaining(self, identifier: str = "global") -> int:
         """Get remaining requests in current window."""
-        if self._fallback:
+        if self._client is None and self._fallback:
             return max(0, int(self._fallback.tokens))
         
         try:
@@ -151,11 +148,11 @@ class RedisSlidingWindowLimiter:
             return max(0, self.rate - current_count)
             
         except Exception:
-            return self.rate  # Assume full if error
+            return max(0, int(self._fallback.tokens))
     
     def reset(self, identifier: str = "global") -> bool:
         """Reset rate limit for an identifier."""
-        if self._fallback:
+        if self._client is None and self._fallback:
             self._fallback.tokens = self._fallback.rate
             return True
         
@@ -163,7 +160,8 @@ class RedisSlidingWindowLimiter:
             key = self._get_key(identifier)
             return self._client.delete(key) > 0
         except Exception:
-            return False
+            self._fallback.tokens = self._fallback.rate
+            return True
 
 
 class PolicyEngine:

--- a/src/qwed_new/core/policy.py
+++ b/src/qwed_new/core/policy.py
@@ -73,8 +73,10 @@ class RedisSlidingWindowLimiter:
         from qwed_new.core.redis_config import get_redis_client
         self._client = get_redis_client()
         
-        # Always keep a local fallback so Redis outages do not fail open.
-        self._fallback: Optional[RateLimiter] = RateLimiter(rate=rate, per=per)
+        # Only use local fallback when Redis is unavailable at initialization.
+        self._fallback: Optional[RateLimiter] = None
+        if self._client is None:
+            self._fallback = RateLimiter(rate=rate, per=per)
     
     def _get_key(self, identifier: str) -> str:
         """Generate Redis key for the rate limit bucket."""
@@ -128,8 +130,8 @@ class RedisSlidingWindowLimiter:
             return True
             
         except Exception as e:
-            logger.warning(f"Redis rate limit error: {e}. Falling back to local limiter.")
-            return self._fallback.allow()
+            logger.warning(f"Redis rate limit error: {e}. Denying request.")
+            return False
     
     def get_remaining(self, identifier: str = "global") -> int:
         """Get remaining requests in current window."""
@@ -148,7 +150,7 @@ class RedisSlidingWindowLimiter:
             return max(0, self.rate - current_count)
             
         except Exception:
-            return max(0, int(self._fallback.tokens))
+            return 0
     
     def reset(self, identifier: str = "global") -> bool:
         """Reset rate limit for an identifier."""
@@ -160,8 +162,7 @@ class RedisSlidingWindowLimiter:
             key = self._get_key(identifier)
             return self._client.delete(key) > 0
         except Exception:
-            self._fallback.tokens = self._fallback.rate
-            return True
+            return False
 
 
 class PolicyEngine:

--- a/tests/test_pr4_runtime_hardening.py
+++ b/tests/test_pr4_runtime_hardening.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from qwed_new.api import main as api_main
-from qwed_new.auth.routes import get_current_user
+from qwed_new.api.main import get_optional_api_key_record, get_optional_current_user
 from qwed_new.core.agent_service import ActionContext, AgentAction, AgentService
 from qwed_new.core.policy import RedisSlidingWindowLimiter
 
@@ -38,18 +38,37 @@ def test_redis_limiter_falls_back_locally_on_backend_error():
     with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
         limiter = RedisSlidingWindowLimiter(rate=1, per=60)
 
+    assert limiter.allow("tenant-1") is False
+    assert limiter.get_remaining("tenant-1") == 0
+
+
+def test_redis_limiter_uses_local_fallback_when_redis_missing_at_init():
+    with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+        limiter = RedisSlidingWindowLimiter(rate=1, per=60)
+
     assert limiter.allow("tenant-1") is True
     assert limiter.allow("tenant-1") is False
 
 
+def test_redis_limiter_reset_reports_failure_on_redis_error():
+    mock_client = MagicMock()
+    mock_client.delete.side_effect = RuntimeError("redis unavailable")
+
+    with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+        limiter = RedisSlidingWindowLimiter(rate=1, per=60)
+
+    assert limiter.reset("tenant-1") is False
+
+
 def test_agent_token_verification_uses_compare_digest():
     service = AgentService()
-    agent_id, agent_token = _register_test_agent(service)
+    agent_id, stored_token = _register_test_agent(service)
+    presented_token = "not-the-stored-token"
 
     with patch("qwed_new.core.agent_service.hmac.compare_digest", return_value=True) as mock_compare:
-        assert service.verify_agent_token(agent_id, agent_token) is True
+        assert service.verify_agent_token(agent_id, presented_token) is True
 
-    mock_compare.assert_called_once_with(agent_token, agent_token)
+    mock_compare.assert_called_once_with(stored_token, presented_token)
 
 
 def test_verify_action_requires_context():
@@ -114,8 +133,40 @@ def test_verify_action_blocks_repetitive_loop():
     assert third["error"]["code"] == "QWED-AGENT-LOOP-003"
 
 
+def test_verify_action_allows_different_action_after_loop_denial_same_step():
+    service = AgentService()
+    agent_id, _ = _register_test_agent(service)
+    repeat_action = AgentAction(action_type="calculate", query="2+2")
+    different_action = AgentAction(action_type="verify_logic", query="x > 1")
+
+    service.verify_action(
+        agent_id,
+        repeat_action,
+        context=ActionContext(conversation_id="conv-3", step_number=1),
+    )
+    service.verify_action(
+        agent_id,
+        repeat_action,
+        context=ActionContext(conversation_id="conv-3", step_number=2),
+    )
+    denied = service.verify_action(
+        agent_id,
+        repeat_action,
+        context=ActionContext(conversation_id="conv-3", step_number=3),
+    )
+    different = service.verify_action(
+        agent_id,
+        different_action,
+        context=ActionContext(conversation_id="conv-3", step_number=3),
+    )
+
+    assert denied["decision"] == "DENIED"
+    assert denied["error"]["code"] == "QWED-AGENT-LOOP-003"
+    assert different["decision"] == "APPROVED"
+
+
 def test_metrics_requires_admin_user(client):
-    api_main.app.dependency_overrides[get_current_user] = lambda: MagicMock(role="member")
+    api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="member")
 
     response = client.get("/metrics", headers={"Authorization": "Bearer fake"})
 
@@ -124,7 +175,7 @@ def test_metrics_requires_admin_user(client):
 
 
 def test_metrics_allows_admin_user(client):
-    api_main.app.dependency_overrides[get_current_user] = lambda: MagicMock(role="admin")
+    api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="admin")
 
     with patch.object(api_main.metrics_collector, "get_global_metrics", return_value={"requests": 1}), patch.object(
         api_main.metrics_collector,
@@ -138,12 +189,19 @@ def test_metrics_allows_admin_user(client):
 
 
 def test_prometheus_metrics_requires_admin_user(client):
-    api_main.app.dependency_overrides[get_current_user] = lambda: MagicMock(role="member")
+    api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="member")
 
     response = client.get("/metrics/prometheus", headers={"Authorization": "Bearer fake"})
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Admin access required"
+
+
+def test_metrics_allows_api_key_client(client):
+    api_main.app.dependency_overrides[get_optional_api_key_record] = lambda: MagicMock(organization_id=1)
+    response = client.get("/metrics", headers={"x-api-key": "fake-key"})
+
+    assert response.status_code == 200
 
 
 def test_enforce_environment_integrity_raises_on_compromise():
@@ -159,10 +217,16 @@ def test_enforce_environment_integrity_raises_on_compromise():
 
 
 def test_on_startup_enforces_environment_before_db_init():
-    with patch("qwed_new.api.main._enforce_environment_integrity") as mock_enforce, patch(
-        "qwed_new.api.main.create_db_and_tables"
+    calls = []
+    with patch(
+        "qwed_new.api.main._enforce_environment_integrity",
+        side_effect=lambda: calls.append("enforce"),
+    ) as mock_enforce, patch(
+        "qwed_new.api.main.create_db_and_tables",
+        side_effect=lambda: calls.append("create"),
     ) as mock_create_db:
         api_main.on_startup()
 
     mock_enforce.assert_called_once()
     mock_create_db.assert_called_once()
+    assert calls == ["enforce", "create"]

--- a/tests/test_pr4_runtime_hardening.py
+++ b/tests/test_pr4_runtime_hardening.py
@@ -1,0 +1,168 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from qwed_new.api import main as api_main
+from qwed_new.auth.routes import get_current_user
+from qwed_new.core.agent_service import ActionContext, AgentAction, AgentService
+from qwed_new.core.policy import RedisSlidingWindowLimiter
+
+
+@pytest.fixture
+def client():
+    original_overrides = api_main.app.dependency_overrides.copy()
+    try:
+        with patch("qwed_new.api.main._enforce_environment_integrity", return_value=None):
+            with TestClient(api_main.app) as test_client:
+                yield test_client
+    finally:
+        api_main.app.dependency_overrides = original_overrides
+
+
+def _register_test_agent(service: AgentService):
+    agent = service.register_agent(
+        name="test-agent",
+        agent_type="autonomous",
+        principal_id="user-1",
+    )
+    return agent["agent_id"], agent["agent_token"]
+
+
+def test_redis_limiter_falls_back_locally_on_backend_error():
+    mock_client = MagicMock()
+    mock_pipe = MagicMock()
+    mock_client.pipeline.return_value = mock_pipe
+    mock_pipe.execute.side_effect = RuntimeError("redis unavailable")
+
+    with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+        limiter = RedisSlidingWindowLimiter(rate=1, per=60)
+
+    assert limiter.allow("tenant-1") is True
+    assert limiter.allow("tenant-1") is False
+
+
+def test_agent_token_verification_uses_compare_digest():
+    service = AgentService()
+    agent_id, agent_token = _register_test_agent(service)
+
+    with patch("qwed_new.core.agent_service.hmac.compare_digest", return_value=True) as mock_compare:
+        assert service.verify_agent_token(agent_id, agent_token) is True
+
+    mock_compare.assert_called_once_with(agent_token, agent_token)
+
+
+def test_verify_action_requires_context():
+    service = AgentService()
+    agent_id, _ = _register_test_agent(service)
+
+    result = service.verify_action(
+        agent_id,
+        AgentAction(action_type="calculate", query="2+2"),
+        context=None,
+    )
+
+    assert result["decision"] == "DENIED"
+    assert result["error"]["code"] == "QWED-AGENT-CTX-001"
+
+
+def test_verify_action_blocks_replay_steps():
+    service = AgentService()
+    agent_id, _ = _register_test_agent(service)
+    action = AgentAction(action_type="calculate", query="2+2")
+
+    approved = service.verify_action(
+        agent_id,
+        action,
+        context=ActionContext(conversation_id="conv-1", step_number=1),
+    )
+    replayed = service.verify_action(
+        agent_id,
+        action,
+        context=ActionContext(conversation_id="conv-1", step_number=1),
+    )
+
+    assert approved["decision"] == "APPROVED"
+    assert replayed["decision"] == "DENIED"
+    assert replayed["error"]["code"] == "QWED-AGENT-LOOP-002"
+
+
+def test_verify_action_blocks_repetitive_loop():
+    service = AgentService()
+    agent_id, _ = _register_test_agent(service)
+    action = AgentAction(action_type="calculate", query="2+2")
+
+    first = service.verify_action(
+        agent_id,
+        action,
+        context=ActionContext(conversation_id="conv-2", step_number=1),
+    )
+    second = service.verify_action(
+        agent_id,
+        action,
+        context=ActionContext(conversation_id="conv-2", step_number=2),
+    )
+    third = service.verify_action(
+        agent_id,
+        action,
+        context=ActionContext(conversation_id="conv-2", step_number=3),
+    )
+
+    assert first["decision"] == "APPROVED"
+    assert second["decision"] == "APPROVED"
+    assert third["decision"] == "DENIED"
+    assert third["error"]["code"] == "QWED-AGENT-LOOP-003"
+
+
+def test_metrics_requires_admin_user(client):
+    api_main.app.dependency_overrides[get_current_user] = lambda: MagicMock(role="member")
+
+    response = client.get("/metrics", headers={"Authorization": "Bearer fake"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin access required"
+
+
+def test_metrics_allows_admin_user(client):
+    api_main.app.dependency_overrides[get_current_user] = lambda: MagicMock(role="admin")
+
+    with patch.object(api_main.metrics_collector, "get_global_metrics", return_value={"requests": 1}), patch.object(
+        api_main.metrics_collector,
+        "get_all_tenant_metrics",
+        return_value={"1": {"requests": 1}},
+    ):
+        response = client.get("/metrics", headers={"Authorization": "Bearer fake"})
+
+    assert response.status_code == 200
+    assert response.json()["global"] == {"requests": 1}
+
+
+def test_prometheus_metrics_requires_admin_user(client):
+    api_main.app.dependency_overrides[get_current_user] = lambda: MagicMock(role="member")
+
+    response = client.get("/metrics/prometheus", headers={"Authorization": "Bearer fake"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin access required"
+
+
+def test_enforce_environment_integrity_raises_on_compromise():
+    with patch("qwed_sdk.guards.environment_guard.StartupHookGuard") as mock_guard_cls:
+        mock_guard = mock_guard_cls.return_value
+        mock_guard.verify_environment_integrity.return_value = {
+            "verified": False,
+            "message": "compromised",
+        }
+
+        with pytest.raises(RuntimeError, match="Environment integrity verification failed"):
+            api_main._enforce_environment_integrity()
+
+
+def test_on_startup_enforces_environment_before_db_init():
+    with patch("qwed_new.api.main._enforce_environment_integrity") as mock_enforce, patch(
+        "qwed_new.api.main.create_db_and_tables"
+    ) as mock_create_db:
+        api_main.on_startup()
+
+    mock_enforce.assert_called_once()
+    mock_create_db.assert_called_once()

--- a/tests/test_pr4_runtime_hardening.py
+++ b/tests/test_pr4_runtime_hardening.py
@@ -205,6 +205,41 @@ def test_verify_action_blocks_repetitive_pending_loop():
     assert third["error"]["code"] == "QWED-AGENT-LOOP-003"
 
 
+def test_verify_action_reserves_in_flight_step_until_release():
+    service = AgentService()
+    agent_id, _ = _register_test_agent(service)
+    action = AgentAction(action_type="calculate", query="2+2")
+
+    error, context_state = service._enforce_action_context(
+        agent_id,
+        action,
+        ActionContext(conversation_id="conv-race", step_number=1),
+    )
+    replay_error, _ = service._enforce_action_context(
+        agent_id,
+        action,
+        ActionContext(conversation_id="conv-race", step_number=1),
+    )
+    service._release_action_context(context_state)
+    retry_error, retry_state = service._enforce_action_context(
+        agent_id,
+        action,
+        ActionContext(conversation_id="conv-race", step_number=1),
+    )
+
+    assert error is None
+    assert replay_error["code"] == "QWED-AGENT-LOOP-002"
+    assert retry_error is None
+    service._release_action_context(retry_state)
+
+
+def test_action_fingerprint_rejects_non_deterministic_parameters():
+    action = AgentAction(action_type="calculate", query="2+2", parameters={"bad": object()})
+
+    with pytest.raises(TypeError, match="Unsupported action parameter type"):
+        AgentService._action_fingerprint(action)
+
+
 def test_metrics_requires_admin_user(client):
     api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="member", is_active=True)
 

--- a/tests/test_pr4_runtime_hardening.py
+++ b/tests/test_pr4_runtime_hardening.py
@@ -198,10 +198,48 @@ def test_prometheus_metrics_requires_admin_user(client):
 
 
 def test_metrics_allows_api_key_client(client):
-    api_main.app.dependency_overrides[get_optional_api_key_record] = lambda: MagicMock(organization_id=1)
-    response = client.get("/metrics", headers={"x-api-key": "fake-key"})
+    api_main.app.dependency_overrides[get_optional_api_key_record] = lambda: MagicMock(
+        organization_id=1,
+        user_id=42,
+    )
+    mock_session = MagicMock()
+    mock_session.get.return_value = MagicMock(role="admin")
+    api_main.app.dependency_overrides[api_main.get_session] = lambda: mock_session
+
+    with patch.object(api_main.metrics_collector, "get_global_metrics", return_value={"requests": 1}), patch.object(
+        api_main.metrics_collector,
+        "get_all_tenant_metrics",
+        return_value={"1": {"requests": 1}},
+    ):
+        response = client.get("/metrics", headers={"x-api-key": "fake-key"})
 
     assert response.status_code == 200
+
+
+def test_metrics_rejects_non_admin_api_key_client(client):
+    api_main.app.dependency_overrides[get_optional_api_key_record] = lambda: MagicMock(
+        organization_id=1,
+        user_id=42,
+    )
+    mock_session = MagicMock()
+    mock_session.get.return_value = MagicMock(role="member")
+    api_main.app.dependency_overrides[api_main.get_session] = lambda: mock_session
+
+    response = client.get("/metrics", headers={"x-api-key": "fake-key"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin access required"
+
+
+def test_get_optional_current_user_rejects_missing_sub_claim():
+    session = MagicMock()
+
+    with patch("qwed_new.api.main.get_current_user_token", return_value={}):
+        with pytest.raises(api_main.HTTPException) as exc_info:
+            api_main.get_optional_current_user("Bearer fake", session)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Missing sub claim in token"
 
 
 def test_enforce_environment_integrity_raises_on_compromise():

--- a/tests/test_pr4_runtime_hardening.py
+++ b/tests/test_pr4_runtime_hardening.py
@@ -149,20 +149,60 @@ def test_verify_action_allows_different_action_after_loop_denial_same_step():
         repeat_action,
         context=ActionContext(conversation_id="conv-3", step_number=2),
     )
+    state_before_denial = service._conversation_state[(agent_id, "conv-3")].copy()
     denied = service.verify_action(
         agent_id,
         repeat_action,
         context=ActionContext(conversation_id="conv-3", step_number=3),
     )
+    assert service._conversation_state[(agent_id, "conv-3")] == state_before_denial
     different = service.verify_action(
         agent_id,
         different_action,
         context=ActionContext(conversation_id="conv-3", step_number=3),
     )
+    step4 = service.verify_action(
+        agent_id,
+        AgentAction(action_type="calculate", query="3+3"),
+        context=ActionContext(conversation_id="conv-3", step_number=4),
+    )
 
     assert denied["decision"] == "DENIED"
     assert denied["error"]["code"] == "QWED-AGENT-LOOP-003"
+    assert state_before_denial == {
+        "last_step": 2,
+        "last_fingerprint": service._action_fingerprint(repeat_action),
+        "repeat_count": 2,
+    }
     assert different["decision"] == "APPROVED"
+    assert step4["decision"] == "APPROVED"
+
+
+def test_verify_action_blocks_repetitive_pending_loop():
+    service = AgentService()
+    agent_id, _ = _register_test_agent(service)
+    pending_action = AgentAction(action_type="file_write", query="write config")
+
+    first = service.verify_action(
+        agent_id,
+        pending_action,
+        context=ActionContext(conversation_id="conv-pending", step_number=1),
+    )
+    second = service.verify_action(
+        agent_id,
+        pending_action,
+        context=ActionContext(conversation_id="conv-pending", step_number=2),
+    )
+    third = service.verify_action(
+        agent_id,
+        pending_action,
+        context=ActionContext(conversation_id="conv-pending", step_number=3),
+    )
+
+    assert first["decision"] == "PENDING"
+    assert second["decision"] == "PENDING"
+    assert third["decision"] == "DENIED"
+    assert third["error"]["code"] == "QWED-AGENT-LOOP-003"
 
 
 def test_metrics_requires_admin_user(client):

--- a/tests/test_pr4_runtime_hardening.py
+++ b/tests/test_pr4_runtime_hardening.py
@@ -29,7 +29,7 @@ def _register_test_agent(service: AgentService):
     return agent["agent_id"], agent["agent_token"]
 
 
-def test_redis_limiter_falls_back_locally_on_backend_error():
+def test_redis_limiter_fails_closed_on_backend_error():
     mock_client = MagicMock()
     mock_pipe = MagicMock()
     mock_client.pipeline.return_value = mock_pipe
@@ -166,7 +166,7 @@ def test_verify_action_allows_different_action_after_loop_denial_same_step():
 
 
 def test_metrics_requires_admin_user(client):
-    api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="member")
+    api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="member", is_active=True)
 
     response = client.get("/metrics", headers={"Authorization": "Bearer fake"})
 
@@ -175,7 +175,7 @@ def test_metrics_requires_admin_user(client):
 
 
 def test_metrics_allows_admin_user(client):
-    api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="admin")
+    api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="admin", is_active=True)
 
     with patch.object(api_main.metrics_collector, "get_global_metrics", return_value={"requests": 1}), patch.object(
         api_main.metrics_collector,
@@ -189,7 +189,7 @@ def test_metrics_allows_admin_user(client):
 
 
 def test_prometheus_metrics_requires_admin_user(client):
-    api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="member")
+    api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="member", is_active=True)
 
     response = client.get("/metrics/prometheus", headers={"Authorization": "Bearer fake"})
 
@@ -203,7 +203,7 @@ def test_metrics_allows_api_key_client(client):
         user_id=42,
     )
     mock_session = MagicMock()
-    mock_session.get.return_value = MagicMock(role="admin")
+    mock_session.get.return_value = MagicMock(role="admin", is_active=True)
     api_main.app.dependency_overrides[api_main.get_session] = lambda: mock_session
 
     with patch.object(api_main.metrics_collector, "get_global_metrics", return_value={"requests": 1}), patch.object(
@@ -222,7 +222,7 @@ def test_metrics_rejects_non_admin_api_key_client(client):
         user_id=42,
     )
     mock_session = MagicMock()
-    mock_session.get.return_value = MagicMock(role="member")
+    mock_session.get.return_value = MagicMock(role="member", is_active=True)
     api_main.app.dependency_overrides[api_main.get_session] = lambda: mock_session
 
     response = client.get("/metrics", headers={"x-api-key": "fake-key"})
@@ -240,6 +240,55 @@ def test_get_optional_current_user_rejects_missing_sub_claim():
 
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "Missing sub claim in token"
+
+
+def test_metrics_rejects_inactive_admin_user(client):
+    api_main.app.dependency_overrides[get_optional_current_user] = lambda: MagicMock(role="admin", is_active=False)
+
+    response = client.get("/metrics", headers={"Authorization": "Bearer fake"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin access required"
+
+
+def test_metrics_allows_api_key_when_authorization_header_is_not_bearer(client):
+    api_main.app.dependency_overrides[get_optional_api_key_record] = lambda: MagicMock(
+        organization_id=1,
+        user_id=42,
+    )
+    mock_session = MagicMock()
+    mock_session.get.return_value = MagicMock(role="admin", is_active=True)
+    api_main.app.dependency_overrides[api_main.get_session] = lambda: mock_session
+
+    with patch.object(api_main.metrics_collector, "get_global_metrics", return_value={"requests": 1}), patch.object(
+        api_main.metrics_collector,
+        "get_all_tenant_metrics",
+        return_value={"1": {"requests": 1}},
+    ):
+        response = client.get("/metrics", headers={"Authorization": "Basic abc", "x-api-key": "fake-key"})
+
+    assert response.status_code == 200
+
+
+def test_budget_denial_does_not_consume_conversation_step():
+    service = AgentService()
+    agent_id, _ = _register_test_agent(service)
+    service._agents[agent_id].budget.max_requests_per_hour = 0
+
+    denied = service.verify_action(
+        agent_id,
+        AgentAction(action_type="calculate", query="2+2"),
+        context=ActionContext(conversation_id="conv-budget", step_number=1),
+    )
+    retry = service.verify_action(
+        agent_id,
+        AgentAction(action_type="verify_logic", query="x > 1"),
+        context=ActionContext(conversation_id="conv-budget", step_number=1),
+    )
+
+    assert denied["decision"] == "BUDGET_EXCEEDED"
+    assert retry["decision"] == "BUDGET_EXCEEDED"
+    assert retry["error"]["code"] == "QWED-AGENT-BUDGET-002"
 
 
 def test_enforce_environment_integrity_raises_on_compromise():


### PR DESCRIPTION
## Summary
- harden runtime enforcement paths so infrastructure failures do not silently weaken policy
- enforce startup environment integrity before serving requests
- require admin authentication for operational metrics endpoints
- make agent token verification timing-safe
- activate deterministic agent loop/replay controls using action context
- add regression coverage for the new runtime and agent hardening behavior

## Why
PR 4 is focused on the runtime and agent hardening phase of the QWED roadmap.

QWED should fail closed under degraded conditions, not silently fall back to weaker behavior. This batch closes several gaps:
- Redis-backed rate limiting no longer fails open on backend errors
- startup environment integrity is now enforced instead of being only test-covered
- operational metrics are no longer anonymously exposed
- agent token comparison is timing-safe
- autonomous agent loops/replays are now actively blocked using deterministic context checks

## Changes

### Runtime hardening
- `src/qwed_new/core/policy.py`
  - changed `RedisSlidingWindowLimiter` so Redis errors fall back to the local limiter instead of allowing requests through unchecked
  - preserved local limiter state for `allow()`, `get_remaining()`, and `reset()`

### Startup environment enforcement
- `src/qwed_new/api/main.py`
  - added startup-time environment integrity enforcement using `StartupHookGuard`
  - startup now fails if Python startup hook integrity cannot be verified
  - added a controlled allowlist path for expected QWED editable `.pth` files and optional env-based overrides

### Metrics endpoint hardening
- `src/qwed_new/api/main.py`
  - restricted `/metrics` to authenticated `owner` / `admin` users
  - restricted `/metrics/prometheus` to authenticated `owner` / `admin` users
  - fixed route ordering so `/metrics/prometheus` is handled correctly and not captured by `/metrics/{organization_id}`

### Agent hardening
- `src/qwed_new/core/agent_service.py`
  - switched agent token verification to `hmac.compare_digest()`
  - made `ActionContext` required for action verification
  - enforce:
    - required `conversation_id`
    - required positive `step_number`
    - max conversation step bound
    - replay / out-of-order step rejection
    - repetitive identical-action loop detection

### Tests
- `tests/test_pr4_runtime_hardening.py`
  - added regression coverage for:
    - Redis fallback behavior
    - timing-safe token verification
    - required agent context
    - replay blocking
    - repetitive loop blocking
    - admin-only metrics access
    - startup environment enforcement

## Validation
- Targeted tests passed: `57 passed`
- `py_compile` on touched files passed

## Notes
- This PR intentionally favors fail-closed enforcement over availability when security-critical runtime guarantees are missing.
- The startup environment allowlist includes expected local QWED editable `.pth` files to avoid false positives in known dev/test installs while still enforcing integrity checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Metrics and Prometheus endpoints now require authorized admin access (user role or API key); optional caller identity resolution and role-gating added.
  * Agent action verification strengthened to enforce context, detect/reject replays and loops, persist conversation progress, and use constant-time token comparison.
  * Startup enforces environment integrity and aborts on failed verification.

* **Bug Fixes**
  * Rate limiter now fails safe on backend errors and refines local fallback behavior.

* **Tests**
  * New tests for metrics auth, agent hardening, rate limiting, and startup integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->