### PR TITLE
fix: fail closed strict additional properties in SchemaVerifier

### DIFF
--- a/src/qwed_new/core/schema_verifier.py
+++ b/src/qwed_new/core/schema_verifier.py
@@ -572,7 +572,7 @@ class SchemaVerifier:
                     issue_type="additional_property",
                     expected="no additional properties",
                     actual=key,
-                    severity="WARNING",
+                    severity="ERROR",
                     message=f"Additional property '{key}' not allowed"
                 ))
             

--- a/tests/test_schema_verifier.py
+++ b/tests/test_schema_verifier.py
@@ -322,6 +322,91 @@ class TestObjectValidation:
         assert verifier.verify({"user": {"name": "John"}}, schema)["is_valid"] == True
         assert verifier.verify({"user": {}}, schema)["is_valid"] == False
 
+    def test_strict_additional_properties_false_rejects_extra_fields(self, verifier):
+        """Strict mode must fail closed on undeclared object properties."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "required": ["name"],
+            "additionalProperties": False
+        }
+
+        result = verifier.verify({"name": "rahul", "role": "admin"}, schema, strict=True)
+
+        assert result["is_valid"] is False
+        assert result["status"] == "INVALID"
+        assert any(
+            issue["type"] == "additional_property" and issue["severity"] == "ERROR"
+            for issue in result["issues"]
+        )
+
+    def test_strict_additional_properties_false_accepts_declared_fields(self, verifier):
+        """Strict mode should still allow payloads that fully match the schema."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "required": ["name"],
+            "additionalProperties": False
+        }
+
+        result = verifier.verify({"name": "rahul"}, schema, strict=True)
+
+        assert result["is_valid"] is True
+        assert result["status"] == "VALID"
+
+    def test_non_strict_mode_keeps_additional_properties_non_blocking(self, verifier):
+        """Non-strict mode preserves permissive handling for extra properties."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "required": ["name"],
+            "additionalProperties": False
+        }
+
+        result = verifier.verify({"name": "rahul", "role": "admin"}, schema, strict=False)
+
+        assert result["is_valid"] is True
+        assert result["status"] == "VALID"
+        assert not any(issue["type"] == "additional_property" for issue in result["issues"])
+
+    def test_nested_additional_properties_false_rejects_extra_nested_fields(self, verifier):
+        """Nested objects must also fail closed on undeclared extra properties."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"}
+                    },
+                    "required": ["name"],
+                    "additionalProperties": False
+                }
+            },
+            "required": ["user"]
+        }
+
+        result = verifier.verify(
+            {"user": {"name": "rahul", "role": "admin"}},
+            schema,
+            strict=True
+        )
+
+        assert result["is_valid"] is False
+        assert result["status"] == "INVALID"
+        assert any(
+            issue["path"] == "$.user.role"
+            and issue["type"] == "additional_property"
+            and issue["severity"] == "ERROR"
+            for issue in result["issues"]
+        )
+
 
 class TestMathDelegation:
     """Test computed field verification."""


### PR DESCRIPTION
## Summary
This PR fixes issue #132 by making `SchemaVerifier` fail closed when `strict=True` and a schema sets `additionalProperties=False`.

Previously, undeclared properties in strict mode were recorded as `WARNING`, while overall validity only counted `ERROR` issues. That allowed payloads with forbidden extra fields to still return `VALID`.

## What changed
- changed strict `additionalProperties=False` violations from `WARNING` to `ERROR`
- added regression tests for:
  - strict extra-field rejection
  - strict valid payload acceptance
  - non-strict permissive behavior
  - nested object rejection when `additionalProperties=False`

## Why
A strict schema denial is a structural validation failure, not an advisory warning.

If strict mode is enabled and the schema forbids additional properties, extra fields must make the payload invalid.

## Validation
- `python -m pytest tests/test_schema_verifier.py -q`
- `python -m pytest -q`

Closes #132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schema validation in strict mode now properly fails when payloads contain undeclared extra fields, improving validation accuracy.

* **Tests**
  * Added test coverage for strict mode validation behavior with additional properties at multiple nesting levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->