### PR TITLE
fix: fail closed in verify_logic_rule

### DIFF
--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -27,6 +27,9 @@ import math
 INVALID_TEMPERATURE_UNIT_ERROR = "Invalid temperature unit"
 INVALID_TOLERANCE_ERROR = "Invalid tolerance"
 TOLERANCE_POLICY_ERROR = "Tolerance exceeds deterministic verification bound"
+VERIFY_LOGIC_RULE_DEPRECATED_ERROR = (
+    "verify_logic_rule is deprecated and fail-closed; use LogicVerifier instead"
+)
 
 
 @dataclass
@@ -949,6 +952,6 @@ class VerificationEngine:
     
     def verify_logic_rule(self, rule: str, context: Dict[str, Any]) -> bool:
         """
-        Legacy placeholder. Use LogicVerifier instead.
+        Legacy placeholder. Hard-fail closed and direct callers to LogicVerifier.
         """
-        pass
+        raise NotImplementedError(VERIFY_LOGIC_RULE_DEPRECATED_ERROR)

--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -950,7 +950,7 @@ class VerificationEngine:
     # Legacy method for compatibility
     # =========================================================================
     
-    def verify_logic_rule(self, rule: str, context: Dict[str, Any]) -> bool:
+    def verify_logic_rule(self, _rule: str, _context: Dict[str, Any]) -> bool:
         """
         Legacy placeholder. Hard-fail closed and direct callers to LogicVerifier.
         """

--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -950,8 +950,9 @@ class VerificationEngine:
     # Legacy method for compatibility
     # =========================================================================
     
-    def verify_logic_rule(self, _rule: str, _context: Dict[str, Any]) -> bool:
+    def verify_logic_rule(self, rule: str, context: Dict[str, Any]) -> bool:
         """
         Legacy placeholder. Hard-fail closed and direct callers to LogicVerifier.
         """
+        _ = (rule, context)
         raise NotImplementedError(VERIFY_LOGIC_RULE_DEPRECATED_ERROR)

--- a/tests/test_verify_logic_rule.py
+++ b/tests/test_verify_logic_rule.py
@@ -1,0 +1,16 @@
+import pytest
+
+from qwed_new.core.verifier import (
+    VERIFY_LOGIC_RULE_DEPRECATED_ERROR,
+    VerificationEngine,
+)
+
+
+def test_verify_logic_rule_fails_closed_with_explicit_error():
+    engine = VerificationEngine()
+
+    with pytest.raises(NotImplementedError, match=VERIFY_LOGIC_RULE_DEPRECATED_ERROR):
+        engine.verify_logic_rule(
+            rule="if user.is_admin then allow",
+            context={"user": {"is_admin": True}},
+        )

--- a/tests/test_verify_logic_rule.py
+++ b/tests/test_verify_logic_rule.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from qwed_new.core.verifier import (
@@ -9,7 +11,10 @@ from qwed_new.core.verifier import (
 def test_verify_logic_rule_fails_closed_with_explicit_error():
     engine = VerificationEngine()
 
-    with pytest.raises(NotImplementedError, match=VERIFY_LOGIC_RULE_DEPRECATED_ERROR):
+    with pytest.raises(
+        NotImplementedError,
+        match=re.escape(VERIFY_LOGIC_RULE_DEPRECATED_ERROR),
+    ):
         engine.verify_logic_rule(
             rule="if user.is_admin then allow",
             context={"user": {"is_admin": True}},


### PR DESCRIPTION
## Summary
This PR fixes issue #145 by making `verify_logic_rule()` fail closed.

Previously, this legacy placeholder returned `None`, which exposed an ambiguous non-verification path. This change replaces that behavior with a deterministic `NotImplementedError` that explicitly directs callers to `LogicVerifier`.

## What changed
- updated `src/qwed_new/core/verifier.py`
  - `verify_logic_rule()` now raises a clear fail-closed error instead of returning `None`
- added `tests/test_verify_logic_rule.py`
  - confirms the method cannot silently succeed or return an ambiguous non-result

## Why
A verifier entry point must never silently do nothing.

Returning `None` is not proof, not a structured failure, and can be mishandled downstream. A hard fail is the correct zero-trust behavior for this deprecated path.

## Validation
- `pytest tests/test_verify_logic_rule.py -q -p no:cacheprovider`
- `pytest tests/test_logic_exceptions.py tests/test_dsl_logic_verifier_routing.py -q -p no:cacheprovider`
- `python -m py_compile src/qwed_new/core/verifier.py tests/test_verify_logic_rule.py`

Closes #145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy verification method now raises an explicit error with clear migration guidance instead of silently succeeding. The fail-closed approach ensures developers are immediately notified when using the deprecated method and directs them to the recommended alternative.

* **Tests**
  * Added comprehensive test coverage to verify the new error behavior, confirming proper exception handling for the deprecated method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->