### PR TITLE
release: prepare v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to the QWED Protocol will be documented in this file.
 
 ## [Unreleased]
 
+## [5.1.0] - 2026-04-19
+### Agent State Governance and Fail-Closed Hardening
+
+Minor release expanding QWED from action verification into state governance while closing the adversarial fail-open gaps identified after v5.0.0. This release includes AgentStateGuard plus a focused hardening wave across execution, tool governance, mathematical verification, API semantics, and schema validation.
+
+#### New Capability
+- **AgentStateGuard**: Added deterministic state verification with strict structural validation, semantic transition checks, and governed atomic state commits. This extends QWED from action-only verification to state and memory governance.
+
+#### Fail-Closed Hardening
+- **Legacy CodeExecutor hard-blocked**: `CodeExecutor.execute()` now raises `RuntimeError` unconditionally. All supported execution remains on `SecureCodeExecutor`.
+- **Unknown tools default-denied**: `ToolApprovalSystem` now blocks unknown tools regardless of heuristic risk score.
+- **Bounded math tolerance**: `verify_math()` rejects oversized, negative, non-finite, and malformed tolerances instead of letting callers weaken correctness checks.
+- **Legacy logic path fails closed**: `verify_logic_rule()` now raises `NotImplementedError` instead of returning `None`.
+- **Identity sampling rejected**: `verify_identity()` now returns `BLOCKED` when numerical sampling matches but no formal proof exists.
+- **Ambiguous math API rejected**: `/verify/math` now blocks ambiguous implicit-multiplication expressions instead of returning `is_valid: true`.
+- **Schema uniqueness fail-closed**: `SchemaVerifier` now emits `uniqueness_validation_error` when `uniqueItems` cannot be proven deterministically.
+
+#### Runtime and Security Follow-Through
+- **Progress-aware doom loop guard**: Added LOOP-004 state-aware replay protection for repeated actions on unchanged state.
+- **Security and infrastructure hardening**: Incorporated follow-up hardening across configs, CI, and infrastructure.
+- **Stats verifier coverage expansion**: Added edge-case coverage for the statistics engine.
+- **CodeQL and cleanup follow-ups**: Merged syntax, test, and static-analysis cleanup work after the v5.0.0 boundary release.
+
+#### Upgrade Notes
+- `CodeExecutor` is no longer usable as a legacy execution path. Migrate any direct imports to `SecureCodeExecutor`.
+- Unknown tools now require explicit allowlisting and are no longer auto-approved at low heuristic risk.
+- `verify_math()` may return `BLOCKED` for tolerances that exceed the deterministic policy bound.
+- `verify_logic_rule()` no longer returns an ambiguous non-result; callers must migrate to `LogicVerifier`.
+- Sampling-only `verify_identity()` matches now return `BLOCKED`, not `UNKNOWN`.
+- Ambiguous `/verify/math` expressions now return `BLOCKED` with `is_valid: false`.
+- `uniqueItems` validation failures are now explicit schema errors instead of silent passes.
+
+#### SDK and Package Versions
+- `qwed` (PyPI): `5.0.0` -> `5.1.0`
+- `qwed_sdk` (Python): `5.0.0` -> `5.1.0`
+- `@qwed-ai/sdk` (NPM): `5.0.0` -> `5.1.0`
+
+#### Included PRs since v5.0.0
+- `#124` feat(agent): add progress-aware doom loop guard (LOOP-004)
+- `#126` security: harden configs, CI, and infrastructure -- full audit fixes
+- `#127` test(stats): add edge case coverage for statistics engine
+- `#136` fix(codeql): resolve remaining syntax and test cleanup alerts
+- `#137` Update contributors section in README
+- `#139` feat: AgentStateGuard - full implementation (structural + semantic + atomic commit)
+- `#149` fix: hard-block legacy CodeExecutor execution path
+- `#150` fix: default deny unknown tool approvals
+- `#151` fix: bound verify_math tolerance by computed magnitude
+- `#152` fix: fail closed in verify_logic_rule
+- `#153` fix: fail closed in verify_identity
+- `#154` fix: fail closed for ambiguous math api inputs
+- `#155` fix: fail closed on uniqueItems validation errors
+
 ## [5.0.0] - 2026-04-04
 ### 🛡️ Enforcement Boundary Hardening
 

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: qwed-core
-          image: ghcr.io/qwed-ai/qwed-core:5.0.0
+          image: ghcr.io/qwed-ai/qwed-core:5.1.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed"
-version = "5.0.0"
+version = "5.1.0"
 description = "The Deterministic Verification Protocol for AI - 11 verification engines for math, logic, code, SQL, facts, images, and more. Now with Agentic Security Guards."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/qwed_sdk/__init__.py
+++ b/qwed_sdk/__init__.py
@@ -37,7 +37,7 @@ from qwed_sdk.models import (
     VerificationType,
 )
 
-__version__ = "5.0.0"
+__version__ = "5.1.0"
 __all__ = [
     "QWEDClient",
     "QWEDAsyncClient",

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@qwed-ai/sdk",
-            "version": "5.0.0",
+            "version": "5.1.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/node": "^20.0.0",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "description": "TypeScript SDK for QWED Verification Protocol",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -32,7 +32,7 @@ TenantDependency = Annotated[TenantContext, Depends(get_current_tenant)]
 SessionDependency = Annotated[Session, Depends(get_session)]
 AgentTokenHeader = Annotated[str, Header(...)]
 
-APP_VERSION = "5.0.0"
+APP_VERSION = "5.1.0"
 
 app = FastAPI(
     title="QWED API",


### PR DESCRIPTION
## Summary
This PR prepares the `v5.1.0` release.

It bumps the live version surfaces from `5.0.0` to `5.1.0` and adds a new `CHANGELOG.md` section covering the post-`v5.0.0` release scope, with AgentStateGuard as the headline addition and the subsequent fail-closed hardening work grouped underneath it.

## What changed
- bumped the Python package version in `pyproject.toml`
- bumped the API-reported version in `src/qwed_new/api/main.py`
- bumped the Python SDK version in `qwed_sdk/__init__.py`
- bumped the TypeScript SDK version in `sdk-ts/package.json`
- bumped the root SDK lockfile version entries in `sdk-ts/package-lock.json`
- updated the Kubernetes deployment image tag to `ghcr.io/qwed-ai/qwed-core:5.1.0`
- added a new `5.1.0` section to `CHANGELOG.md`

## Release scope
This release includes:
- AgentStateGuard (`#139`)
- post-v5.0.0 fail-closed hardening fixes (`#149`–`#155`)
- supporting hardening and follow-up work such as LOOP-004, infra/security cleanup, stats coverage expansion, and CodeQL cleanup

## Validation
- `python -m py_compile src/qwed_new/api/main.py qwed_sdk/__init__.py`
- `pytest tests/test_coverage_gap.py -q -p no:cacheprovider`

## Notes
- historical `5.0.0` references in past release notes were left intact
- dependency references such as `redis>=5.0.0` and third-party package versions inside `sdk-ts/package-lock.json` were intentionally not changed because they are not QWED release surfaces
- local `.coverage` and `test_venv/` were left untouched

Closes the v5.1.0 release prep step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced AgentStateGuard for expanded state governance with deterministic structural verification and semantic transition checks.
  * Enhanced validation and verification systems with stricter fail-closed behaviors across components for improved security.

* **Chores**
  * Version bump to 5.1.0 across all packages and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->