### PR TITLE
feat: AgentStateGuard – full implementation (structural + semantic + atomic commit)

### DIFF
--- a/src/qwed_new/guards/__init__.py
+++ b/src/qwed_new/guards/__init__.py
@@ -1,2 +1,3 @@
 from .code_guard import CodeGuard
 from .sql_guard import SQLGuard
+from .agent_state_guard import AgentStateGuard

--- a/src/qwed_new/guards/agent_state_guard.py
+++ b/src/qwed_new/guards/agent_state_guard.py
@@ -27,10 +27,26 @@ class AgentStateGuard:
     _VALID_SCHEMA_TYPES = frozenset(
         {"object", "array", "string", "integer", "number", "boolean", "null"}
     )
+    _VALID_TRANSITION_RULE_KEYS = frozenset(
+        {
+            "immutable_paths",
+            "monotonic_integer_paths",
+            "ordered_enum_paths",
+            "keyed_object_array_paths",
+        }
+    )
     MAX_VALIDATION_DEPTH = 64
 
-    def __init__(self, required_schema: Dict[str, Any]) -> None:
+    def __init__(
+        self,
+        required_schema: Dict[str, Any],
+        transition_rules: Dict[str, Any] | None = None,
+    ) -> None:
         self.required_schema = self._validate_schema_definition(required_schema, "$")
+        self._transition_rules_configured = bool(transition_rules)
+        self.transition_rules = self._validate_transition_rules_definition(
+            transition_rules or {}
+        )
 
     def verify_state_payload(self, proposed_state_json: str) -> Dict[str, Any]:
         """
@@ -70,6 +86,59 @@ class AgentStateGuard:
             "normalized_state": self._canonicalize(state_data),
         }
 
+    def verify_state_transition(
+        self,
+        current_state_json: str,
+        proposed_state_json: str,
+    ) -> Dict[str, Any]:
+        """
+        Verify an old_state -> new_state transition with structural and
+        configured semantic checks. No side effects occur here.
+        """
+        if not self._transition_rules_configured:
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-104",
+                message=(
+                    "Blocked: semantic transition verification requires configured "
+                    "transition rules."
+                ),
+            )
+
+        current_result = self.verify_state_payload(current_state_json)
+        if not current_result["verified"]:
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-105",
+                message=(
+                    "Blocked: current agent state failed structural verification. "
+                    f"{current_result['message']}"
+                ),
+            )
+
+        proposed_result = self.verify_state_payload(proposed_state_json)
+        if not proposed_result["verified"]:
+            return proposed_result
+
+        transition_error = self._validate_transition_rules(
+            current_state=current_result["normalized_state"],
+            proposed_state=proposed_result["normalized_state"],
+        )
+        if transition_error is not None:
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-106",
+                message=f"Blocked: {transition_error}",
+            )
+
+        return {
+            "verified": True,
+            "status": "VERIFIED",
+            "proof": (
+                "State transition satisfied the configured structural and "
+                "semantic rules."
+            ),
+            "normalized_previous_state": current_result["normalized_state"],
+            "normalized_state": proposed_result["normalized_state"],
+        }
+
     def _load_strict_json(self, proposed_state_json: str) -> Any:
         return json.loads(
             proposed_state_json,
@@ -92,6 +161,39 @@ class AgentStateGuard:
             handler(self, schema, path)
 
         return schema
+
+    def _validate_transition_rules_definition(
+        self, transition_rules: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        if not isinstance(transition_rules, dict):
+            raise ValueError("Transition rules must be a dictionary.")
+
+        unknown_keys = sorted(
+            set(transition_rules) - set(self._VALID_TRANSITION_RULE_KEYS)
+        )
+        if unknown_keys:
+            raise ValueError(
+                f"Transition rules contain unsupported keys: {unknown_keys}."
+            )
+
+        validated_rules: Dict[str, Any] = {}
+        validated_rules["immutable_paths"] = self._validate_path_list(
+            transition_rules.get("immutable_paths", []),
+            "immutable_paths",
+        )
+        validated_rules["monotonic_integer_paths"] = self._validate_path_list(
+            transition_rules.get("monotonic_integer_paths", []),
+            "monotonic_integer_paths",
+        )
+        validated_rules["ordered_enum_paths"] = self._validate_ordered_enum_paths(
+            transition_rules.get("ordered_enum_paths", {})
+        )
+        validated_rules["keyed_object_array_paths"] = (
+            self._validate_keyed_object_array_paths(
+                transition_rules.get("keyed_object_array_paths", {})
+            )
+        )
+        return validated_rules
 
     def _validate_value(
         self,
@@ -123,6 +225,72 @@ class AgentStateGuard:
                 f"Schema at {path} must declare a supported type, got {schema_type!r}."
             )
         return schema_type
+
+    @staticmethod
+    def _validate_path_list(paths: Any, rule_name: str) -> list[str]:
+        if not isinstance(paths, list) or any(not isinstance(path, str) for path in paths):
+            raise ValueError(f"{rule_name} must be a list of JSON-style path strings.")
+        for path in paths:
+            AgentStateGuard._validate_json_path(path, rule_name)
+        return paths
+
+    def _validate_ordered_enum_paths(self, rules: Any) -> Dict[str, list[Any]]:
+        if not isinstance(rules, dict):
+            raise ValueError("ordered_enum_paths must be a dictionary.")
+
+        validated: Dict[str, list[Any]] = {}
+        for path, allowed_values in rules.items():
+            self._validate_json_path(path, "ordered_enum_paths")
+            if not isinstance(allowed_values, list) or len(allowed_values) < 2:
+                raise ValueError(
+                    f"ordered_enum_paths[{path!r}] must define at least two ordered values."
+                )
+            validated[path] = allowed_values
+        return validated
+
+    def _validate_keyed_object_array_paths(
+        self, rules: Any
+    ) -> Dict[str, Dict[str, Any]]:
+        if not isinstance(rules, dict):
+            raise ValueError("keyed_object_array_paths must be a dictionary.")
+
+        validated: Dict[str, Dict[str, Any]] = {}
+        for path, rule in rules.items():
+            self._validate_json_path(path, "keyed_object_array_paths")
+            if not isinstance(rule, dict):
+                raise ValueError(
+                    f"keyed_object_array_paths[{path!r}] must be a dictionary."
+                )
+
+            key = rule.get("key")
+            if not isinstance(key, str) or not key:
+                raise ValueError(
+                    f"keyed_object_array_paths[{path!r}] must define a non-empty key field."
+                )
+
+            monotonic_boolean_fields = rule.get("monotonic_boolean_fields", [])
+            if not isinstance(monotonic_boolean_fields, list) or any(
+                not isinstance(field, str) or not field
+                for field in monotonic_boolean_fields
+            ):
+                raise ValueError(
+                    f"keyed_object_array_paths[{path!r}].monotonic_boolean_fields "
+                    "must be a list of field names."
+                )
+
+            allow_new_items = rule.get("allow_new_items", True)
+            if not isinstance(allow_new_items, bool):
+                raise ValueError(
+                    f"keyed_object_array_paths[{path!r}].allow_new_items must be a boolean."
+                )
+
+            validated[path] = {
+                "key": key,
+                "monotonic_boolean_fields": monotonic_boolean_fields,
+                "allow_new_items": allow_new_items,
+            }
+
+        return validated
 
     @staticmethod
     def _validate_enum_definition(schema: Dict[str, Any], path: str) -> None:
@@ -178,6 +346,191 @@ class AgentStateGuard:
         if "enum" in schema and value not in schema["enum"]:
             return f"{path} must be one of {schema['enum']!r}, got {value!r}."
         return None
+
+    def _validate_transition_rules(
+        self,
+        current_state: Dict[str, Any],
+        proposed_state: Dict[str, Any],
+    ) -> str | None:
+        validators = (
+            self._validate_immutable_paths,
+            self._validate_monotonic_integer_paths,
+            self._validate_ordered_enum_transition_paths,
+            self._validate_keyed_object_array_transition_paths,
+        )
+        for validator in validators:
+            error = validator(current_state, proposed_state)
+            if error is not None:
+                return error
+        return None
+
+    def _validate_immutable_paths(
+        self,
+        current_state: Dict[str, Any],
+        proposed_state: Dict[str, Any],
+    ) -> str | None:
+        for path in self.transition_rules["immutable_paths"]:
+            current_value = self._get_path_value(current_state, path)
+            proposed_value = self._get_path_value(proposed_state, path)
+            if current_value != proposed_value:
+                return (
+                    f"{path} is immutable across state transitions. "
+                    f"Current={current_value!r}, proposed={proposed_value!r}."
+                )
+        return None
+
+    def _validate_monotonic_integer_paths(
+        self,
+        current_state: Dict[str, Any],
+        proposed_state: Dict[str, Any],
+    ) -> str | None:
+        for path in self.transition_rules["monotonic_integer_paths"]:
+            current_value = self._get_path_value(current_state, path)
+            proposed_value = self._get_path_value(proposed_state, path)
+            if proposed_value < current_value:
+                return (
+                    f"{path} regressed from {current_value!r} to "
+                    f"{proposed_value!r}."
+                )
+        return None
+
+    def _validate_ordered_enum_transition_paths(
+        self,
+        current_state: Dict[str, Any],
+        proposed_state: Dict[str, Any],
+    ) -> str | None:
+        for path, allowed_values in self.transition_rules["ordered_enum_paths"].items():
+            current_value = self._get_path_value(current_state, path)
+            proposed_value = self._get_path_value(proposed_state, path)
+            current_index = allowed_values.index(current_value)
+            proposed_index = allowed_values.index(proposed_value)
+            if proposed_index < current_index:
+                return (
+                    f"{path} regressed from {current_value!r} to "
+                    f"{proposed_value!r}."
+                )
+        return None
+
+    def _validate_keyed_object_array_transition_paths(
+        self,
+        current_state: Dict[str, Any],
+        proposed_state: Dict[str, Any],
+    ) -> str | None:
+        for path, rule in self.transition_rules["keyed_object_array_paths"].items():
+            current_items = self._get_path_value(current_state, path)
+            proposed_items = self._get_path_value(proposed_state, path)
+            error = self._validate_keyed_object_array_transition(
+                path=path,
+                current_items=current_items,
+                proposed_items=proposed_items,
+                rule=rule,
+            )
+            if error is not None:
+                return error
+        return None
+
+    def _validate_keyed_object_array_transition(
+        self,
+        path: str,
+        current_items: Any,
+        proposed_items: Any,
+        rule: Dict[str, Any],
+    ) -> str | None:
+        if not isinstance(current_items, list) or not isinstance(proposed_items, list):
+            return f"{path} must resolve to arrays in both current and proposed state."
+
+        key_field = rule["key"]
+        current_keys = self._extract_keyed_item_keys(current_items, path, key_field)
+        if isinstance(current_keys, str):
+            return current_keys
+        proposed_keys = self._extract_keyed_item_keys(proposed_items, path, key_field)
+        if isinstance(proposed_keys, str):
+            return proposed_keys
+
+        if proposed_keys[: len(current_keys)] != current_keys:
+            return f"{path} must preserve existing item order and prevent deletion."
+        if not rule["allow_new_items"] and len(proposed_keys) != len(current_keys):
+            return f"{path} does not allow appending new items."
+
+        current_map = {item[key_field]: item for item in current_items}
+        proposed_map = {item[key_field]: item for item in proposed_items}
+
+        for key in current_keys:
+            current_item = current_map[key]
+            proposed_item = proposed_map[key]
+            item_error = self._validate_keyed_object_item_transition(
+                path=path,
+                key_field=key_field,
+                item_key=key,
+                current_item=current_item,
+                proposed_item=proposed_item,
+                monotonic_boolean_fields=rule["monotonic_boolean_fields"],
+            )
+            if item_error is not None:
+                return item_error
+        return None
+
+    @staticmethod
+    def _extract_keyed_item_keys(
+        items: list[Any], path: str, key_field: str
+    ) -> list[Any] | str:
+        keys: list[Any] = []
+        seen_keys: set[Any] = set()
+        for index, item in enumerate(items):
+            if not isinstance(item, dict):
+                return f"{path}[{index}] must be an object."
+            if key_field not in item:
+                return f"{path}[{index}] is missing key field {key_field!r}."
+            key = item[key_field]
+            if key in seen_keys:
+                return f"{path} contains duplicate {key_field!r} values: {key!r}."
+            seen_keys.add(key)
+            keys.append(key)
+        return keys
+
+    @staticmethod
+    def _validate_keyed_object_item_transition(
+        path: str,
+        key_field: str,
+        item_key: Any,
+        current_item: Dict[str, Any],
+        proposed_item: Dict[str, Any],
+        monotonic_boolean_fields: list[str],
+    ) -> str | None:
+        for field in monotonic_boolean_fields:
+            old_value = current_item.get(field)
+            new_value = proposed_item.get(field)
+            if old_value is True and new_value is False:
+                return (
+                    f"{path}[{key_field}={item_key!r}].{field} regressed from True to False."
+                )
+
+        for field, old_value in current_item.items():
+            if field in monotonic_boolean_fields:
+                continue
+            new_value = proposed_item.get(field)
+            if old_value != new_value:
+                return (
+                    f"{path}[{key_field}={item_key!r}].{field} changed from "
+                    f"{old_value!r} to {new_value!r}."
+                )
+        return None
+
+    @staticmethod
+    def _validate_json_path(path: str, rule_name: str) -> None:
+        if not isinstance(path, str) or not path.startswith("$.") or ".." in path:
+            raise ValueError(
+                f"{rule_name} paths must use dot-style JSON paths starting with '$.'."
+            )
+
+    @staticmethod
+    def _get_path_value(state: Dict[str, Any], path: str) -> Any:
+        value: Any = state
+        for part in path[2:].split("."):
+            if not isinstance(value, dict) or part not in value:
+                raise ValueError(f"Configured path {path!r} was not found in state.")
+            value = value[part]
+        return value
 
     def _validate_object_value(
         self, schema: Dict[str, Any], value: Any, path: str, depth: int

--- a/src/qwed_new/guards/agent_state_guard.py
+++ b/src/qwed_new/guards/agent_state_guard.py
@@ -1,0 +1,34 @@
+"""
+AgentStateGuard
+
+Phase 1 focuses only on structural verification:
+- strict JSON parsing
+- strict schema validation
+- fail-closed decision objects
+
+No state transition proof or commit side effects are introduced here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class AgentStateGuard:
+    """
+    Deterministically verifies proposed agent state payloads before any commit.
+
+    Phase 1 validates structure only. Semantic transition proof and execution
+    policy belong to later phases.
+    """
+
+    def __init__(self, required_schema: Dict[str, Any]) -> None:
+        self.required_schema = required_schema
+
+    def verify_state_payload(self, proposed_state_json: str) -> Dict[str, Any]:
+        """
+        Verify a proposed state payload against the configured strict schema.
+
+        Returns a strict verified/non-verified decision object.
+        """
+        raise NotImplementedError("AgentStateGuard Phase 1 implementation pending")

