### PR TITLE
fix: fail closed on uniqueItems validation errors

### DIFF
--- a/src/qwed_new/core/schema_verifier.py
+++ b/src/qwed_new/core/schema_verifier.py
@@ -504,9 +504,18 @@ class SchemaVerifier:
                         ))
                         break
                     seen.add(item_key)
-            except (TypeError, ValueError):
-                pass  # Can't check uniqueness for unhashable items
-        
+            except (TypeError, ValueError) as exc:
+                issues.append(SchemaIssue(
+                    path=path,
+                    issue_type="uniqueness_validation_error",
+                    expected="provably unique items",
+                    actual="uniqueness check could not be completed",
+                    message=(
+                        "uniqueItems could not be verified deterministically: "
+                        f"{exc}"
+                    )
+                ))
+
         # items (single schema for all items)
         if "items" in schema and isinstance(schema["items"], dict):
             for i, item in enumerate(data):

--- a/tests/test_schema_verifier.py
+++ b/tests/test_schema_verifier.py
@@ -243,7 +243,17 @@ class TestArrayValidation:
         schema = {"type": "array", "uniqueItems": True}
         result = verifier.verify([1, 2, 2, 3], schema)
         assert result["is_valid"] == False
-    
+
+    def test_unique_items_uncheckable_fails_closed(self, verifier):
+        """If uniqueness cannot be proven, validation must fail closed."""
+        schema = {"type": "array", "uniqueItems": True}
+        result = verifier.verify([{"bad": {1, 2}}, {"bad": {3, 4}}], schema)
+
+        assert result["is_valid"] == False
+        assert result["status"] == "INVALID"
+        assert result["issues"][0]["type"] == "uniqueness_validation_error"
+        assert "uniqueItems could not be verified deterministically" in result["issues"][0]["message"]
+
     def test_items_schema(self, verifier):
         """Array items validated against item schema."""
         schema = {

--- a/tests/test_schema_verifier.py
+++ b/tests/test_schema_verifier.py
@@ -242,7 +242,7 @@ class TestArrayValidation:
         """Array with duplicates fails."""
         schema = {"type": "array", "uniqueItems": True}
         result = verifier.verify([1, 2, 2, 3], schema)
-        assert result["is_valid"] == False
+        assert not result["is_valid"]
 
     def test_unique_items_uncheckable_fails_closed(self, verifier):
         """If uniqueness cannot be proven, validation must fail closed."""


### PR DESCRIPTION
## Summary
This PR fixes issue #148 by making `SchemaVerifier` fail closed when `uniqueItems` cannot be deterministically validated.

Previously, the `uniqueItems` path swallowed `TypeError` and `ValueError`, which meant uniqueness enforcement could silently disappear and the payload could still pass validation.

This change converts that path into an explicit validation failure.

## What changed
- updated `src/qwed_new/core/schema_verifier.py`
  - `uniqueItems` validation errors now produce an explicit `uniqueness_validation_error`
  - verification no longer silently skips uniqueness enforcement
- updated `tests/test_schema_verifier.py`
  - added a regression for an uncheckable uniqueness payload that previously passed silently

## Why
QWED should not treat failed validation as successful validation.

If `uniqueItems` cannot be proven, the verifier must fail closed instead of silently continuing.

## Validation
- `pytest tests/test_schema_verifier.py -q -p no:cacheprovider`
- `pytest tests/test_coverage_edge_cases.py tests/test_coverage_gap.py -q -p no:cacheprovider`
- `python -m py_compile src/qwed_new/core/schema_verifier.py tests/test_schema_verifier.py`

Closes #148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to properly report when array uniqueness constraints cannot be verified deterministically, instead of silently ignoring verification errors.

* **Tests**
  * Added test coverage for uniqueness validation edge cases with non-deterministic items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->