### PR TITLE
PR 5: Align determinism and trust boundaries

### DIFF
--- a/src/qwed_new/core/control_plane.py
+++ b/src/qwed_new/core/control_plane.py
@@ -35,6 +35,34 @@ class ControlPlane:
         # Enterprise security components
         self.security_gateway = EnhancedSecurityGateway()
         self.output_sanitizer = OutputSanitizer()
+
+    @staticmethod
+    def _build_math_trust_boundary(
+        provider: str,
+        verification_result: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Describe exactly what the math pipeline did and did not prove."""
+        expression_status = verification_result.get("status")
+        deterministic_evaluation = expression_status in {"VERIFIED", "CORRECTION_NEEDED"}
+        return {
+            "query_interpretation_source": "llm_translation",
+            "query_semantics_verified": False,
+            "verification_scope": "translated_expression_only",
+            "deterministic_expression_evaluation": deterministic_evaluation,
+            "formal_proof": False,
+            "translation_claim_self_consistent": verification_result.get("is_correct"),
+            "provider_used": provider,
+        }
+
+    @staticmethod
+    def _determine_math_response_status(verification_result: Dict[str, Any]) -> str:
+        """Avoid representing translated-query evaluation as a proven user-query verdict."""
+        expression_status = verification_result.get("status")
+        if expression_status in {"VERIFIED", "CORRECTION_NEEDED"}:
+            return "INCONCLUSIVE"
+        if expression_status == "SYNTAX_ERROR":
+            return "ERROR"
+        return expression_status or "ERROR"
         
     async def process_natural_language(
         self, 
@@ -99,14 +127,18 @@ class ControlPlane:
                 expression=task.expression,
                 expected_value=task.claimed_answer
             )
+            response_status = self._determine_math_response_status(verification_result)
+            trust_boundary = self._build_math_trust_boundary(provider, verification_result)
+            trust_boundary["overall_status"] = response_status
             
             # 5. Response Construction
             response = {
-                "status": verification_result["status"],
+                "status": response_status,
                 "final_answer": verification_result.get("calculated_value"),
                 "user_query": query,
                 "translation": task.dict(),
                 "verification": verification_result,
+                "trust_boundary": trust_boundary,
                 "provider_used": provider,
                 "latency_ms": (time.time() - start_time) * 1000
             }

--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -178,10 +178,11 @@ class VerificationEngine:
             
             if evaluated_points > 0 and matches == evaluated_points:
                 return {
-                    "is_equivalent": True,
-                    "status": "LIKELY_EQUIVALENT",
+                    "is_equivalent": None,
+                    "status": "UNKNOWN",
                     "method": "numerical_sampling",
-                    "confidence": 0.99
+                    "confidence": 0.0,
+                    "reason": "Numerical sampling matched at fixed points, but no formal proof was established"
                 }
             
             return {

--- a/tests/test_pr5_determinism_alignment.py
+++ b/tests/test_pr5_determinism_alignment.py
@@ -1,0 +1,97 @@
+import pytest
+
+from qwed_new.core.control_plane import ControlPlane, metrics_collector
+from qwed_new.core.schemas import MathVerificationTask
+from qwed_new.core.verifier import VerificationEngine
+
+
+def test_verify_identity_sampling_returns_unknown_without_formal_proof():
+    engine = VerificationEngine()
+
+    result = engine.verify_identity(
+        "x",
+        "x + (x-0.5)*(x-1)*(x-2)*(x+1)*(x-0.1)",
+    )
+
+    assert result["status"] == "UNKNOWN"
+    assert result["is_equivalent"] is None
+    assert result["method"] == "numerical_sampling"
+
+
+@pytest.mark.asyncio
+async def test_control_plane_marks_translated_math_as_inconclusive(monkeypatch):
+    cp = ControlPlane()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(cp.security_gateway, "detect_advanced_injection", lambda _: (True, ""))
+    monkeypatch.setattr(cp.policy, "check_policy", lambda _query, organization_id=None: (True, ""))
+    monkeypatch.setattr(cp.router, "route", lambda _query, preferred_provider=None: "openai_compat")
+    monkeypatch.setattr(cp.output_sanitizer, "sanitize_output", lambda result, output_type, organization_id: result)
+    monkeypatch.setattr(
+        cp.translator,
+        "translate",
+        lambda query, provider=None: MathVerificationTask(
+            expression="0.15 * 200",
+            claimed_answer=30.0,
+            reasoning="15 percent is 0.15, multiplied by 200",
+            confidence=0.99,
+        ),
+    )
+
+    def _track_request(*, organization_id, status, latency_ms, provider):
+        captured.update(
+            {
+                "organization_id": organization_id,
+                "status": status,
+                "provider": provider,
+                "latency_ms": latency_ms,
+            }
+        )
+
+    monkeypatch.setattr(metrics_collector, "track_request", _track_request)
+
+    result = await cp.process_natural_language("What is 15% of 200?", organization_id=42)
+
+    assert result["status"] == "INCONCLUSIVE"
+    assert result["final_answer"] == 30.0
+    assert result["verification"]["status"] == "VERIFIED"
+    assert result["trust_boundary"] == {
+        "query_interpretation_source": "llm_translation",
+        "query_semantics_verified": False,
+        "verification_scope": "translated_expression_only",
+        "deterministic_expression_evaluation": True,
+        "formal_proof": False,
+        "translation_claim_self_consistent": True,
+        "provider_used": "openai_compat",
+        "overall_status": "INCONCLUSIVE",
+    }
+    assert captured["organization_id"] == 42
+    assert captured["status"] == "INCONCLUSIVE"
+    assert captured["provider"] == "openai_compat"
+
+
+@pytest.mark.asyncio
+async def test_control_plane_keeps_inconclusive_when_translation_claim_is_wrong(monkeypatch):
+    cp = ControlPlane()
+
+    monkeypatch.setattr(cp.security_gateway, "detect_advanced_injection", lambda _: (True, ""))
+    monkeypatch.setattr(cp.policy, "check_policy", lambda _query, organization_id=None: (True, ""))
+    monkeypatch.setattr(cp.router, "route", lambda _query, preferred_provider=None: "openai_compat")
+    monkeypatch.setattr(cp.output_sanitizer, "sanitize_output", lambda result, output_type, organization_id: result)
+    monkeypatch.setattr(
+        cp.translator,
+        "translate",
+        lambda query, provider=None: MathVerificationTask(
+            expression="0.15 * 200",
+            claimed_answer=40.0,
+            reasoning="Incorrectly interpreted result",
+            confidence=0.99,
+        ),
+    )
+
+    result = await cp.process_natural_language("What is 15% of 200?", organization_id=42)
+
+    assert result["status"] == "INCONCLUSIVE"
+    assert result["final_answer"] == 30.0
+    assert result["verification"]["status"] == "CORRECTION_NEEDED"
+    assert result["trust_boundary"]["translation_claim_self_consistent"] is False

--- a/tests/test_pr5_determinism_alignment.py
+++ b/tests/test_pr5_determinism_alignment.py
@@ -1,6 +1,7 @@
 import pytest
 
-from qwed_new.core.control_plane import ControlPlane, metrics_collector
+from qwed_new.core.control_plane import ControlPlane
+from qwed_new.core.observability import metrics_collector
 from qwed_new.core.schemas import MathVerificationTask
 from qwed_new.core.verifier import VerificationEngine
 
@@ -95,3 +96,25 @@ async def test_control_plane_keeps_inconclusive_when_translation_claim_is_wrong(
     assert result["final_answer"] == 30.0
     assert result["verification"]["status"] == "CORRECTION_NEEDED"
     assert result["trust_boundary"]["translation_claim_self_consistent"] is False
+
+
+def test_control_plane_maps_syntax_error_to_error_status():
+    result = ControlPlane._determine_math_response_status({"status": "SYNTAX_ERROR"})
+
+    assert result == "ERROR"
+
+
+def test_control_plane_defaults_missing_math_status_to_error():
+    result = ControlPlane._determine_math_response_status({})
+
+    assert result == "ERROR"
+
+
+def test_control_plane_marks_failed_expression_evaluation_as_non_deterministic():
+    result = ControlPlane._build_math_trust_boundary(
+        "openai_compat",
+        {"status": "SYNTAX_ERROR", "is_correct": False},
+    )
+
+    assert result["deterministic_expression_evaluation"] is False
+    assert result["translation_claim_self_consistent"] is False

--- a/tests/test_pr5_determinism_alignment.py
+++ b/tests/test_pr5_determinism_alignment.py
@@ -9,6 +9,8 @@ from qwed_new.core.verifier import VerificationEngine
 def test_verify_identity_sampling_returns_unknown_without_formal_proof():
     engine = VerificationEngine()
 
+    # This RHS is crafted to equal x at the hardcoded sample points used by
+    # verify_identity (0.5, 1, 2, -1, 0.1) without being algebraically identical.
     result = engine.verify_identity(
         "x",
         "x + (x-0.5)*(x-1)*(x-2)*(x+1)*(x-0.1)",


### PR DESCRIPTION
## Summary
- stop representing translated natural-language math as fully verified user-query truth
- return `UNKNOWN` instead of heuristic `LIKELY_EQUIVALENT` for symbolic identity checks that rely only on fixed-point sampling
- add explicit trust-boundary metadata so clients can see what was actually proven and what remained model-mediated
- add regression coverage for the new determinism-alignment behavior

## Why
PR 5 is the final roadmap batch focused on philosophy alignment.

QWED’s deterministic engines are strong, but the API should not overstate what they prove. If the system only deterministically evaluates an **LLM-translated expression**, that is not the same thing as formally verifying the original user query semantics. Likewise, fixed numerical sampling is not a formal symbolic proof.

This PR makes the boundary honest:
- heuristic equivalence checks now surface uncertainty
- translated-query math results now expose a deterministic expression evaluation without claiming the original natural-language question itself was formally verified
- responses now carry trust metadata that distinguishes proven facts from model-mediated interpretation

## Changes

### Natural-language math trust boundary
- `src/qwed_new/core/control_plane.py`
  - added `_determine_math_response_status(...)`
  - added `_build_math_trust_boundary(...)`
  - natural-language math now returns top-level `INCONCLUSIVE` when the result depends on LLM query interpretation, even if the translated expression was deterministically evaluated
  - added `trust_boundary` metadata to responses:
    - `query_interpretation_source`
    - `query_semantics_verified`
    - `verification_scope`
    - `deterministic_expression_evaluation`
    - `formal_proof`
    - `translation_claim_self_consistent`
    - `provider_used`
    - `overall_status`

### Symbolic identity honesty
- `src/qwed_new/core/verifier.py`
  - changed `verify_identity()` so fixed-point numerical sampling no longer returns `LIKELY_EQUIVALENT`
  - when algebraic simplification/expansion cannot prove equivalence but numerical samples happen to match, the engine now returns:
    - `status = "UNKNOWN"`
    - `is_equivalent = None`
    - explicit reason explaining that no formal proof was established

### Tests
- `tests/test_pr5_determinism_alignment.py`
  - added regression coverage for:
    - heuristic identity fallback returning `UNKNOWN`
    - natural-language math remaining `INCONCLUSIVE` even when translated expression is internally verified
    - wrong LLM claimed answer still producing deterministic correction without becoming a proven user-query verdict

## Validation
- `pytest tests/test_pr5_determinism_alignment.py tests/test_enterprise_math.py tests/test_pr112_regressions.py -q`
  - `49 passed`
- cleanup rerun:
  - `pytest tests/test_pr5_determinism_alignment.py -q`
  - `3 passed`
- `py_compile` on touched files passed

## Notes
- This PR intentionally preserves deterministic computation while tightening how its guarantees are described.
- Direct deterministic math verification endpoints remain separate; this change is about preventing model-mediated natural-language flows from being overstated as formally verified truth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses now include a trust boundary summary describing verification scope, methods used, and an overall trust status; top-level status is now normalized for clearer outcomes.

* **Bug Fixes**
  * Numerical-sampling fallbacks no longer claim equivalence—unproven results return "unknown" with zero confidence.

* **Tests**
  * Added determinism and alignment tests covering verification and end-to-end control-plane behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->