--- a/src/qwed_new/guards/agent_state_guard.py
+++ b/src/qwed_new/guards/agent_state_guard.py
@@ -1,18 +1,21 @@
 """
 AgentStateGuard
 
-Phase 1 focuses only on structural verification:
+Phase 1 focuses on structural verification and Phase 2 adds bounded semantic
+transition validation:
 - strict JSON parsing
 - strict schema validation
+- deterministic transition checks
 - fail-closed decision objects
 
-No state transition proof or commit side effects are introduced here.
+No commit side effects are introduced here.
 """
 
 from __future__ import annotations
 
 import json
 from decimal import Decimal
+from types import MappingProxyType
 from typing import Any, Dict, Iterable
 
 
@@ -20,8 +23,8 @@ class AgentStateGuard:
     """
     Deterministically verifies proposed agent state payloads before any commit.
 
-    Phase 1 validates structure only. Semantic transition proof and execution
-    policy belong to later phases.
+    Phase 1 validates structure and Phase 2 adds bounded semantic transition
+    proof. Execution policy still belongs to a later phase.
     """
 
     _VALID_SCHEMA_TYPES = frozenset(
@@ -42,10 +45,14 @@ class AgentStateGuard:
         required_schema: Dict[str, Any],
         transition_rules: Dict[str, Any] | None = None,
     ) -> None:
