### PR TITLE
fix: default deny unknown tool approvals

### DIFF
--- a/src/qwed_new/core/tool_approval.py
+++ b/src/qwed_new/core/tool_approval.py
@@ -98,7 +98,7 @@ class ToolApprovalSystem:
             tool_call.approved_by = None
             tool_call.blocked_reason = (
                 f"Unknown tool '{tool_name}' requires explicit allowlisting "
-                f"(risk_score={risk_score})"
+                f"(risk_score={risk_score:.1f})"
             )
 
             session.add(tool_call)

--- a/src/qwed_new/core/tool_approval.py
+++ b/src/qwed_new/core/tool_approval.py
@@ -93,27 +93,19 @@ class ToolApprovalSystem:
             return True, None, tool_call
         
         else:
-            # Unknown operation - evaluate by risk score
-            if risk_score < 0.3:
-                # Low risk - approve
-                tool_call.approved = True
-                tool_call.approved_by = "policy"
-                
-                session.add(tool_call)
-                session.commit()
-                session.refresh(tool_call)
-                
-                return True, None, tool_call
-            else:
-                # High risk - block
-                tool_call.approved = False
-                tool_call.blocked_reason = f"High risk score ({risk_score})"
-                
-                session.add(tool_call)
-                session.commit()
-                session.refresh(tool_call)
-                
-                return False, tool_call.blocked_reason, tool_call
+            # Unknown operations fail closed, regardless of heuristic risk score.
+            tool_call.approved = False
+            tool_call.approved_by = None
+            tool_call.blocked_reason = (
+                f"Unknown tool '{tool_name}' requires explicit allowlisting "
+                f"(risk_score={risk_score})"
+            )
+
+            session.add(tool_call)
+            session.commit()
+            session.refresh(tool_call)
+
+            return False, tool_call.blocked_reason, tool_call
     
     def execute_tool_call(
         self,

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -1,0 +1,97 @@
+from unittest.mock import MagicMock
+
+from qwed_new.core.tool_approval import ToolApprovalSystem
+
+
+def _build_session():
+    session = MagicMock()
+    session.add = MagicMock()
+    session.commit = MagicMock()
+    session.refresh = MagicMock()
+    session.get = MagicMock()
+    return session
+
+
+def test_safe_operation_is_auto_approved():
+    approval = ToolApprovalSystem()
+    session = _build_session()
+
+    approved, blocked_reason, tool_call = approval.approve_tool_call(
+        session=session,
+        agent_id=1,
+        tool_name="search_web",
+        tool_params={"q": "qwed"},
+    )
+
+    assert approved is True
+    assert blocked_reason is None
+    assert tool_call.approved is True
+    assert tool_call.approved_by == "automatic"
+    session.add.assert_called_once_with(tool_call)
+    session.commit.assert_called_once()
+    session.refresh.assert_called_once_with(tool_call)
+
+
+def test_dangerous_operation_requires_manual_approval():
+    approval = ToolApprovalSystem()
+    session = _build_session()
+
+    approved, blocked_reason, tool_call = approval.approve_tool_call(
+        session=session,
+        agent_id=1,
+        tool_name="delete_database",
+        tool_params={"database": "prod"},
+    )
+
+    assert approved is False
+    assert "requires manual approval" in blocked_reason
+    assert tool_call.approved is False
+    assert tool_call.approved_by is None
+
+
+def test_unknown_low_risk_operation_is_blocked():
+    approval = ToolApprovalSystem()
+    session = _build_session()
+
+    approved, blocked_reason, tool_call = approval.approve_tool_call(
+        session=session,
+        agent_id=1,
+        tool_name="list_dashboards",
+        tool_params={"team": "analytics"},
+    )
+
+    assert approved is False
+    assert "Unknown tool 'list_dashboards' requires explicit allowlisting" in blocked_reason
+    assert "risk_score=0.0" in blocked_reason
+    assert tool_call.approved is False
+    assert tool_call.approved_by is None
+
+
+def test_unknown_high_risk_operation_is_also_blocked():
+    approval = ToolApprovalSystem()
+    session = _build_session()
+
+    approved, blocked_reason, tool_call = approval.approve_tool_call(
+        session=session,
+        agent_id=1,
+        tool_name="delete_archive",
+        tool_params={"database": "prod", "role": "admin"},
+    )
+
+    assert approved is False
+    assert "Unknown tool 'delete_archive' requires explicit allowlisting" in blocked_reason
+    assert "risk_score=" in blocked_reason
+    assert tool_call.risk_score > 0.0
+
+
+def test_execute_tool_call_rejects_unapproved_calls():
+    approval = ToolApprovalSystem()
+    session = _build_session()
+    tool_call = MagicMock(approved=False, blocked_reason="blocked by policy")
+    session.get.return_value = tool_call
+
+    success, error, result = approval.execute_tool_call(session=session, tool_call_id=123)
+
+    assert success is False
+    assert error == "Tool call not approved: blocked by policy"
+    assert result is None

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -80,8 +80,8 @@ def test_unknown_high_risk_operation_is_also_blocked():
 
     assert approved is False
     assert "Unknown tool 'delete_archive' requires explicit allowlisting" in blocked_reason
-    assert "risk_score=" in blocked_reason
-    assert tool_call.risk_score > 0.0
+    assert "risk_score=0.9" in blocked_reason
+    assert tool_call.risk_score >= 0.3
 
 
 def test_execute_tool_call_rejects_unapproved_calls():


### PR DESCRIPTION
## Summary
This PR fixes issue #143 by changing `ToolApprovalSystem` to fail closed for unknown tools.

Previously, unknown tools could be auto-approved if their heuristic risk score stayed below the threshold. That behavior weakened QWED’s zero-trust boundary by allowing unrecognized execution surfaces through a policy shortcut.

This change removes that bypass path:
- explicitly safe tools still auto-approve
- explicitly dangerous tools still block / require manual approval
- unknown tools are now blocked by default

## What changed
- updated `src/qwed_new/core/tool_approval.py`
  - unknown tools no longer auto-approve based on heuristic risk score
  - unknown tools now return a deterministic blocked result with an explicit allowlisting requirement
- added `tests/test_tool_approval.py`
  - covers safe, dangerous, and unknown tool paths
  - confirms unapproved tool calls cannot be executed

## Why
QWED should not trust unknown tools.

An unknown tool is an unverified execution surface, so default-allow behavior violates fail-closed and zero-trust principles. Heuristic risk estimation can still be useful for audit context, but it must not grant approval on its own.

## Validation
- `pytest tests/test_tool_approval.py -q -p no:cacheprovider`
- `pytest tests/test_api_exceptions.py -q -p no:cacheprovider`
- `python -m py_compile src/qwed_new/core/tool_approval.py tests/test_tool_approval.py`

Closes #143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enhanced tool approval system: unrecognized tool operations now require explicit allowlisting rather than automatic approval, strengthening safety controls.

* **Tests**
  * Added comprehensive test coverage for tool approval behaviors, including safe, dangerous, and unknown operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->