### PR TITLE
release(v5.0.0): version bump + CHANGELOG for Enforcement Boundary Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,65 @@
 All notable changes to the QWED Protocol will be documented in this file.
 
 ## [Unreleased]
-### Security
-- Agent verification security checks are now enforced server-side and are no longer configurable through client request payloads.
-- TypeScript SDK agent verification helpers no longer send `security_checks`; `tool_schema` remains available for server-side MCP inspection.
-- Statistical verification now requires the secure Docker sandbox; Wasm and restricted in-process fallback execution paths are disabled.
-- Consensus Python verification now uses the secure Docker executor instead of same-process code execution.
+
+## [4.1.0] - 2026-04-04
+### 🛡️ Enforcement Boundary Hardening
+
+Major release focused on making QWED's verification boundary fail-closed, deterministic about what it proves, and substantially harder to bypass under adversarial conditions. Consolidates 98 commits and 20 merged PRs since v4.0.1, including the full PR 0–5 enforcement hardening series.
+
+#### 🔐 Security Hardening
+- **Fail-Closed Verification**: Disabled unsafe in-process execution fallbacks; stats and consensus paths now require secure Docker sandbox.
+- **Critical Boundary Closures**: Removed logic verifier `eval()` fallback — raises `RuntimeError` if `SafeEvaluator` is unavailable (CVE-QWED-001).
+- **Mandatory Guards**: Agent security guards (Exfiltration, MCP Poison) are now server-enforced and unconditional — `security_checks` field removed from request model.
+- **Consensus Rate Limiting**: `/verify/consensus` endpoint now enforces `check_rate_limit` to prevent cost amplification attacks.
+- **Self-Attestation Fix**: Consensus fact engine no longer calls `verify_fact(query, query)` — requires external context.
+- **Redis Fail-Closed**: `RedisSlidingWindowLimiter` now denies requests on Redis errors instead of allowing them.
+- **Timing-Safe Token Verification**: Agent token comparison switched to `hmac.compare_digest`.
+- **Metrics Access Control**: `/metrics` and `/metrics/prometheus` now require authenticated admin access.
+- **Environment Integrity**: Startup enforces `verify_environment_integrity()` before database initialization.
+
+#### 🧠 Determinism & Trust Boundary
+- Natural-language math responses now return `INCONCLUSIVE` when verifying LLM-translated expressions — never `VERIFIED`.
+- Added explicit `trust_boundary` metadata in API responses describing what was actually verified.
+- `verify_identity()` numerical sampling fallback now returns `UNKNOWN` instead of `LIKELY_EQUIVALENT`.
+- Heuristic/non-proof outcomes are honestly labeled instead of presented as formal verification.
+
+#### 🤖 Agent Hardening
+- **Action context mandatory**: `verify_action()` requires `ActionContext` with `conversation_id` and `step_number`.
+- **Replay detection**: Same `(conversation_id, step_number)` pair blocked (QWED-AGENT-LOOP-002).
+- **Loop detection**: Same action repeated 3+ times triggers DENIED (QWED-AGENT-LOOP-003).
+- **In-flight step reservations**: Prevents race conditions in concurrent agent calls.
+- **Budget denial isolation**: Budget-exceeded denials do not consume conversation state.
+
+#### 📜 Tool Governance (PR 0)
+- Added `QWED_RULES.md` — canonical enforcement contract for contributors and tools.
+- Added `.github/copilot-instructions.md` — blocks Copilot from suggesting fallback execution.
+- Added `.github/pull_request_template.md` — mandatory enforcement checklist.
+- Extended `.coderabbit.yaml` with enforcement-specific review instructions.
+
+#### 🔧 Supply Chain & CI
+- Pinned third-party GitHub Actions to verified commit SHAs.
+- Merged security autofix PRs and dependency hardening (#100–#114).
+
+#### 📦 SDK & Package Versions
+- `qwed` (PyPI): `4.0.1` → `4.1.0`
+- `qwed_sdk` (Python): `2.1.0-dev` → `4.1.0`
+- `@qwed-ai/sdk` (NPM): `4.0.1` → `4.1.0`
+- TypeScript SDK: Removed `security_checks` from agent verification helpers; `tool_schema` remains.
+
+#### 🧪 Test Coverage
+- `test_pr115_regressions.py` — critical boundary closures (eval removal, guard enforcement, consensus rate limit, fact self-attestation).
+- `test_pr117_regressions.py` — stats fail-closed behavior, sandbox enforcement.
+- `test_pr4_runtime_hardening.py` — Redis fail-closed, agent loop controls, metrics auth, environment integrity.
+- `test_pr5_determinism_alignment.py` — trust boundary metadata, INCONCLUSIVE status, numerical sampling UNKNOWN.
+- **Sanity sweep**: 162 passed, 11 skipped, 0 failures.
+
+#### ⚠️ Upgrade Notes
+- `INCONCLUSIVE` is now a distinct verification status — downstream consumers must handle it.
+- `BLOCKED` and `UNKNOWN` are explicit outcomes, not generic failures.
+- Agent integrations must provide `ActionContext` with `conversation_id` and `step_number`.
+- `/metrics` endpoints now require admin role — update monitoring integrations accordingly.
+
 
 ## [4.0.1] - 2026-03-23
 ### 🔄 Sentinel Guard Sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the QWED Protocol will be documented in this file.
 
 ## [Unreleased]
 
-## [4.1.0] - 2026-04-04
+## [5.0.0] - 2026-04-04
 ### 🛡️ Enforcement Boundary Hardening
 
 Major release focused on making QWED's verification boundary fail-closed, deterministic about what it proves, and substantially harder to bypass under adversarial conditions. Consolidates 98 commits and 20 merged PRs since v4.0.1, including the full PR 0–5 enforcement hardening series.
@@ -44,9 +44,9 @@ Major release focused on making QWED's verification boundary fail-closed, determ
 - Merged security autofix PRs and dependency hardening (#100–#114).
 
 #### 📦 SDK & Package Versions
-- `qwed` (PyPI): `4.0.1` → `4.1.0`
-- `qwed_sdk` (Python): `2.1.0-dev` → `4.1.0`
-- `@qwed-ai/sdk` (NPM): `4.0.1` → `4.1.0`
+- `qwed` (PyPI): `4.0.1` → `5.0.0`
+- `qwed_sdk` (Python): `2.1.0-dev` → `5.0.0`
+- `@qwed-ai/sdk` (NPM): `4.0.1` → `5.0.0`
 - TypeScript SDK: Removed `security_checks` from agent verification helpers; `tool_schema` remains.
 
 #### 🧪 Test Coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed"
-version = "4.1.0"
+version = "5.0.0"
 description = "The Deterministic Verification Protocol for AI - 11 verification engines for math, logic, code, SQL, facts, images, and more. Now with Agentic Security Guards."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed"
-version = "4.0.1"
+version = "4.1.0"
 description = "The Deterministic Verification Protocol for AI - 11 verification engines for math, logic, code, SQL, facts, images, and more. Now with Agentic Security Guards."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/qwed_sdk/__init__.py
+++ b/qwed_sdk/__init__.py
@@ -37,7 +37,7 @@ from qwed_sdk.models import (
     VerificationType,
 )
 
-__version__ = "4.1.0"
+__version__ = "5.0.0"
 __all__ = [
     "QWEDClient",
     "QWEDAsyncClient",

--- a/qwed_sdk/__init__.py
+++ b/qwed_sdk/__init__.py
@@ -37,7 +37,7 @@ from qwed_sdk.models import (
     VerificationType,
 )
 
-__version__ = "2.1.0-dev"
+__version__ = "4.1.0"
 __all__ = [
     "QWEDClient",
     "QWEDAsyncClient",

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "4.1.0",
+    "version": "5.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@qwed-ai/sdk",
-            "version": "4.1.0",
+            "version": "5.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/node": "^20.0.0",

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "4.0.1",
+    "version": "4.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@qwed-ai/sdk",
-            "version": "4.0.1",
+            "version": "4.1.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/node": "^20.0.0",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "4.1.0",
+    "version": "5.0.0",
     "description": "TypeScript SDK for QWED Verification Protocol",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "4.0.1",
+    "version": "4.1.0",
     "description": "TypeScript SDK for QWED Verification Protocol",
     "main": "dist/index.js",
     "module": "dist/index.mjs",


### PR DESCRIPTION
Release v5.0.0 — Enforcement Boundary Hardening

## What this PR does
Bumps all package and SDK versions to `5.0.0` and finalizes the `CHANGELOG.md` entry for the Enforcement Boundary Hardening release.

## Files changed

| File | Change |
|---|---|
| `pyproject.toml` | `4.0.1` → `5.0.0` |
| `qwed_sdk/__init__.py` | `2.1.0-dev` → `5.0.0` |
| `sdk-ts/package.json` | `4.0.1` → `5.0.0` |
| `sdk-ts/package-lock.json` | `4.0.1` → `5.0.0` |
| `CHANGELOG.md` | Added `[5.0.0]` entry covering 98 commits and 20 merged PRs since `v4.0.1` |

## Why v5.0.0 (not v4.1.0)
This release contains intentional breaking changes and must be versioned as a major release under Semantic Versioning.

Breaking changes include:
- mandatory agent guards are now server-enforced
- `security_checks` field removed from agent verification request flow
- `ActionContext` is now mandatory for agent verification
- `/metrics` and `/metrics/prometheus` now require authenticated admin/owner access
- verification semantics now expose explicit `INCONCLUSIVE`, `BLOCKED`, and `UNKNOWN` outcomes
- trust-boundary metadata is now part of natural-language math verification behavior

## What’s included in v5.0.0
- 251+ security issues fixed across the post-`v4.0.1` hardening cycle
- full PR 0–5 enforcement series merged
- fail-closed runtime and secure execution hardening
- deterministic trust-boundary alignment
- runtime/agent replay and loop protection
- release-ready changelog summarizing the full delta since `v4.0.1`

## Sanity Sweep Results
- `162 passed, 11 skipped, 0 failures` in `17.22s`
- all 10 adversarial audit findings verified fixed in code
- release checklist outcome:
  - `8/10 PASS`
  - `2 MINOR`
  - `0 MAJOR`

## Pre-merge checklist
- [x] All sanity sweep tests pass
- [x] All adversarial audit findings verified fixed
- [x] Version consistency across backend, Python SDK, and TypeScript SDK
- [x] `CHANGELOG.md` reflects all merged release work since `v4.0.1`
- [x] No unsafe eval/exec fallback remains on protected verification paths
- [x] Guards are server-enforced, not client-optional
- [x] Redis rate limiter fails closed on backend error
- [x] `/metrics` requires authenticated privileged access

## Post-merge
After merging this PR:
- create GitHub release `v5.0.0`
- publish PyPI package `qwed==5.0.0`
- publish NPM package `@qwed-ai/sdk@5.0.0`
- tag/publish Docker image `5.0.0`

## Summary
This PR converts the planned `v4.1.0` release into a SemVer-correct `v5.0.0` release because the enforcement-boundary hardening work includes externally visible breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enforcement boundary hardening: fail-closed behavior, no unsafe verification fallbacks, Docker sandbox requirement, endpoint rate limiting, metrics require admin auth, and timing-safe token checks.

* **New Features**
  * New verification/trust outcomes (e.g., INCONCLUSIVE/UNKNOWN) and stricter agent action/context requirements, replay/loop detection, and in-flight step reservations.

* **Bug Fixes**
  * Corrected consensus self-attestation logic and fail-closed rate-limiter behavior on backend errors.

* **Chores**
  * Package and SDK version bumped to 5.0.0; upgrade notes added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->