-        self.required_schema = self._validate_schema_definition(required_schema, "$")
-        self._transition_rules_configured = bool(transition_rules)
-        self.transition_rules = self._validate_transition_rules_definition(
+        validated_schema = self._validate_schema_definition(required_schema, "$")
+        validated_transition_rules = self._validate_transition_rules_definition(
             transition_rules or {}
+        )
+        self.required_schema = self._freeze_config(validated_schema)
+        self.transition_rules = self._freeze_config(validated_transition_rules)
+        self._transition_rules_configured = self._has_effective_transition_rules(
+            self.transition_rules
         )
 
     def verify_state_payload(self, proposed_state_json: str) -> Dict[str, Any]:
@@ -118,10 +125,19 @@ class AgentStateGuard:
         if not proposed_result["verified"]:
             return proposed_result
 
-        transition_error = self._validate_transition_rules(
-            current_state=current_result["normalized_state"],
-            proposed_state=proposed_result["normalized_state"],
-        )
+        try:
+            transition_error = self._validate_transition_rules(
+                current_state=current_result["normalized_state"],
+                proposed_state=proposed_result["normalized_state"],
+            )
+        except Exception as exc:
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-106",
+                message=(
+                    "Blocked: transition-rule evaluation failed deterministically. "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+            )
         if transition_error is not None:
             return self._blocked(
                 error_code="QWED-AGENT-STATE-106",
@@ -147,6 +163,19 @@ class AgentStateGuard:
             # Preserve deterministic numeric semantics for Phase 1 validation.
             parse_float=Decimal,
         )
+
+    @classmethod
+    def _freeze_config(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            frozen = {key: cls._freeze_config(item) for key, item in value.items()}
+            return MappingProxyType(frozen)
+        if isinstance(value, list):
+            return tuple(cls._freeze_config(item) for item in value)
+        return value
+
+    @staticmethod
+    def _has_effective_transition_rules(transition_rules: Any) -> bool:
+        return any(bool(value) for value in transition_rules.values())
 
     def _validate_schema_definition(
         self, schema: Dict[str, Any], path: str
@@ -260,6 +289,14 @@ class AgentStateGuard:
             if not isinstance(rule, dict):
                 raise ValueError(
                     f"keyed_object_array_paths[{path!r}] must be a dictionary."
+                )
+            unknown_rule_keys = sorted(
+                set(rule) - {"key", "monotonic_boolean_fields", "allow_new_items"}
+            )
+            if unknown_rule_keys:
+                raise ValueError(
+                    f"keyed_object_array_paths[{path!r}] contains unsupported keys: "
+                    f"{unknown_rule_keys}."
                 )
 
             key = rule.get("key")

--- a/src/qwed_new/guards/agent_state_guard.py
+++ b/src/qwed_new/guards/agent_state_guard.py
@@ -1,20 +1,23 @@
 """
 AgentStateGuard
 
-Phase 1 focuses on structural verification and Phase 2 adds bounded semantic
-transition validation:
+Phase 1 focuses on structural verification, Phase 2 adds bounded semantic
+transition validation, and Phase 3 adds governed atomic commit:
 - strict JSON parsing
 - strict schema validation
 - deterministic transition checks
 - fail-closed decision objects
 
-No commit side effects are introduced here.
+No side effects occur before verification completes.
 """
 
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from decimal import Decimal
+from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Dict, Iterable
 
@@ -23,8 +26,8 @@ class AgentStateGuard:
     """
     Deterministically verifies proposed agent state payloads before any commit.
 
-    Phase 1 validates structure and Phase 2 adds bounded semantic transition
-    proof. Execution policy still belongs to a later phase.
+    Phase 1 validates structure, Phase 2 adds bounded semantic transition
+    proof, and Phase 3 adds governed atomic commit.
     """
 
     _VALID_SCHEMA_TYPES = frozenset(
@@ -44,6 +47,7 @@ class AgentStateGuard:
         self,
         required_schema: Dict[str, Any],
         transition_rules: Dict[str, Any] | None = None,
+        allowed_commit_roots: list[str] | tuple[str, ...] | None = None,
     ) -> None:
         validated_schema = self._validate_schema_definition(required_schema, "$")
         validated_transition_rules = self._validate_transition_rules_definition(
@@ -53,6 +57,9 @@ class AgentStateGuard:
         self.transition_rules = self._freeze_config(validated_transition_rules)
         self._transition_rules_configured = self._has_effective_transition_rules(
             self.transition_rules
+        )
+        self.allowed_commit_roots = self._validate_allowed_commit_roots(
+            allowed_commit_roots or []
         )
 
     def verify_state_payload(self, proposed_state_json: str) -> Dict[str, Any]:
@@ -155,6 +162,54 @@ class AgentStateGuard:
             "normalized_state": proposed_result["normalized_state"],
         }
 
+    def verify_transition_and_commit_state(
+        self,
+        current_state_json: str,
+        proposed_state_json: str,
+        target_path: str,
+    ) -> Dict[str, Any]:
+        """
+        Verify a transition and atomically commit the normalized state only after
+        verification succeeds.
+        """
+        commit_target = self._validate_commit_target(target_path)
+        if isinstance(commit_target, dict):
+            return commit_target
+
+        verification_result = self.verify_state_transition(
+            current_state_json=current_state_json,
+            proposed_state_json=proposed_state_json,
+        )
+        if not verification_result["verified"]:
+            return verification_result
+
+        try:
+            committed_bytes = self._atomic_write_json(
+                verification_result["normalized_state"],
+                commit_target,
+            )
+        except OSError as exc:
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-108",
+                message=(
+                    "Blocked: atomic state commit failed deterministically. "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+            )
+
+        return {
+            "verified": True,
+            "status": "VERIFIED",
+            "proof": (
+                "State transition satisfied structural and semantic rules and was "
+                "atomically committed."
+            ),
+            "normalized_previous_state": verification_result["normalized_previous_state"],
+            "normalized_state": verification_result["normalized_state"],
+            "committed_path": str(commit_target),
+            "committed_bytes": committed_bytes,
+        }
+
     def _load_strict_json(self, proposed_state_json: str) -> Any:
         return json.loads(
             proposed_state_json,
@@ -176,6 +231,78 @@ class AgentStateGuard:
     @staticmethod
     def _has_effective_transition_rules(transition_rules: Any) -> bool:
         return any(bool(value) for value in transition_rules.values())
+
+    @staticmethod
+    def _validate_allowed_commit_roots(
+        allowed_commit_roots: list[str] | tuple[str, ...]
+    ) -> tuple[Path, ...]:
+        if not isinstance(allowed_commit_roots, (list, tuple)):
+            raise ValueError("allowed_commit_roots must be a list or tuple of paths.")
+
+        validated_roots: list[Path] = []
+        for root in allowed_commit_roots:
+            if not isinstance(root, str) or not root.strip():
+                raise ValueError(
+                    "allowed_commit_roots entries must be non-empty absolute paths."
+                )
+            resolved_root = Path(root).resolve(strict=False)
+            if not resolved_root.is_absolute():
+                raise ValueError(
+                    "allowed_commit_roots entries must be absolute paths."
+                )
+            validated_roots.append(resolved_root)
+        return tuple(validated_roots)
+
+    def _validate_commit_target(self, target_path: str) -> Path | Dict[str, Any]:
+        if not self.allowed_commit_roots:
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-107",
+                message=(
+                    "Blocked: atomic state commit requires configured allowed "
+                    "commit roots."
+                ),
+            )
+
+        if not isinstance(target_path, str) or not target_path.strip():
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-107",
+                message="Blocked: target_path must be a non-empty absolute path.",
+            )
+
+        candidate = Path(target_path)
+        if not candidate.is_absolute():
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-107",
+                message="Blocked: target_path must be an absolute path.",
+            )
+
+        resolved_target = candidate.resolve(strict=False)
+        parent = resolved_target.parent
+        if not parent.exists() or not parent.is_dir():
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-107",
+                message=(
+                    "Blocked: target_path parent directory must already exist for "
+                    "atomic commit."
+                ),
+            )
+
+        if resolved_target.suffix.lower() != ".json":
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-107",
+                message="Blocked: target_path must end with .json for state commits.",
+            )
+
+        if not any(
+            self._is_path_within_root(resolved_target, allowed_root)
+            for allowed_root in self.allowed_commit_roots
+        ):
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-107",
+                message="Blocked: target_path is outside the configured commit roots.",
+            )
+
+        return resolved_target
 
     def _validate_schema_definition(
         self, schema: Dict[str, Any], path: str
@@ -561,6 +688,14 @@ class AgentStateGuard:
             )
 
     @staticmethod
+    def _is_path_within_root(candidate: Path, root: Path) -> bool:
+        try:
+            candidate.relative_to(root)
+            return True
+        except ValueError:
+            return False
+
+    @staticmethod
     def _get_path_value(state: Dict[str, Any], path: str) -> Any:
         value: Any = state
         for part in path[2:].split("."):
@@ -568,6 +703,50 @@ class AgentStateGuard:
                 raise ValueError(f"Configured path {path!r} was not found in state.")
             value = value[part]
         return value
