### PR TITLE
fix: fail closed for ambiguous math api inputs

### DIFF
--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -540,7 +540,9 @@ async def verify_math(
                 elif is_ambiguous:
                     simplified = simplify(parsed)
                     result = {
-                        "is_valid": True,
+                        "is_valid": False,
+                        "result": False,
+                        "status": "BLOCKED",
                         "warning": "ambiguous",
                         "message": "Expression may be ambiguous due to implicit multiplication after division",
                         "simplified": str(simplified),

--- a/tests/test_api_verify_math.py
+++ b/tests/test_api_verify_math.py
@@ -6,7 +6,11 @@ from qwed_new.api.main import app, get_current_tenant, get_session
 
 
 def test_verify_math_ambiguous_expression_fails_closed_and_logs_unverified():
-    mock_tenant = MagicMock(organization_id=123, api_key="dummy_key", user_id=456)
+    mock_tenant = MagicMock(
+        organization_id=123,
+        api_key=MagicMock(name="tenant_api_key"),
+        user_id=456,
+    )
     mock_session = MagicMock()
 
     app.dependency_overrides[get_current_tenant] = lambda: mock_tenant

--- a/tests/test_api_verify_math.py
+++ b/tests/test_api_verify_math.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from qwed_new.api.main import app, get_current_tenant, get_session
+
+
+def test_verify_math_ambiguous_expression_fails_closed_and_logs_unverified():
+    mock_tenant = MagicMock(organization_id=123, api_key="dummy_key", user_id=456)
+    mock_session = MagicMock()
+
+    app.dependency_overrides[get_current_tenant] = lambda: mock_tenant
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    try:
+        client = TestClient(app)
+
+        with patch("qwed_new.api.main.check_rate_limit"):
+            response = client.post(
+                "/verify/math",
+                json={"expression": "1/2(3+1)"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "BLOCKED"
+        assert data["is_valid"] is False
+        assert data["result"] is False
+        assert data["warning"] == "ambiguous"
+        assert "implicit multiplication after division" in data["message"]
+
+        logged = mock_session.add.call_args[0][0]
+        assert logged.is_verified is False
+        assert logged.domain == "MATH"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
This PR fixes issue #147 by making `/verify/math` fail closed for ambiguous expressions.

Previously, the endpoint detected ambiguity caused by implicit multiplication after division, but still returned:
- `is_valid: true`

That created a fail-open API boundary, because ambiguous math could still look valid to downstream consumers and logging.

This change blocks that path instead:
- `is_valid: false`
- `result: false`
- `status: "BLOCKED"`

## What changed
- updated `src/qwed_new/api/main.py`
  - the ambiguous-expression branch now returns a non-success response
- added `tests/test_api_verify_math.py`
  - verifies the API response fails closed
  - verifies `VerificationLog.is_verified` remains `False`

## Why
Ambiguous math is not proven math.

QWED should not expose an ambiguity warning inside a pass-like result. If the expression is ambiguous, the API must not treat it as valid.

## Validation
- `pytest tests/test_api_verify_math.py -q -p no:cacheprovider`
- `pytest tests/test_api_exceptions.py tests/test_api_phase17_endpoints.py -q -p no:cacheprovider`
- `python -m py_compile src/qwed_new/api/main.py tests/test_api_verify_math.py`

Closes #147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ambiguous math expressions with implicit multiplication after division (e.g., "1/2(3+1)") now correctly return as invalid and blocked instead of being marked valid.
* **Tests**
  * Added an API test ensuring ambiguous math expressions are reported as blocked and logged as unverified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->