### PR TITLE
fix: hard-block legacy CodeExecutor execution path

### DIFF
--- a/src/qwed_new/core/code_executor.py
+++ b/src/qwed_new/core/code_executor.py
@@ -8,7 +8,9 @@ execution boundary.
 
 from __future__ import annotations
 
-from typing import Any, Final
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any, ClassVar, Final
 
 
 LEGACY_CODE_EXECUTOR_DISABLED: Final[str] = (
@@ -26,7 +28,7 @@ class CodeExecutor:
     now raises a deterministic runtime error.
     """
 
-    ALLOWED_GLOBALS: dict[str, Any] = {}
+    ALLOWED_GLOBALS: ClassVar[Mapping[str, Any]] = MappingProxyType({})
 
     def execute(self, code: str, df: Any = None) -> str:
         """Fail closed on every attempted execution."""

--- a/src/qwed_new/core/code_executor.py
+++ b/src/qwed_new/core/code_executor.py
@@ -1,66 +1,33 @@
-import pandas as pd
-import numpy as np
-import scipy
-import math
-import io
-import contextlib
+"""
+Legacy CodeExecutor disabled for fail-closed safety.
+
+This module intentionally hard-blocks the historical raw-exec path. All code
+execution must go through SecureCodeExecutor or another explicitly hardened
+execution boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+
+LEGACY_CODE_EXECUTOR_DISABLED: Final[str] = (
+    "CodeExecutor is disabled because raw exec() is not a valid QWED "
+    "verification boundary. Use SecureCodeExecutor instead."
+)
+
 
 class CodeExecutor:
     """
-    Safely executes generated Python code for statistical analysis.
-    Restricts imports and system access.
-    """
-    
-    ALLOWED_GLOBALS = {
-        "pd": pd,
-        "np": np,
-        "scipy": scipy,
-        "math": math,
-        "print": print,
-        "len": len,
-        "sum": sum,
-        "max": max,
-        "min": min,
-        "abs": abs,
-        "round": round,
-        "list": list,
-        "dict": dict,
-        "set": set,
-        "tuple": tuple,
-        "str": str,
-        "int": int,
-        "float": float,
-        "bool": bool,
-    }
+    Legacy executor intentionally disabled.
 
-    def execute(self, code: str, df: pd.DataFrame = None) -> str:
-        """
-        Executes the provided code with the DataFrame `df` in context.
-        The code is expected to define a function `verify_claim(df)` or simply run and print/return something.
-        
-        For this implementation, we expect the code to print the result or assign it to a variable named `result`.
-        """
-        
-        # Capture stdout
-        output_buffer = io.StringIO()
-        
-        # Execution context
-        local_scope = {"df": df if df is not None else pd.DataFrame(), "result": None}
-        
-        try:
-            with contextlib.redirect_stdout(output_buffer):
-                exec(code, self.ALLOWED_GLOBALS, local_scope)
-            
-            # Check if 'result' variable was set
-            if local_scope.get("result") is not None:
-                return str(local_scope["result"])
-            
-            # Fallback to stdout
-            output = output_buffer.getvalue().strip()
-            if output:
-                return output
-                
-            return "No result returned or printed."
-            
-        except Exception as e:
-            return f"Execution Error: {str(e)}"
+    The previous implementation executed arbitrary Python through raw exec().
+    That behavior violated QWED's fail-closed guarantees, so any attempted use
+    now raises a deterministic runtime error.
+    """
+
+    ALLOWED_GLOBALS: dict[str, Any] = {}
+
+    def execute(self, code: str, df: Any = None) -> str:
+        """Fail closed on every attempted execution."""
+        raise RuntimeError(LEGACY_CODE_EXECUTOR_DISABLED)

--- a/tests/test_code_executor.py
+++ b/tests/test_code_executor.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pytest
+
+from qwed_new.core.code_executor import (
+    LEGACY_CODE_EXECUTOR_DISABLED,
+    CodeExecutor,
+)
+
+
+def test_code_executor_is_hard_blocked_for_harmless_code():
+    executor = CodeExecutor()
+
+    with pytest.raises(RuntimeError, match="CodeExecutor is disabled"):
+        executor.execute("result = 2 + 2")
+
+
+def test_code_executor_is_hard_blocked_with_dataframe_context():
+    executor = CodeExecutor()
+    df = pd.DataFrame({"value": [1, 2, 3]})
+
+    with pytest.raises(RuntimeError) as exc_info:
+        executor.execute("result = df['value'].sum()", df=df)
+
+    assert str(exc_info.value) == LEGACY_CODE_EXECUTOR_DISABLED
+
+
+def test_code_executor_error_points_callers_to_secure_boundary():
+    executor = CodeExecutor()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        executor.execute("__import__('os').system('echo unsafe')")
+
+    assert "SecureCodeExecutor" in str(exc_info.value)

--- a/tests/test_code_executor.py
+++ b/tests/test_code_executor.py
@@ -28,6 +28,6 @@ def test_code_executor_error_points_callers_to_secure_boundary():
     executor = CodeExecutor()
 
     with pytest.raises(RuntimeError) as exc_info:
-        executor.execute("__import__('os').system('echo unsafe')")
+        executor.execute("__import__('os').getcwd()")
 
     assert "SecureCodeExecutor" in str(exc_info.value)


### PR DESCRIPTION
## Summary
This PR fixes issue #141 by hard-blocking the legacy `CodeExecutor`.

`CodeExecutor` previously exposed a raw `exec(...)` path, which is not a valid QWED verification boundary. Instead of trying to patch that legacy path, this change makes all attempted use fail closed with a deterministic runtime error and directs callers to the supported hardened execution boundary.

## What changed
- replaced the legacy raw-exec behavior in `src/qwed_new/core/code_executor.py`
- added a deterministic fail-closed runtime error for any attempted execution
- added regression tests in `tests/test_code_executor.py`

## Why
QWED must not allow unverified code execution.

The old `CodeExecutor` design allowed arbitrary Python execution before deterministic proof, which breaks fail-closed and zero-trust guarantees. This PR removes that unsafe behavior from active use.

## Validation
- targeted regression tests added for blocked execution behavior
- secure execution path tests still pass
- harmless and malicious-looking payloads now both fail closed through the legacy executor

## Result
- `CodeExecutor` no longer executes code
- attempted use now fails closed
- supported code execution remains the hardened secure executor path

Closes #141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Legacy code execution has been disabled. Users depending on this feature should migrate to the secure code execution alternative.

* **Tests**
  * Added test coverage verifying legacy code execution is disabled and error messaging properly guides users to secure alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->