+
+    @classmethod
+    def _serialize_json_deterministically(cls, value: Any) -> str:
+        if isinstance(value, MappingProxyType):
+            value = dict(value)
+        if isinstance(value, dict):
+            items = []
+            for key in sorted(value):
+                items.append(
+                    f"{json.dumps(key)}:{cls._serialize_json_deterministically(value[key])}"
+                )
+            return "{" + ",".join(items) + "}"
+        if isinstance(value, (list, tuple)):
+            return "[" + ",".join(cls._serialize_json_deterministically(item) for item in value) + "]"
+        if isinstance(value, Decimal):
+            return str(value)
+        return json.dumps(value, separators=(",", ":"))
+
+    def _atomic_write_json(self, normalized_state: Dict[str, Any], target_path: Path) -> int:
+        payload = self._serialize_json_deterministically(normalized_state).encode("utf-8")
+        temp_file_path: str | None = None
+
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                delete=False,
+                dir=target_path.parent,
+                prefix=f"{target_path.stem}.",
+                suffix=".tmp",
+            ) as temp_file:
+                temp_file_path = temp_file.name
+                temp_file.write(payload)
+                temp_file.flush()
+                os.fsync(temp_file.fileno())
+
+            os.replace(temp_file_path, target_path)
+            temp_file_path = None
+            return len(payload)
+        finally:
+            if temp_file_path is not None:
+                try:
+                    os.unlink(temp_file_path)
+                except FileNotFoundError:
+                    pass
 
     def _validate_object_value(
         self, schema: Dict[str, Any], value: Any, path: str, depth: int

--- a/src/qwed_new/guards/agent_state_guard.py
+++ b/src/qwed_new/guards/agent_state_guard.py
@@ -11,7 +11,9 @@ No state transition proof or commit side effects are introduced here.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import json
+import math
+from typing import Any, Dict, Iterable
 
 
 class AgentStateGuard:
@@ -22,8 +24,12 @@ class AgentStateGuard:
     policy belong to later phases.
     """
 
+    _VALID_SCHEMA_TYPES = frozenset(
+        {"object", "array", "string", "integer", "number", "boolean", "null"}
+    )
+
     def __init__(self, required_schema: Dict[str, Any]) -> None:
-        self.required_schema = required_schema
+        self.required_schema = self._validate_schema_definition(required_schema, "$")
 
     def verify_state_payload(self, proposed_state_json: str) -> Dict[str, Any]:
         """
@@ -31,4 +37,197 @@ class AgentStateGuard:
 
         Returns a strict verified/non-verified decision object.
         """
-        raise NotImplementedError("AgentStateGuard Phase 1 implementation pending")
+        if not isinstance(proposed_state_json, str) or not proposed_state_json.strip():
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-101",
+                message="Blocked: proposed agent state must be a non-empty JSON string.",
+            )
+
+        try:
+            state_data = self._load_strict_json(proposed_state_json)
+        except ValueError as exc:
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-102",
+                message=f"Blocked: invalid or non-deterministic JSON state payload. {exc}",
+            )
+
+        validation_error = self._validate_value(
+            schema=self.required_schema,
+            value=state_data,
+            path="$",
+        )
+        if validation_error is not None:
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-103",
+                message=f"Blocked: {validation_error}",
+            )
+
+        return {
+            "verified": True,
+            "status": "VERIFIED",
+            "proof": "State payload matched the configured strict schema.",
+            "normalized_state": self._canonicalize(state_data),
+        }
+
+    def _load_strict_json(self, proposed_state_json: str) -> Any:
+        return json.loads(
+            proposed_state_json,
+            object_pairs_hook=self._reject_duplicate_keys,
+            parse_constant=self._reject_non_standard_constant,
+        )
+
+    def _validate_schema_definition(
+        self, schema: Dict[str, Any], path: str
+    ) -> Dict[str, Any]:
+        if not isinstance(schema, dict):
+            raise ValueError(f"Schema at {path} must be a dictionary.")
+
+        schema_type = schema.get("type")
+        if schema_type not in self._VALID_SCHEMA_TYPES:
+            raise ValueError(
+                f"Schema at {path} must declare a supported type, got {schema_type!r}."
+            )
+
+        if "enum" in schema:
+            enum_values = schema["enum"]
+            if not isinstance(enum_values, list) or not enum_values:
+                raise ValueError(f"Schema enum at {path} must be a non-empty list.")
+
+        if schema_type == "object":
+            properties = schema.get("properties")
+            if not isinstance(properties, dict):
+                raise ValueError(f"Object schema at {path} must define properties.")
+
+            required = schema.get("required", [])
+            if not isinstance(required, list) or any(
+                not isinstance(item, str) for item in required
+            ):
+                raise ValueError(f"Required keys at {path} must be a list of strings.")
+
+            unknown_required = sorted(set(required) - set(properties))
+            if unknown_required:
+                raise ValueError(
+                    f"Required keys at {path} are missing from properties: {unknown_required}."
+                )
+
+            additional_properties = schema.get("additionalProperties", False)
+            if not isinstance(additional_properties, bool):
+                raise ValueError(
+                    f"additionalProperties at {path} must be a boolean value."
+                )
+
+            for key, child_schema in properties.items():
+                if not isinstance(key, str) or not key:
+                    raise ValueError(f"Object property names at {path} must be non-empty strings.")
+                self._validate_schema_definition(child_schema, f"{path}.{key}")
+
+        elif schema_type == "array":
+            if "items" not in schema:
+                raise ValueError(f"Array schema at {path} must define an items schema.")
+            self._validate_schema_definition(schema["items"], f"{path}[]")
+
+        return schema
+
+    def _validate_value(self, schema: Dict[str, Any], value: Any, path: str) -> str | None:
+        schema_type = schema["type"]
+
+        if "enum" in schema and value not in schema["enum"]:
+            return f"{path} must be one of {schema['enum']!r}, got {value!r}."
+
+        if schema_type == "object":
+            if not isinstance(value, dict):
+                return f"{path} must be an object, got {type(value).__name__}."
+
+            properties = schema["properties"]
+            required = schema.get("required", [])
+
+            missing_keys = [key for key in required if key not in value]
+            if missing_keys:
+                return f"{path} is missing required keys: {missing_keys}."
+
+            additional_properties = schema.get("additionalProperties", False)
+            if not additional_properties:
+                extra_keys = sorted(set(value) - set(properties))
+                if extra_keys:
+                    return f"{path} contains unexpected keys: {extra_keys}."
+
+            for key, child_schema in properties.items():
+                if key in value:
+                    error = self._validate_value(child_schema, value[key], f"{path}.{key}")
+                    if error is not None:
+                        return error
+
+            return None
+
+        if schema_type == "array":
+            if not isinstance(value, list):
+                return f"{path} must be an array, got {type(value).__name__}."
+
+            item_schema = schema["items"]
+            for index, item in enumerate(value):
+                error = self._validate_value(item_schema, item, f"{path}[{index}]")
+                if error is not None:
+                    return error
+            return None
+
+        if schema_type == "string":
+            if not isinstance(value, str):
+                return f"{path} must be a string, got {type(value).__name__}."
+            return None
+
+        if schema_type == "integer":
+            if isinstance(value, bool) or not isinstance(value, int):
+                return f"{path} must be an integer, got {type(value).__name__}."
+            return None
+
+        if schema_type == "number":
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                return f"{path} must be a number, got {type(value).__name__}."
+            if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+                return f"{path} must be a finite number."
+            return None
+
+        if schema_type == "boolean":
+            if not isinstance(value, bool):
+                return f"{path} must be a boolean, got {type(value).__name__}."
+            return None
+
+        if schema_type == "null":
+            if value is not None:
+                return f"{path} must be null, got {type(value).__name__}."
+            return None
+
+        return f"{path} uses unsupported schema type {schema_type!r}."
+
+    @staticmethod
+    def _reject_duplicate_keys(pairs: Iterable[tuple[str, Any]]) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"Duplicate key {key!r} is not allowed.")
+            result[key] = value
+        return result
+
+    @staticmethod
+    def _reject_non_standard_constant(value: str) -> Any:
+        raise ValueError(f"Non-standard JSON constant {value!r} is not allowed.")
+
+    @classmethod
+    def _blocked(cls, error_code: str, message: str) -> Dict[str, Any]:
+        return {
+            "verified": False,
+            "status": "BLOCKED",
+            "error_code": error_code,
+            "message": message,
+        }
+
+    @classmethod
+    def _canonicalize(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: cls._canonicalize(value[key])
+                for key in sorted(value)
+            }
+        if isinstance(value, list):
+            return [cls._canonicalize(item) for item in value]
+        return value

--- a/src/qwed_new/guards/agent_state_guard.py
+++ b/src/qwed_new/guards/agent_state_guard.py
@@ -12,7 +12,7 @@ No state transition proof or commit side effects are introduced here.
 from __future__ import annotations
 
 import json
-import math
+from decimal import Decimal
 from typing import Any, Dict, Iterable
 
 
@@ -27,6 +27,7 @@ class AgentStateGuard:
     _VALID_SCHEMA_TYPES = frozenset(
         {"object", "array", "string", "integer", "number", "boolean", "null"}
     )
+    MAX_VALIDATION_DEPTH = 64
 
     def __init__(self, required_schema: Dict[str, Any]) -> None:
         self.required_schema = self._validate_schema_definition(required_schema, "$")
@@ -74,6 +75,8 @@ class AgentStateGuard:
             proposed_state_json,
             object_pairs_hook=self._reject_duplicate_keys,
             parse_constant=self._reject_non_standard_constant,
+            # Preserve deterministic numeric semantics for Phase 1 validation.
+            parse_float=Decimal,
         )
 
     def _validate_schema_definition(
@@ -82,122 +85,225 @@ class AgentStateGuard:
         if not isinstance(schema, dict):
             raise ValueError(f"Schema at {path} must be a dictionary.")
 
+        schema_type = self._validate_schema_type(schema, path)
+        self._validate_enum_definition(schema, path)
+        handler = self._SCHEMA_DEFINITION_VALIDATORS.get(schema_type)
+        if handler is not None:
+            handler(self, schema, path)
+
+        return schema
+
+    def _validate_value(
+        self,
+        schema: Dict[str, Any],
+        value: Any,
+        path: str,
+        depth: int = 0,
+    ) -> str | None:
+        if depth >= self.MAX_VALIDATION_DEPTH:
+            return (
+                f"{path} exceeds maximum validation depth "
+                f"({self.MAX_VALIDATION_DEPTH})."
+            )
+
+        enum_error = self._validate_enum_value(schema, value, path)
+        if enum_error is not None:
+            return enum_error
+
+        schema_type = schema["type"]
+        handler = self._VALUE_VALIDATORS.get(schema_type)
+        if handler is None:
+            return f"{path} uses unsupported schema type {schema_type!r}."
+        return handler(self, schema, value, path, depth)
+
+    def _validate_schema_type(self, schema: Dict[str, Any], path: str) -> str:
         schema_type = schema.get("type")
         if schema_type not in self._VALID_SCHEMA_TYPES:
             raise ValueError(
                 f"Schema at {path} must declare a supported type, got {schema_type!r}."
             )
+        return schema_type
 
-        if "enum" in schema:
-            enum_values = schema["enum"]
-            if not isinstance(enum_values, list) or not enum_values:
-                raise ValueError(f"Schema enum at {path} must be a non-empty list.")
+    @staticmethod
+    def _validate_enum_definition(schema: Dict[str, Any], path: str) -> None:
+        if "enum" not in schema:
+            return
+        enum_values = schema["enum"]
+        if not isinstance(enum_values, list) or not enum_values:
+            raise ValueError(f"Schema enum at {path} must be a non-empty list.")
 
-        if schema_type == "object":
-            properties = schema.get("properties")
-            if not isinstance(properties, dict):
-                raise ValueError(f"Object schema at {path} must define properties.")
+    def _validate_object_schema(self, schema: Dict[str, Any], path: str) -> None:
+        properties = schema.get("properties")
+        if not isinstance(properties, dict):
+            raise ValueError(f"Object schema at {path} must define properties.")
 
-            required = schema.get("required", [])
-            if not isinstance(required, list) or any(
-                not isinstance(item, str) for item in required
-            ):
-                raise ValueError(f"Required keys at {path} must be a list of strings.")
+        required = schema.get("required", [])
+        self._validate_required_keys(required, properties, path)
+        self._validate_additional_properties(schema.get("additionalProperties", False), path)
 
-            unknown_required = sorted(set(required) - set(properties))
-            if unknown_required:
-                raise ValueError(
-                    f"Required keys at {path} are missing from properties: {unknown_required}."
-                )
+        for key, child_schema in properties.items():
+            self._validate_property_name(key, path)
+            self._validate_schema_definition(child_schema, f"{path}.{key}")
 
-            additional_properties = schema.get("additionalProperties", False)
-            if not isinstance(additional_properties, bool):
-                raise ValueError(
-                    f"additionalProperties at {path} must be a boolean value."
-                )
+    def _validate_array_schema(self, schema: Dict[str, Any], path: str) -> None:
+        if "items" not in schema:
+            raise ValueError(f"Array schema at {path} must define an items schema.")
+        self._validate_schema_definition(schema["items"], f"{path}[]")
 
-            for key, child_schema in properties.items():
-                if not isinstance(key, str) or not key:
-                    raise ValueError(f"Object property names at {path} must be non-empty strings.")
-                self._validate_schema_definition(child_schema, f"{path}.{key}")
+    @staticmethod
+    def _validate_required_keys(
+        required: Any, properties: Dict[str, Any], path: str
+    ) -> None:
+        if not isinstance(required, list) or any(not isinstance(item, str) for item in required):
+            raise ValueError(f"Required keys at {path} must be a list of strings.")
 
-        elif schema_type == "array":
-            if "items" not in schema:
-                raise ValueError(f"Array schema at {path} must define an items schema.")
-            self._validate_schema_definition(schema["items"], f"{path}[]")
+        unknown_required = sorted(set(required) - set(properties))
+        if unknown_required:
+            raise ValueError(
+                f"Required keys at {path} are missing from properties: {unknown_required}."
+            )
 
-        return schema
+    @staticmethod
+    def _validate_additional_properties(additional_properties: Any, path: str) -> None:
+        if not isinstance(additional_properties, bool):
+            raise ValueError(f"additionalProperties at {path} must be a boolean value.")
 
-    def _validate_value(self, schema: Dict[str, Any], value: Any, path: str) -> str | None:
-        schema_type = schema["type"]
+    @staticmethod
+    def _validate_property_name(key: Any, path: str) -> None:
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"Object property names at {path} must be non-empty strings.")
 
+    @staticmethod
+    def _validate_enum_value(schema: Dict[str, Any], value: Any, path: str) -> str | None:
         if "enum" in schema and value not in schema["enum"]:
             return f"{path} must be one of {schema['enum']!r}, got {value!r}."
+        return None
 
-        if schema_type == "object":
-            if not isinstance(value, dict):
-                return f"{path} must be an object, got {type(value).__name__}."
+    def _validate_object_value(
+        self, schema: Dict[str, Any], value: Any, path: str, depth: int
+    ) -> str | None:
+        if not isinstance(value, dict):
+            return f"{path} must be an object, got {type(value).__name__}."
 
-            properties = schema["properties"]
-            required = schema.get("required", [])
+        properties = schema["properties"]
+        required = schema.get("required", [])
+        missing_keys = [key for key in required if key not in value]
+        if missing_keys:
+            return f"{path} is missing required keys: {missing_keys}."
 
-            missing_keys = [key for key in required if key not in value]
-            if missing_keys:
-                return f"{path} is missing required keys: {missing_keys}."
+        extra_key_error = self._validate_extra_keys(
+            value=value,
+            properties=properties,
+            additional_properties=schema.get("additionalProperties", False),
+            path=path,
+        )
+        if extra_key_error is not None:
+            return extra_key_error
 
-            additional_properties = schema.get("additionalProperties", False)
-            if not additional_properties:
-                extra_keys = sorted(set(value) - set(properties))
-                if extra_keys:
-                    return f"{path} contains unexpected keys: {extra_keys}."
+        for key, child_schema in properties.items():
+            if key not in value:
+                continue
+            error = self._validate_value(
+                child_schema,
+                value[key],
+                f"{path}.{key}",
+                depth + 1,
+            )
+            if error is not None:
+                return error
 
-            for key, child_schema in properties.items():
-                if key in value:
-                    error = self._validate_value(child_schema, value[key], f"{path}.{key}")
-                    if error is not None:
-                        return error
+        return None
 
+    def _validate_array_value(
+        self, schema: Dict[str, Any], value: Any, path: str, depth: int
+    ) -> str | None:
+        if not isinstance(value, list):
+            return f"{path} must be an array, got {type(value).__name__}."
+
+        item_schema = schema["items"]
+        for index, item in enumerate(value):
+            error = self._validate_value(
+                item_schema,
+                item,
+                f"{path}[{index}]",
+                depth + 1,
+            )
+            if error is not None:
+                return error
+        return None
+
+    @staticmethod
+    def _validate_extra_keys(
+        value: Dict[str, Any],
+        properties: Dict[str, Any],
+        additional_properties: bool,
+        path: str,
+    ) -> str | None:
+        if additional_properties:
             return None
+        extra_keys = sorted(set(value) - set(properties))
+        if extra_keys:
+            return f"{path} contains unexpected keys: {extra_keys}."
+        return None
 
-        if schema_type == "array":
-            if not isinstance(value, list):
-                return f"{path} must be an array, got {type(value).__name__}."
+    def _validate_string_value(
+        self, schema: Dict[str, Any], value: Any, path: str, depth: int
+    ) -> str | None:
+        del self
+        del schema
+        del depth
+        if not isinstance(value, str):
+            return f"{path} must be a string, got {type(value).__name__}."
+        return None
 
-            item_schema = schema["items"]
-            for index, item in enumerate(value):
-                error = self._validate_value(item_schema, item, f"{path}[{index}]")
-                if error is not None:
-                    return error
+    def _validate_integer_value(
+        self, schema: Dict[str, Any], value: Any, path: str, depth: int
+    ) -> str | None:
+        del self
+        del schema
+        del depth
+        if isinstance(value, bool) or not isinstance(value, int):
+            return f"{path} must be an integer, got {type(value).__name__}."
+        return None
+
+    def _validate_number_value(
+        self, schema: Dict[str, Any], value: Any, path: str, depth: int
+    ) -> str | None:
+        del self
+        del schema
+        del depth
+        if isinstance(value, bool):
+            return f"{path} must be a number, got {type(value).__name__}."
+        if isinstance(value, Decimal):
             return None
+        if isinstance(value, float):
+            return (
+                f"{path} must use deterministic JSON numbers. "
+                "Provide decimals in JSON so they parse as Decimal."
+            )
+        if not isinstance(value, int):
+            return f"{path} must be a number, got {type(value).__name__}."
+        return None
 
-        if schema_type == "string":
-            if not isinstance(value, str):
-                return f"{path} must be a string, got {type(value).__name__}."
-            return None
+    def _validate_boolean_value(
+        self, schema: Dict[str, Any], value: Any, path: str, depth: int
+    ) -> str | None:
+        del self
+        del schema
+        del depth
+        if not isinstance(value, bool):
+            return f"{path} must be a boolean, got {type(value).__name__}."
+        return None
 
-        if schema_type == "integer":
-            if isinstance(value, bool) or not isinstance(value, int):
-                return f"{path} must be an integer, got {type(value).__name__}."
-            return None
-
-        if schema_type == "number":
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                return f"{path} must be a number, got {type(value).__name__}."
-            if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
-                return f"{path} must be a finite number."
-            return None
-
-        if schema_type == "boolean":
-            if not isinstance(value, bool):
-                return f"{path} must be a boolean, got {type(value).__name__}."
-            return None
-
-        if schema_type == "null":
-            if value is not None:
-                return f"{path} must be null, got {type(value).__name__}."
-            return None
-
-        return f"{path} uses unsupported schema type {schema_type!r}."
+    def _validate_null_value(
+        self, schema: Dict[str, Any], value: Any, path: str, depth: int
+    ) -> str | None:
+        del self
+        del schema
+        del depth
+        if value is not None:
+            return f"{path} must be null, got {type(value).__name__}."
+        return None
 
     @staticmethod
     def _reject_duplicate_keys(pairs: Iterable[tuple[str, Any]]) -> Dict[str, Any]:
@@ -214,6 +320,9 @@ class AgentStateGuard:
 
     @classmethod
     def _blocked(cls, error_code: str, message: str) -> Dict[str, Any]:
+        # Error-code allocation:
+        # - QWED-AGENT-STATE-001..099 are reserved for shared state/input guards
+        # - QWED-AGENT-STATE-100..199 are reserved for AgentStateGuard failures
         return {
             "verified": False,
             "status": "BLOCKED",
@@ -231,3 +340,19 @@ class AgentStateGuard:
         if isinstance(value, list):
             return [cls._canonicalize(item) for item in value]
         return value
+
+
+AgentStateGuard._SCHEMA_DEFINITION_VALIDATORS = {
+    "object": AgentStateGuard._validate_object_schema,
+    "array": AgentStateGuard._validate_array_schema,
+}
+
+AgentStateGuard._VALUE_VALIDATORS = {
+    "object": AgentStateGuard._validate_object_value,
+    "array": AgentStateGuard._validate_array_value,
+    "string": AgentStateGuard._validate_string_value,
+    "integer": AgentStateGuard._validate_integer_value,
+    "number": AgentStateGuard._validate_number_value,
+    "boolean": AgentStateGuard._validate_boolean_value,
+    "null": AgentStateGuard._validate_null_value,
+}

--- a/src/qwed_new/guards/doom_loop_guard.py
+++ b/src/qwed_new/guards/doom_loop_guard.py
@@ -7,7 +7,7 @@ each action to the *world state* at the time it was proposed.  If the agent
 takes the exact same action on the exact same unchanged state multiple times,
 it is stuck — even if step numbers are advancing normally.
 
-Design principles (from ChatGPT / NotebookLM architecture review):
+Design principles:
 - Additive to existing guards (LOOP-001/002/003), never replaces them
 - SHA-256 fingerprints (not MD5)
 - State hash source must be explicitly declared by the caller
@@ -28,6 +28,10 @@ class ProgressAwareDoomLoopGuard:
     when an agent is repeating actions without changing the underlying
     system state (Adaptive Control Error / no-progress doom loop).
     """
+
+    # Error-code allocation:
+    # - QWED-AGENT-STATE-001..099 are reserved for shared state/input guards
+    # - QWED-AGENT-LOOP-* remains specific to loop-detection outcomes
 
     VALID_STATE_SOURCES = frozenset(
         {"file_tree", "db_snapshot", "conversation_digest", "git_tree", "custom"}

--- a/tests/test_agent_state_guard.py
+++ b/tests/test_agent_state_guard.py
@@ -1,0 +1,179 @@
+import pytest
+
+from qwed_new.guards.agent_state_guard import AgentStateGuard
+
+
+STRICT_AGENT_STATE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "agent_id": {"type": "string"},
+        "status": {"type": "string", "enum": ["pending", "running", "completed"]},
+        "step_count": {"type": "integer"},
+        "tasks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "done": {"type": "boolean"},
+                },
+                "required": ["id", "done"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["agent_id", "status", "step_count", "tasks"],
+    "additionalProperties": False,
+}
+
+
+def _build_guard() -> AgentStateGuard:
+    return AgentStateGuard(STRICT_AGENT_STATE_SCHEMA)
+
+
+def test_rejects_empty_payload():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload("")
+
+    assert result["verified"] is False
+    assert result["status"] == "BLOCKED"
+    assert result["error_code"] == "QWED-AGENT-STATE-101"
+
+
+def test_rejects_invalid_json():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload('{"agent_id": "a1",')
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-102"
+
+
+def test_rejects_duplicate_keys():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(
+        """
+        {
+          "agent_id": "a1",
+          "agent_id": "shadow",
+          "status": "pending",
+          "step_count": 1,
+          "tasks": []
+        }
+        """
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-102"
+    assert "Duplicate key" in result["message"]
+
+
+def test_rejects_non_standard_json_constants():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(
+        """
+        {
+          "agent_id": "a1",
+          "status": "pending",
+          "step_count": NaN,
+          "tasks": []
+        }
+        """
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-102"
+    assert "Non-standard JSON constant" in result["message"]
+
+
+def test_rejects_missing_required_keys():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(
+        """
+        {
+          "agent_id": "a1",
+          "status": "pending",
+          "tasks": []
+        }
+        """
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-103"
+    assert "missing required keys" in result["message"]
+
+
+def test_rejects_unexpected_keys():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(
+        """
+        {
+          "agent_id": "a1",
+          "status": "pending",
+          "step_count": 1,
+          "tasks": [],
+          "claimed_done": true
+        }
+        """
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-103"
+    assert "unexpected keys" in result["message"]
+
+
+def test_rejects_wrong_types_in_nested_payload():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(
+        """
+        {
+          "agent_id": "a1",
+          "status": "pending",
+          "step_count": 1,
+          "tasks": [
+            {"id": "task-1", "done": "yes"}
+          ]
+        }
+        """
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-103"
+    assert "$.tasks[0].done must be a boolean" in result["message"]
+
+
+def test_accepts_structurally_valid_payload_and_normalizes_order():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(
+        """
+        {
+          "tasks": [
+            {"done": false, "id": "task-1"}
+          ],
+          "step_count": 1,
+          "status": "pending",
+          "agent_id": "a1"
+        }
+        """
+    )
+
+    assert result["verified"] is True
+    assert result["status"] == "VERIFIED"
+    assert result["normalized_state"] == {
+        "agent_id": "a1",
+        "status": "pending",
+        "step_count": 1,
+        "tasks": [{"done": False, "id": "task-1"}],
+    }
+
+
+def test_invalid_schema_definition_fails_fast():
+    with pytest.raises(ValueError, match="must declare a supported type"):
+        AgentStateGuard({"properties": {}})

--- a/tests/test_agent_state_guard.py
+++ b/tests/test_agent_state_guard.py
@@ -28,9 +28,31 @@ STRICT_AGENT_STATE_SCHEMA = {
     "additionalProperties": False,
 }
 
+STRICT_AGENT_TRANSITION_RULES = {
+    "immutable_paths": ["$.agent_id"],
+    "monotonic_integer_paths": ["$.step_count"],
+    "ordered_enum_paths": {
+        "$.status": ["pending", "running", "completed"],
+    },
+    "keyed_object_array_paths": {
+        "$.tasks": {
+            "key": "id",
+            "monotonic_boolean_fields": ["done"],
+            "allow_new_items": True,
+        }
+    },
+}
+
 
 def _build_guard() -> AgentStateGuard:
     return AgentStateGuard(STRICT_AGENT_STATE_SCHEMA)
+
+
+def _build_transition_guard() -> AgentStateGuard:
+    return AgentStateGuard(
+        STRICT_AGENT_STATE_SCHEMA,
+        transition_rules=STRICT_AGENT_TRANSITION_RULES,
+    )
 
 
 def test_rejects_empty_payload():
@@ -185,6 +207,401 @@ def test_accepts_structurally_valid_payload_and_normalizes_order():
         "step_count": 1,
         "tasks": [{"done": False, "id": "task-1"}],
     }
+
+
+def test_transition_requires_configured_rules():
+    guard = _build_guard()
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-104"
+
+
+def test_accepts_valid_monotonic_state_transition():
+    guard = _build_transition_guard()
+
+    result = guard.verify_state_transition(
+        """
+        {
+          "agent_id": "a1",
+          "status": "pending",
+          "step_count": 1,
+          "tasks": [{"id": "task-1", "done": false}]
+        }
+        """,
+        """
+        {
+          "agent_id": "a1",
+          "status": "running",
+          "step_count": 2,
+          "tasks": [
+            {"id": "task-1", "done": true},
+            {"id": "task-2", "done": false}
+          ]
+        }
+        """,
+    )
+
+    assert result["verified"] is True
+    assert result["status"] == "VERIFIED"
+    assert result["normalized_previous_state"]["status"] == "pending"
+    assert result["normalized_state"]["status"] == "running"
+
+
+def test_rejects_invalid_current_state_during_transition():
+    guard = _build_transition_guard()
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "pending"}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-105"
+    assert "current agent state failed structural verification" in result["message"]
+
+
+def test_rejects_immutable_field_transition_change():
+    guard = _build_transition_guard()
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a2", "status": "running", "step_count": 2, "tasks": []}',
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-106"
+    assert "$.agent_id is immutable" in result["message"]
+
+
+def test_rejects_monotonic_counter_regression():
+    guard = _build_transition_guard()
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "running", "step_count": 3, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+    )
+
+    assert result["verified"] is False
+    assert "$.step_count regressed" in result["message"]
+
+
+def test_rejects_ordered_status_regression():
+    guard = _build_transition_guard()
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "completed", "step_count": 3, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 4, "tasks": []}',
+    )
+
+    assert result["verified"] is False
+    assert "$.status regressed" in result["message"]
+
+
+def test_rejects_task_reopen_transition():
+    guard = _build_transition_guard()
+
+    result = guard.verify_state_transition(
+        """
+        {
+          "agent_id": "a1",
+          "status": "running",
+          "step_count": 2,
+          "tasks": [{"id": "task-1", "done": true}]
+        }
+        """,
+        """
+        {
+          "agent_id": "a1",
+          "status": "running",
+          "step_count": 3,
+          "tasks": [{"id": "task-1", "done": false}]
+        }
+        """,
+    )
+
+    assert result["verified"] is False
+    assert "regressed from True to False" in result["message"]
+
+
+def test_rejects_task_deletion_or_reordering():
+    guard = _build_transition_guard()
+
+    result = guard.verify_state_transition(
+        """
+        {
+          "agent_id": "a1",
+          "status": "running",
+          "step_count": 2,
+          "tasks": [
+            {"id": "task-1", "done": false},
+            {"id": "task-2", "done": false}
+          ]
+        }
+        """,
+        """
+        {
+          "agent_id": "a1",
+          "status": "running",
+          "step_count": 3,
+          "tasks": [
+            {"id": "task-2", "done": false},
+            {"id": "task-1", "done": true}
+          ]
+        }
+        """,
+    )
+
+    assert result["verified"] is False
+    assert "must preserve existing item order and prevent deletion" in result["message"]
+
+
+def test_returns_structural_failure_for_invalid_proposed_state_in_transition():
+    guard = _build_transition_guard()
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a1", "status": "running"}',
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-103"
+
+
+def test_rejects_transition_rules_that_are_not_dicts():
+    with pytest.raises(ValueError, match="Transition rules must be a dictionary"):
+        AgentStateGuard(STRICT_AGENT_STATE_SCHEMA, transition_rules=["nope"])
+
+
+def test_rejects_transition_rules_with_unknown_keys():
+    with pytest.raises(ValueError, match="unsupported keys"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={"unknown_rule": []},
+        )
+
+
+def test_rejects_invalid_path_list_rule():
+    with pytest.raises(ValueError, match="must be a list of JSON-style path strings"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={"immutable_paths": "$.agent_id"},
+        )
+
+
+def test_rejects_invalid_json_path_rule():
+    with pytest.raises(ValueError, match="paths must use dot-style JSON paths"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={"immutable_paths": ["agent_id"]},
+        )
+
+
+def test_rejects_invalid_ordered_enum_rule():
+    with pytest.raises(ValueError, match="must define at least two ordered values"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={"ordered_enum_paths": {"$.status": ["pending"]}},
+        )
+
+
+def test_rejects_non_dict_ordered_enum_rules():
+    with pytest.raises(ValueError, match="ordered_enum_paths must be a dictionary"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={"ordered_enum_paths": ["$.status"]},
+        )
+
+
+def test_rejects_invalid_keyed_object_array_rule():
+    with pytest.raises(ValueError, match="must define a non-empty key field"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={"keyed_object_array_paths": {"$.tasks": {}}},
+        )
+
+
+def test_rejects_non_dict_keyed_object_array_rules():
+    with pytest.raises(ValueError, match="keyed_object_array_paths must be a dictionary"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={"keyed_object_array_paths": ["$.tasks"]},
+        )
+
+
+def test_rejects_non_dict_single_keyed_object_array_rule():
+    with pytest.raises(ValueError, match="must be a dictionary"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={"keyed_object_array_paths": {"$.tasks": "bad"}},
+        )
+
+
+def test_rejects_invalid_monotonic_boolean_fields_rule():
+    with pytest.raises(ValueError, match="must be a list of field names"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={
+                "keyed_object_array_paths": {
+                    "$.tasks": {"key": "id", "monotonic_boolean_fields": "done"}
+                }
+            },
+        )
+
+
+def test_rejects_non_boolean_allow_new_items_rule():
+    with pytest.raises(ValueError, match="allow_new_items must be a boolean"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={
+                "keyed_object_array_paths": {
+                    "$.tasks": {"key": "id", "allow_new_items": "yes"}
+                }
+            },
+        )
+
+
+def test_rejects_keyed_object_array_duplicate_ids():
+    guard = _build_transition_guard()
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "running", "step_count": 1, "tasks": []}',
+        """
+        {
+          "agent_id": "a1",
+          "status": "running",
+          "step_count": 2,
+          "tasks": [
+            {"id": "task-1", "done": false},
+            {"id": "task-1", "done": false}
+          ]
+        }
+        """,
+    )
+
+    assert result["verified"] is False
+    assert "contains duplicate 'id' values" in result["message"]
+
+
+def test_rejects_keyed_object_array_missing_key_field():
+    guard = _build_transition_guard()
+
+    error = guard._validate_keyed_object_array_transition(
+        path="$.tasks",
+        current_items=[],
+        proposed_items=[{"done": False}],
+        rule={"key": "id", "monotonic_boolean_fields": ["done"], "allow_new_items": True},
+    )
+
+    assert error == "$.tasks[0] is missing key field 'id'."
+
+
+def test_rejects_keyed_object_array_non_object_items():
+    guard = _build_transition_guard()
+
+    current_state = {"tasks": []}
+    proposed_state = {"tasks": ["bad-item"]}
+    rule = {"key": "id", "monotonic_boolean_fields": ["done"], "allow_new_items": True}
+
+    error = guard._validate_keyed_object_array_transition(
+        path="$.tasks",
+        current_items=current_state["tasks"],
+        proposed_items=proposed_state["tasks"],
+        rule=rule,
+    )
+
+    assert error == "$.tasks[0] must be an object."
+
+
+def test_rejects_keyed_object_array_non_array_values():
+    guard = _build_transition_guard()
+
+    error = guard._validate_keyed_object_array_transition(
+        path="$.tasks",
+        current_items={},
+        proposed_items=[],
+        rule={"key": "id", "monotonic_boolean_fields": ["done"], "allow_new_items": True},
+    )
+
+    assert error == "$.tasks must resolve to arrays in both current and proposed state."
+
+
+def test_rejects_keyed_object_array_invalid_current_items():
+    guard = _build_transition_guard()
+
+    error = guard._validate_keyed_object_array_transition(
+        path="$.tasks",
+        current_items=[{"done": False}],
+        proposed_items=[],
+        rule={"key": "id", "monotonic_boolean_fields": ["done"], "allow_new_items": True},
+    )
+
+    assert error == "$.tasks[0] is missing key field 'id'."
+
+
+def test_rejects_new_items_when_append_is_disabled():
+    guard = AgentStateGuard(
+        STRICT_AGENT_STATE_SCHEMA,
+        transition_rules={
+            **STRICT_AGENT_TRANSITION_RULES,
+            "keyed_object_array_paths": {
+                "$.tasks": {
+                    "key": "id",
+                    "monotonic_boolean_fields": ["done"],
+                    "allow_new_items": False,
+                }
+            },
+        },
+    )
+
+    result = guard.verify_state_transition(
+        """
+        {
+          "agent_id": "a1",
+          "status": "running",
+          "step_count": 1,
+          "tasks": [{"id": "task-1", "done": false}]
+        }
+        """,
+        """
+        {
+          "agent_id": "a1",
+          "status": "running",
+          "step_count": 2,
+          "tasks": [
+            {"id": "task-1", "done": true},
+            {"id": "task-2", "done": false}
+          ]
+        }
+        """,
+    )
+
+    assert result["verified"] is False
+    assert "does not allow appending new items" in result["message"]
+
+
+def test_rejects_changes_to_existing_task_fields_outside_monotonic_bool():
+    guard = _build_transition_guard()
+
+    error = guard._validate_keyed_object_item_transition(
+        path="$.tasks",
+        key_field="id",
+        item_key="task-1",
+        current_item={"id": "task-1", "done": False, "label": "old"},
+        proposed_item={"id": "task-1", "done": True, "label": "new"},
+        monotonic_boolean_fields=["done"],
+    )
+
+    assert error == "$.tasks[id='task-1'].label changed from 'old' to 'new'."
+
+
+def test_get_path_value_rejects_missing_paths():
+    with pytest.raises(ValueError, match="was not found in state"):
+        AgentStateGuard._get_path_value({"agent_id": "a1"}, "$.status")
 
 
 def test_invalid_schema_definition_fails_fast():

