### PR TITLE
fix: fail closed in verify_identity

### DIFF
--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -236,11 +236,14 @@ class VerificationEngine:
             
             if evaluated_points > 0 and matches == evaluated_points:
                 return {
-                    "is_equivalent": None,
-                    "status": "UNKNOWN",
-                    "method": "numerical_sampling",
+                    "is_equivalent": False,
+                    "status": "BLOCKED",
+                    "method": "numerical_sampling_rejected",
                     "confidence": 0.0,
-                    "reason": "Numerical sampling matched at fixed points, but no formal proof was established"
+                    "reason": (
+                        "Numerical sampling matched at fixed points, but no formal proof "
+                        "was established"
+                    ),
                 }
             
             return {

--- a/tests/test_enterprise_math.py
+++ b/tests/test_enterprise_math.py
@@ -69,6 +69,19 @@ class TestIdentityVerification:
         """Test non-equivalent expressions."""
         result = engine.verify_identity("x**2", "x**3")
         assert result["is_equivalent"] is False
+        assert result["status"] == "NOT_EQUIVALENT"
+
+    def test_sampling_only_match_fails_closed(self, engine):
+        """Fixed-point sampling must not produce an equivalence-style result."""
+        result = engine.verify_identity(
+            "x*(x-0.5)*(x-1)*(x-2)*(x+1)*(x-0.1)",
+            "0",
+        )
+
+        assert result["is_equivalent"] is False
+        assert result["status"] == "BLOCKED"
+        assert result["method"] == "numerical_sampling_rejected"
+        assert "no formal proof" in result["reason"]
 
 
 class TestCalculus:

--- a/tests/test_pr5_determinism_alignment.py
+++ b/tests/test_pr5_determinism_alignment.py
@@ -6,7 +6,7 @@ from qwed_new.core.schemas import MathVerificationTask
 from qwed_new.core.verifier import VerificationEngine
 
 
-def test_verify_identity_sampling_returns_unknown_without_formal_proof():
+def test_verify_identity_sampling_fails_closed_without_formal_proof():
     engine = VerificationEngine()
 
     # This RHS is crafted to equal x at the hardcoded sample points used by
@@ -16,9 +16,9 @@ def test_verify_identity_sampling_returns_unknown_without_formal_proof():
         "x + (x-0.5)*(x-1)*(x-2)*(x+1)*(x-0.1)",
     )
 
-    assert result["status"] == "UNKNOWN"
-    assert result["is_equivalent"] is None
-    assert result["method"] == "numerical_sampling"
+    assert result["status"] == "BLOCKED"
+    assert result["is_equivalent"] is False
+    assert result["method"] == "numerical_sampling_rejected"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
This PR fixes issue #146 by making `verify_identity()` fail closed when only fixed-point numerical sampling matches.

Previously, `verify_identity()` could return an ambiguous equivalence-style result:
- `is_equivalent: None`
- `status: UNKNOWN`

That exposed a soft-success state even when no formal proof existed.

This change blocks that path instead:
- `is_equivalent: False`
- `status: BLOCKED`

## What changed
- updated `src/qwed_new/core/verifier.py`
  - sampling-only matches no longer produce an ambiguous equivalence state
  - the numerical-sampling fallback now returns a deterministic blocked result
- updated `tests/test_enterprise_math.py`
  - added an adversarial regression for an expression crafted to match the fixed sample set only
  - tightened the non-equivalent identity assertion

## Why
QWED should not treat sampled coincidence as proof.

If symbolic verification cannot establish equivalence, then the result must not remain usable as a partial or ambiguous success state.

## Validation
- `pytest tests/test_enterprise_math.py -q -p no:cacheprovider`
- `pytest tests/test_math_engine_extended.py -q -p no:cacheprovider`
- `python -m py_compile src/qwed_new/core/verifier.py tests/test_enterprise_math.py`

Closes #146


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Identity verification now returns a deterministic rejection status when numerical sampling matches across all test points but lacks formal proof, rather than returning an indeterminate result. This provides stricter validation.

* **Tests**
  * Added tests validating the updated verification behavior for equivalent expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->