--- a/tests/test_agent_state_guard.py
+++ b/tests/test_agent_state_guard.py
@@ -55,6 +55,14 @@ def _build_transition_guard() -> AgentStateGuard:
     )
 
 
+def _build_commit_guard(tmp_path) -> AgentStateGuard:
+    return AgentStateGuard(
+        STRICT_AGENT_STATE_SCHEMA,
+        transition_rules=STRICT_AGENT_TRANSITION_RULES,
+        allowed_commit_roots=[str(tmp_path)],
+    )
+
+
 def test_rejects_empty_payload():
     guard = _build_guard()
 
@@ -301,6 +309,154 @@ def test_accepts_valid_monotonic_state_transition():
     assert result["status"] == "VERIFIED"
     assert result["normalized_previous_state"]["status"] == "pending"
     assert result["normalized_state"]["status"] == "running"
+
+
+def test_rejects_commit_without_allowed_roots(tmp_path):
+    guard = _build_transition_guard()
+    target_path = tmp_path / "state.json"
+
+    result = guard.verify_transition_and_commit_state(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+        str(target_path),
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-107"
+    assert not target_path.exists()
+
+
+def test_rejects_relative_commit_path(tmp_path):
+    guard = _build_commit_guard(tmp_path)
+
+    result = guard.verify_transition_and_commit_state(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+        "state.json",
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-107"
+
+
+def test_rejects_commit_path_outside_allowed_roots(tmp_path):
+    guard = _build_commit_guard(tmp_path)
+    outside_target = tmp_path.parent / "outside.json"
+
+    result = guard.verify_transition_and_commit_state(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+        str(outside_target),
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-107"
+    assert not outside_target.exists()
+
+
+def test_rejects_commit_path_with_non_json_extension(tmp_path):
+    guard = _build_commit_guard(tmp_path)
+    target_path = tmp_path / "state.txt"
+
+    result = guard.verify_transition_and_commit_state(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+        str(target_path),
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-107"
+    assert not target_path.exists()
+
+
+def test_rejects_commit_when_target_parent_does_not_exist(tmp_path):
+    guard = _build_commit_guard(tmp_path)
+    target_path = tmp_path / "missing" / "state.json"
+
+    result = guard.verify_transition_and_commit_state(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+        str(target_path),
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-107"
+    assert not target_path.exists()
+
+
+def test_rejects_commit_without_side_effects_when_transition_is_blocked(tmp_path):
+    guard = _build_commit_guard(tmp_path)
+    target_path = tmp_path / "state.json"
+
+    result = guard.verify_transition_and_commit_state(
+        '{"agent_id": "a1", "status": "running", "step_count": 3, "tasks": []}',
+        '{"agent_id": "a1", "status": "pending", "step_count": 2, "tasks": []}',
+        str(target_path),
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-106"
+    assert not target_path.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_commits_verified_transition_atomically(tmp_path):
+    guard = _build_commit_guard(tmp_path)
+    target_path = tmp_path / "state.json"
+
+    result = guard.verify_transition_and_commit_state(
+        """
+        {
+          "agent_id": "a1",
+          "status": "pending",
+          "step_count": 1,
+          "tasks": [{"id": "task-1", "done": false}]
+        }
+        """,
+        """
+        {
+          "tasks": [
+            {"done": true, "id": "task-1"},
+            {"done": false, "id": "task-2"}
+          ],
+          "step_count": 2,
+          "status": "running",
+          "agent_id": "a1"
+        }
+        """,
+        str(target_path),
+    )
+
+    assert result["verified"] is True
+    assert result["status"] == "VERIFIED"
+    assert result["committed_path"] == str(target_path)
+    assert result["committed_bytes"] > 0
+    assert target_path.read_text(encoding="utf-8") == (
+        '{"agent_id":"a1","status":"running","step_count":2,'
+        '"tasks":[{"done":true,"id":"task-1"},{"done":false,"id":"task-2"}]}'
+    )
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_cleans_up_temp_file_when_atomic_replace_fails(tmp_path, monkeypatch):
+    guard = _build_commit_guard(tmp_path)
+    target_path = tmp_path / "state.json"
+
+    def failing_replace(source, destination):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr("qwed_new.guards.agent_state_guard.os.replace", failing_replace)
+
+    result = guard.verify_transition_and_commit_state(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+        str(target_path),
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-108"
+    assert not target_path.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
 
 
 def test_rejects_invalid_current_state_during_transition():

--- a/tests/test_agent_state_guard.py
+++ b/tests/test_agent_state_guard.py
@@ -221,6 +221,57 @@ def test_transition_requires_configured_rules():
     assert result["error_code"] == "QWED-AGENT-STATE-104"
 
 
+def test_placeholder_transition_config_does_not_count_as_enabled():
+    guard = AgentStateGuard(
+        STRICT_AGENT_STATE_SCHEMA,
+        transition_rules={
+            "immutable_paths": [],
+            "monotonic_integer_paths": [],
+            "ordered_enum_paths": {},
+            "keyed_object_array_paths": {},
+        },
+    )
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-104"
+
+
+def test_freezes_schema_and_transition_rules_against_caller_mutation():
+    schema = {
+        "type": "object",
+        "properties": {
+            "agent_id": {"type": "string"},
+            "status": {"type": "string", "enum": ["pending", "running", "completed"]},
+        },
+        "required": ["agent_id", "status"],
+        "additionalProperties": False,
+    }
+    transition_rules = {
+        "immutable_paths": ["$.agent_id"],
+        "ordered_enum_paths": {"$.status": ["pending", "running", "completed"]},
+    }
+
+    guard = AgentStateGuard(schema, transition_rules=transition_rules)
+
+    schema["properties"]["agent_id"]["type"] = "integer"
+    transition_rules["immutable_paths"].append("$.status")
+    transition_rules["ordered_enum_paths"]["$.status"].append("failed")
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "pending"}',
+        '{"agent_id": "a1", "status": "running"}',
+    )
+
+    assert result["verified"] is True
+    assert guard.required_schema["properties"]["agent_id"]["type"] == "string"
+    assert guard.transition_rules["immutable_paths"] == ("$.agent_id",)
+
+
 def test_accepts_valid_monotonic_state_transition():
     guard = _build_transition_guard()
 
@@ -409,6 +460,42 @@ def test_rejects_invalid_ordered_enum_rule():
         )
 
 
+def test_blocks_transition_when_ordered_enum_rule_omits_valid_state_value():
+    guard = AgentStateGuard(
+        STRICT_AGENT_STATE_SCHEMA,
+        transition_rules={
+            "ordered_enum_paths": {"$.status": ["pending", "running"]},
+        },
+    )
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "completed", "step_count": 2, "tasks": []}',
+        '{"agent_id": "a1", "status": "completed", "step_count": 3, "tasks": []}',
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-106"
+    assert "transition-rule evaluation failed deterministically" in result["message"]
+
+
+def test_blocks_transition_when_rule_path_is_missing_from_state():
+    guard = AgentStateGuard(
+        STRICT_AGENT_STATE_SCHEMA,
+        transition_rules={
+            "immutable_paths": ["$.notes"],
+        },
+    )
+
+    result = guard.verify_state_transition(
+        '{"agent_id": "a1", "status": "pending", "step_count": 1, "tasks": []}',
+        '{"agent_id": "a1", "status": "running", "step_count": 2, "tasks": []}',
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-106"
+    assert "Configured path '$.notes' was not found in state." in result["message"]
+
+
 def test_rejects_non_dict_ordered_enum_rules():
     with pytest.raises(ValueError, match="ordered_enum_paths must be a dictionary"):
         AgentStateGuard(
@@ -422,6 +509,18 @@ def test_rejects_invalid_keyed_object_array_rule():
         AgentStateGuard(
             STRICT_AGENT_STATE_SCHEMA,
             transition_rules={"keyed_object_array_paths": {"$.tasks": {}}},
+        )
+
+
+def test_rejects_unknown_keyed_object_array_rule_keys():
+    with pytest.raises(ValueError, match="contains unsupported keys"):
+        AgentStateGuard(
+            STRICT_AGENT_STATE_SCHEMA,
+            transition_rules={
+                "keyed_object_array_paths": {
+                    "$.tasks": {"key": "id", "allow_new_item": False}
+                }
+            },
         )
 
 

--- a/tests/test_agent_state_guard.py
+++ b/tests/test_agent_state_guard.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 
 from qwed_new.guards.agent_state_guard import AgentStateGuard
@@ -35,6 +37,17 @@ def test_rejects_empty_payload():
     guard = _build_guard()
 
     result = guard.verify_state_payload("")
+
+    assert result["verified"] is False
+    assert result["status"] == "BLOCKED"
+    assert result["error_code"] == "QWED-AGENT-STATE-101"
+
+
+@pytest.mark.parametrize("payload", [None, 123, []])
+def test_rejects_non_string_input(payload):
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(payload)
 
     assert result["verified"] is False
     assert result["status"] == "BLOCKED"
@@ -177,3 +190,328 @@ def test_accepts_structurally_valid_payload_and_normalizes_order():
 def test_invalid_schema_definition_fails_fast():
     with pytest.raises(ValueError, match="must declare a supported type"):
         AgentStateGuard({"properties": {}})
+
+
+def test_rejects_non_dict_schema_definition():
+    with pytest.raises(ValueError, match="must be a dictionary"):
+        AgentStateGuard(["not", "a", "dict"])
+
+
+def test_rejects_empty_enum_definition():
+    with pytest.raises(ValueError, match="must be a non-empty list"):
+        AgentStateGuard(
+            {
+                "type": "object",
+                "properties": {"status": {"type": "string", "enum": []}},
+                "required": [],
+                "additionalProperties": False,
+            }
+        )
+
+
+def test_rejects_object_schema_without_properties():
+    with pytest.raises(ValueError, match="must define properties"):
+        AgentStateGuard({"type": "object"})
+
+
+def test_rejects_required_key_list_with_non_strings():
+    with pytest.raises(ValueError, match="must be a list of strings"):
+        AgentStateGuard(
+            {
+                "type": "object",
+                "properties": {"agent_id": {"type": "string"}},
+                "required": ["agent_id", 1],
+                "additionalProperties": False,
+            }
+        )
+
+
+def test_rejects_required_keys_missing_from_properties():
+    with pytest.raises(ValueError, match="missing from properties"):
+        AgentStateGuard(
+            {
+                "type": "object",
+                "properties": {"agent_id": {"type": "string"}},
+                "required": ["agent_id", "status"],
+                "additionalProperties": False,
+            }
+        )
+
+
+def test_rejects_non_boolean_additional_properties():
+    with pytest.raises(ValueError, match="must be a boolean value"):
+        AgentStateGuard(
+            {
+                "type": "object",
+                "properties": {"agent_id": {"type": "string"}},
+                "required": [],
+                "additionalProperties": "nope",
+            }
+        )
+
+
+def test_rejects_array_schema_without_items():
+    with pytest.raises(ValueError, match="must define an items schema"):
+        AgentStateGuard(
+            {
+                "type": "object",
+                "properties": {"tasks": {"type": "array"}},
+                "required": [],
+                "additionalProperties": False,
+            }
+        )
+
+
+def test_rejects_string_enum_mismatch():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(
+        """
+        {
+          "agent_id": "a1",
+          "status": "failed",
+          "step_count": 1,
+          "tasks": []
+        }
+        """
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-103"
+    assert "$.status must be one of" in result["message"]
+
+
+def test_rejects_object_type_mismatch():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(
+        """
+        [
+          {
+            "agent_id": "a1",
+            "status": "pending",
+            "step_count": 1,
+            "tasks": []
+          }
+        ]
+        """
+    )
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-103"
+    assert "$ must be an object" in result["message"]
+
+
+def test_rejects_array_type_mismatch():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(
+        """
+        {
+          "agent_id": "a1",
+          "status": "pending",
+          "step_count": 1,
+          "tasks": {}
+        }
+        """
+    )
+
+    assert result["verified"] is False
+    assert "$.tasks must be an array" in result["message"]
+
+
+def test_rejects_integer_bool_type_confusion():
+    guard = _build_guard()
+
+    result = guard.verify_state_payload(
+        """
+        {
+          "agent_id": "a1",
+          "status": "pending",
+          "step_count": true,
+          "tasks": []
+        }
+        """
+    )
+
+    assert result["verified"] is False
+    assert "$.step_count must be an integer" in result["message"]
+
+
+def test_validate_number_value_rejects_non_finite_numbers():
+    guard = AgentStateGuard(
+        {
+            "type": "object",
+            "properties": {"score": {"type": "number"}},
+            "required": ["score"],
+            "additionalProperties": False,
+        }
+    )
+
+    error = guard._validate_value({"type": "number"}, float("nan"), "$.score")
+
+    assert "must use deterministic JSON numbers" in error
+
+
+def test_validate_null_value_rejects_non_null():
+    guard = AgentStateGuard(
+        {
+            "type": "object",
+            "properties": {"marker": {"type": "null"}},
+            "required": ["marker"],
+            "additionalProperties": False,
+        }
+    )
+
+    error = guard._validate_value({"type": "null"}, "not-null", "$.marker")
+
+    assert error == "$.marker must be null, got str."
+
+
+def test_rejects_empty_property_name_in_schema():
+    with pytest.raises(ValueError, match="must be non-empty strings"):
+        AgentStateGuard(
+            {
+                "type": "object",
+                "properties": {"": {"type": "string"}},
+                "required": [],
+                "additionalProperties": False,
+            }
+        )
+
+
+def test_allows_optional_keys_to_be_absent():
+    guard = AgentStateGuard(
+        {
+            "type": "object",
+            "properties": {
+                "agent_id": {"type": "string"},
+                "notes": {"type": "string"},
+            },
+            "required": ["agent_id"],
+            "additionalProperties": False,
+        }
+    )
+
+    result = guard.verify_state_payload('{"agent_id": "a1"}')
+
+    assert result["verified"] is True
+    assert result["normalized_state"] == {"agent_id": "a1"}
+
+
+def test_allows_extra_keys_when_schema_explicitly_permits_them():
+    guard = AgentStateGuard(
+        {
+            "type": "object",
+            "properties": {"agent_id": {"type": "string"}},
+            "required": ["agent_id"],
+            "additionalProperties": True,
+        }
+    )
+
+    result = guard.verify_state_payload(
+        """
+        {
+          "agent_id": "a1",
+          "runtime_note": "allowed"
+        }
+        """
+    )
+
+    assert result["verified"] is True
+    assert result["normalized_state"] == {
+        "agent_id": "a1",
+        "runtime_note": "allowed",
+    }
+
+
+def test_validate_value_rejects_unsupported_schema_type():
+    guard = _build_guard()
+
+    error = guard._validate_value({"type": "mystery"}, "x", "$.mystery")
+
+    assert error == "$.mystery uses unsupported schema type 'mystery'."
+
+
+def test_validate_string_value_rejects_non_string():
+    guard = _build_guard()
+
+    error = guard._validate_value({"type": "string"}, 7, "$.agent_id")
+
+    assert error == "$.agent_id must be a string, got int."
+
+
+def test_validate_number_value_rejects_non_numeric_type():
+    guard = _build_guard()
+
+    error = guard._validate_value({"type": "number"}, "7", "$.score")
+
+    assert error == "$.score must be a number, got str."
+
+
+def test_validate_number_value_accepts_finite_number():
+    guard = _build_guard()
+
+    error = guard._validate_value({"type": "number"}, Decimal("7.5"), "$.score")
+
+    assert error is None
+
+
+def test_validate_number_value_accepts_integer():
+    guard = _build_guard()
+
+    error = guard._validate_value({"type": "number"}, 7, "$.score")
+
+    assert error is None
+
+
+def test_validate_number_value_rejects_bool():
+    guard = _build_guard()
+
+    error = guard._validate_value({"type": "number"}, True, "$.score")
+
+    assert error == "$.score must be a number, got bool."
+
+
+def test_validate_null_value_accepts_null():
+    guard = _build_guard()
+
+    error = guard._validate_value({"type": "null"}, None, "$.marker")
+
+    assert error is None
+
+
+def test_parses_decimal_json_numbers_as_decimal():
+    guard = AgentStateGuard(
+        {
+            "type": "object",
+            "properties": {"score": {"type": "number"}},
+            "required": ["score"],
+            "additionalProperties": False,
+        }
+    )
+
+    result = guard.verify_state_payload('{"score": 7.5}')
+
+    assert result["verified"] is True
+    assert result["normalized_state"]["score"] == Decimal("7.5")
+
+
+def test_rejects_excessive_validation_depth():
+    schema = {"type": "string"}
+    value = "leaf"
+
+    for _ in range(AgentStateGuard.MAX_VALIDATION_DEPTH):
+        schema = {"type": "array", "items": schema}
+        value = [value]
+
+    guard = AgentStateGuard(schema)
+
+    # Directly validate the nested structure to exercise the depth guard.
+    error = guard._validate_value(schema, value, "$")
+
+    assert error is not None
+    assert error.startswith("$[0]")
+    assert error.endswith(
+        f"exceeds maximum validation depth ({AgentStateGuard.MAX_VALIDATION_DEPTH})."
+    )


### PR DESCRIPTION
## Summary
This PR implements all three phases of `AgentStateGuard` for issue #138.

It introduces deterministic verification and governed atomic commit for proposed agent state payloads — extending QWED from action verification into agent memory governance.

## What changed
- added `AgentStateGuard` in `src/qwed_new/guards/agent_state_guard.py`
- exported the new guard from `src/qwed_new/guards/__init__.py`
- added full regression coverage in `tests/test_agent_state_guard.py`

## Phase 1 — Structural Verification
- strict JSON parsing (no standard lib shortcuts)
- duplicate-key rejection
- `NaN` / non-standard JSON constant rejection
- missing required key detection
- unexpected key rejection
- deep nested type validation
- `VERIFIED` returned only on full schema match

## Phase 2 — Semantic Transition Verification
- immutable field enforcement (declared paths cannot change)
- monotonic integer path enforcement (counters cannot regress)
- ordered enum transition enforcement (e.g. `pending → running → completed` only)
- keyed object array integrity (no deletion, no reordering, no duplicate keys, monotonic boolean fields)
- misconfigured or missing rule paths fail closed — never pass through

## Phase 3 — Governed Atomic Commit
- commit sandboxed to configured `allowed_commit_roots` only
- relative paths, non-`.json` extensions, and non-existent parent dirs blocked
- `tempfile` + `os.fsync` + `os.replace` for true atomicity
- temp file cleaned up on any failure — no partial writes ever persist
- commit only proceeds after full Phase 1 + Phase 2 verification succeeds

## Validation
- `py_compile` passed
- `pytest tests/test_agent_state_guard.py -q` → **78 passed**
- SonarCloud: Quality Gate passed (99.7% coverage on new code)
- All 33 CI checks passed

## Notes
- no side effects occur during verification phase
- schema and transition rules are deep-frozen at construction time — caller mutation has no effect
- no existing guard behavior was changed
