### PR TITLE
fix: fail closed symbolic verification without proof

### DIFF
--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -115,32 +115,82 @@ class SymbolicVerifier:
         
         if not functions:
             return {
-                "is_verified": True,
-                "status": "no_functions_to_check",
-                "message": "No typed functions found to verify",
-                "issues": [],
-                "functions_checked": 0
+                "is_verified": False,
+                "status": "no_verifiable_functions",
+                "message": "No functions found to verify symbolically",
+                "issues": [{
+                    "type": "unverifiable",
+                    "function": None,
+                    "description": "No functions found in code to verify symbolically"
+                }],
+                "functions_checked": 0,
+                "functions_verified": 0,
+                "functions_skipped": 0,
+                "functions_unverifiable": 0,
+                "functions_discovered": 0,
+                "counterexamples_found": 0
             }
         
         # Run CrossHair analysis
         issues = []
         verified_count = 0
+        checked_count = 0
+        skipped_count = 0
+        unverifiable_count = 0
+        counterexample_count = 0
         
         for func in functions:
             result = self._verify_function(code, func)
-            if result["verified"]:
+            if result.get("verified"):
                 verified_count += 1
-            else:
-                issues.extend(result.get("issues", []))
-        
-        all_verified = len(issues) == 0
+            if not result.get("skipped"):
+                checked_count += 1
+
+            if result.get("skipped") or result.get("unverifiable"):
+                unverifiable_count += 1
+                if result.get("skipped"):
+                    skipped_count += 1
+
+            result_issues = result.get("issues", [])
+            issues.extend(result_issues)
+            counterexample_count += sum(
+                1 for issue in result_issues if issue.get("type") == "counterexample"
+            )
+
+        all_verified = (
+            checked_count > 0 and
+            verified_count == checked_count and
+            skipped_count == 0 and
+            unverifiable_count == 0 and
+            counterexample_count == 0
+        )
+
+        if all_verified:
+            status = "verified"
+            message = "All verifiable functions were proven symbolically."
+        elif checked_count == 0:
+            status = "no_verifiable_functions"
+            message = "No typed functions could be symbolically verified."
+        elif skipped_count > 0 or unverifiable_count > 0:
+            status = "unverifiable"
+            message = "Symbolic verification was incomplete; at least one function could not be proven."
+        elif counterexample_count > 0:
+            status = "counterexamples_found"
+            message = "CrossHair found counterexamples for one or more functions."
+        else:
+            status = "verification_error"
+            message = "Symbolic verification did not complete cleanly."
         
         return {
             "is_verified": all_verified,
-            "status": "verified" if all_verified else "counterexamples_found",
-            "functions_checked": len(functions),
+            "status": status,
+            "message": message,
+            "functions_checked": checked_count,
             "functions_verified": verified_count,
-            "counterexamples_found": len(issues),
+            "functions_skipped": skipped_count,
+            "functions_unverifiable": unverifiable_count,
+            "functions_discovered": len(functions),
+            "counterexamples_found": counterexample_count,
             "issues": issues
         }
     
@@ -181,9 +231,15 @@ class SymbolicVerifier:
         # Skip functions without type hints (CrossHair needs them)
         if not func_info["has_types"]:
             return {
-                "verified": True,
+                "verified": False,
                 "skipped": True,
-                "reason": "No type annotations - CrossHair requires type hints"
+                "unverifiable": True,
+                "reason": "No type annotations - CrossHair requires type hints",
+                "issues": [{
+                    "type": "unverifiable",
+                    "function": func_name,
+                    "description": "Function skipped: no type annotations for symbolic verification"
+                }]
             }
         
         try:
@@ -203,6 +259,8 @@ class SymbolicVerifier:
                 return {
                     "verified": len(issues) == 0,
                     "function": func_name,
+                    "skipped": False,
+                    "unverifiable": False,
                     "issues": issues
                 }
             finally:
@@ -212,6 +270,8 @@ class SymbolicVerifier:
             return {
                 "verified": False,
                 "function": func_name,
+                "skipped": False,
+                "unverifiable": True,
                 "issues": [{
                     "type": "error",
                     "function": func_name,

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -92,59 +92,89 @@ class SymbolicVerifier:
             Dict with verification results
         """
         if not self._crosshair_available:
-            return {
-                "is_verified": False,
-                "is_safe": False,
-                "verified": False,
-                "status": "crosshair_not_available",
-                "message": "CrossHair not installed. Run: pip install crosshair-tool",
-                "issues": []
-            }
+            return self._build_terminal_result(
+                status="crosshair_not_available",
+                message="CrossHair not installed. Run: pip install crosshair-tool",
+            )
         
         # Parse code to extract functions
         try:
             tree = ast.parse(code)
         except SyntaxError as e:
-            return {
-                "is_verified": False,
-                "is_safe": False,
-                "verified": False,
-                "status": "syntax_error",
-                "message": str(e),
-                "issues": []
-            }
+            return self._build_terminal_result(
+                status="syntax_error",
+                message=str(e),
+            )
         
         # Find all functions with type hints (CrossHair needs types)
         functions = self._extract_functions(tree)
         
         if not functions:
-            return {
-                "is_verified": False,
-                "is_safe": False,
-                "verified": False,
-                "status": "no_verifiable_functions",
-                "message": "No functions found to verify symbolically",
-                "issues": [{
-                    "type": "unverifiable",
-                    "function": None,
-                    "description": "No functions found in code to verify symbolically"
-                }],
-                "functions_checked": 0,
-                "functions_verified": 0,
-                "functions_skipped": 0,
-                "functions_unverifiable": 0,
-                "functions_discovered": 0,
-                "counterexamples_found": 0
-            }
-        
-        # Run CrossHair analysis
+            return self._no_verifiable_functions_result()
+
+        summary = self._summarize_verification_results(code, functions)
+        status, message = self._derive_verification_outcome(summary)
+
+        return {
+            "is_verified": summary["all_verified"],
+            "is_safe": summary["all_verified"],
+            "verified": summary["all_verified"],
+            "status": status,
+            "message": message,
+            "functions_checked": summary["checked_count"],
+            "functions_verified": summary["verified_count"],
+            "functions_skipped": summary["skipped_count"],
+            "functions_unverifiable": summary["unverifiable_count"],
+            "functions_discovered": summary["functions_discovered"],
+            "counterexamples_found": summary["counterexample_count"],
+            "issues": summary["issues"]
+        }
+
+    def _build_terminal_result(self, status: str, message: str) -> Dict[str, Any]:
+        """Build a fail-closed terminal result for pre-verification exits."""
+        return {
+            "is_verified": False,
+            "is_safe": False,
+            "verified": False,
+            "status": status,
+            "message": message,
+            "issues": []
+        }
+
+    def _no_verifiable_functions_result(self) -> Dict[str, Any]:
+        """Return a fail-closed result when no functions can be symbolically checked."""
+        return {
+            "is_verified": False,
+            "is_safe": False,
+            "verified": False,
+            "status": "no_verifiable_functions",
+            "message": "No functions found to verify symbolically",
+            "issues": [{
+                "type": "unverifiable",
+                "function": None,
+                "description": "No functions found in code to verify symbolically"
+            }],
+            "functions_checked": 0,
+            "functions_verified": 0,
+            "functions_skipped": 0,
+            "functions_unverifiable": 0,
+            "functions_discovered": 0,
+            "counterexamples_found": 0
+        }
+
+    def _summarize_verification_results(
+        self,
+        code: str,
+        functions: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Aggregate per-function verification results into summary counts."""
         issues = []
         verified_count = 0
         checked_count = 0
         skipped_count = 0
         unverifiable_count = 0
         counterexample_count = 0
-        
+
         for func in functions:
             result = self._verify_function(code, func)
             if result.get("verified"):
@@ -171,36 +201,28 @@ class SymbolicVerifier:
             counterexample_count == 0
         )
 
-        if all_verified:
-            status = "verified"
-            message = "All verifiable functions were proven symbolically."
-        elif counterexample_count > 0:
-            status = "counterexamples_found"
-            message = "CrossHair found counterexamples for one or more functions."
-        elif checked_count == 0:
-            status = "no_verifiable_functions"
-            message = "No typed functions could be symbolically verified."
-        elif skipped_count > 0 or unverifiable_count > 0:
-            status = "unverifiable"
-            message = "Symbolic verification was incomplete; at least one function could not be proven."
-        else:
-            status = "verification_error"
-            message = "Symbolic verification did not complete cleanly."
-        
         return {
-            "is_verified": all_verified,
-            "is_safe": all_verified,
-            "verified": all_verified,
-            "status": status,
-            "message": message,
-            "functions_checked": checked_count,
-            "functions_verified": verified_count,
-            "functions_skipped": skipped_count,
-            "functions_unverifiable": unverifiable_count,
+            "all_verified": all_verified,
+            "issues": issues,
+            "verified_count": verified_count,
+            "checked_count": checked_count,
+            "skipped_count": skipped_count,
+            "unverifiable_count": unverifiable_count,
+            "counterexample_count": counterexample_count,
             "functions_discovered": len(functions),
-            "counterexamples_found": counterexample_count,
-            "issues": issues
         }
+
+    def _derive_verification_outcome(self, summary: Dict[str, Any]) -> tuple[str, str]:
+        """Map aggregated counts to a final verification status and message."""
+        if summary["all_verified"]:
+            return "verified", "All verifiable functions were proven symbolically."
+        if summary["counterexample_count"] > 0:
+            return "counterexamples_found", "CrossHair found counterexamples for one or more functions."
+        if summary["checked_count"] == 0:
+            return "no_verifiable_functions", "No typed functions could be symbolically verified."
+        if summary["skipped_count"] > 0 or summary["unverifiable_count"] > 0:
+            return "unverifiable", "Symbolic verification was incomplete; at least one function could not be proven."
+        return "verification_error", "Symbolic verification did not complete cleanly."
     
     def _extract_functions(self, tree: ast.AST) -> List[Dict[str, Any]]:
         """Extract function names and info from AST."""

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -94,6 +94,8 @@ class SymbolicVerifier:
         if not self._crosshair_available:
             return {
                 "is_verified": False,
+                "is_safe": False,
+                "verified": False,
                 "status": "crosshair_not_available",
                 "message": "CrossHair not installed. Run: pip install crosshair-tool",
                 "issues": []
@@ -105,6 +107,8 @@ class SymbolicVerifier:
         except SyntaxError as e:
             return {
                 "is_verified": False,
+                "is_safe": False,
+                "verified": False,
                 "status": "syntax_error",
                 "message": str(e),
                 "issues": []
@@ -116,6 +120,8 @@ class SymbolicVerifier:
         if not functions:
             return {
                 "is_verified": False,
+                "is_safe": False,
+                "verified": False,
                 "status": "no_verifiable_functions",
                 "message": "No functions found to verify symbolically",
                 "issues": [{
@@ -168,21 +174,23 @@ class SymbolicVerifier:
         if all_verified:
             status = "verified"
             message = "All verifiable functions were proven symbolically."
+        elif counterexample_count > 0:
+            status = "counterexamples_found"
+            message = "CrossHair found counterexamples for one or more functions."
         elif checked_count == 0:
             status = "no_verifiable_functions"
             message = "No typed functions could be symbolically verified."
         elif skipped_count > 0 or unverifiable_count > 0:
             status = "unverifiable"
             message = "Symbolic verification was incomplete; at least one function could not be proven."
-        elif counterexample_count > 0:
-            status = "counterexamples_found"
-            message = "CrossHair found counterexamples for one or more functions."
         else:
             status = "verification_error"
             message = "Symbolic verification did not complete cleanly."
         
         return {
             "is_verified": all_verified,
+            "is_safe": all_verified,
+            "verified": all_verified,
             "status": status,
             "message": message,
             "functions_checked": checked_count,

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -138,7 +138,13 @@ class SymbolicVerifier:
             "verified": False,
             "status": status,
             "message": message,
-            "issues": []
+            "issues": [],
+            "functions_checked": 0,
+            "functions_verified": 0,
+            "functions_skipped": 0,
+            "functions_unverifiable": 0,
+            "functions_discovered": 0,
+            "counterexamples_found": 0,
         }
 
     def _no_verifiable_functions_result(self) -> Dict[str, Any]:

--- a/tests/test_symbolic_verifier.py
+++ b/tests/test_symbolic_verifier.py
@@ -156,6 +156,8 @@ print(x)
         with patch.object(self.verifier, "_crosshair_available", True):
             result = self.verifier.verify_code(code)
         assert result["is_verified"] is False
+        assert result["is_safe"] is False
+        assert result["verified"] is False
         assert result["status"] == "no_verifiable_functions"
         assert result["functions_discovered"] == 0
         assert result["functions_checked"] == 0
@@ -182,6 +184,8 @@ def add(x: int, y: int) -> int:
         result = self.verifier.verify_code(code)
         # Simple addition should verify
         assert result["functions_checked"] > 0
+        assert result["is_safe"] is result["is_verified"]
+        assert result["verified"] is result["is_verified"]
 
     def test_verify_untyped_function_fails_closed(self):
         """Untyped functions must not be reported as verified."""
@@ -244,6 +248,79 @@ def untyped_add(a, b):
         assert result["functions_verified"] == 1
         assert result["functions_skipped"] == 1
         assert result["functions_unverifiable"] == 1
+
+    def test_verify_counterexample_takes_precedence_over_unverifiable(self):
+        """Concrete counterexamples should outrank generic unverifiable status."""
+        code = """
+def typed_add(a: int, b: int) -> int:
+    return a + b
+
+def untyped_add(a, b):
+    return a + b
+"""
+        with patch.object(self.verifier, "_crosshair_available", True):
+            with patch.object(
+                self.verifier,
+                "_verify_function",
+                side_effect=[
+                    {
+                        "verified": False,
+                        "function": "typed_add",
+                        "skipped": False,
+                        "unverifiable": False,
+                        "issues": [{
+                            "type": "counterexample",
+                            "function": "typed_add",
+                            "description": "Counterexample found"
+                        }]
+                    },
+                    {
+                        "verified": False,
+                        "function": "untyped_add",
+                        "skipped": True,
+                        "unverifiable": True,
+                        "issues": [{
+                            "type": "unverifiable",
+                            "function": "untyped_add",
+                            "description": "Function skipped: no type annotations for symbolic verification"
+                        }]
+                    }
+                ]
+            ):
+                result = self.verifier.verify_code(code)
+
+        assert result["is_verified"] is False
+        assert result["status"] == "counterexamples_found"
+        assert result["functions_discovered"] == 2
+        assert result["functions_checked"] == 1
+        assert result["counterexamples_found"] == 1
+        assert result["functions_skipped"] == 1
+        assert result["functions_unverifiable"] == 1
+        assert result["functions_verified"] == 0
+
+    def test_verify_inconsistent_function_result_falls_back_to_verification_error(self):
+        """Unexpected verifier output must not silently pass or masquerade as another state."""
+        code = """
+def typed_add(a: int, b: int) -> int:
+    return a + b
+"""
+        with patch.object(self.verifier, "_crosshair_available", True):
+            with patch.object(
+                self.verifier,
+                "_verify_function",
+                return_value={
+                    "verified": False,
+                    "function": "typed_add",
+                    "skipped": False,
+                    "unverifiable": False,
+                    "issues": []
+                }
+            ):
+                result = self.verifier.verify_code(code)
+
+        assert result["is_verified"] is False
+        assert result["status"] == "verification_error"
+        assert result["message"] == "Symbolic verification did not complete cleanly."
 
     def test_skipped_function_result_is_not_marked_verified(self):
         """Function-level skip results must not claim successful verification."""

--- a/tests/test_symbolic_verifier.py
+++ b/tests/test_symbolic_verifier.py
@@ -162,8 +162,24 @@ print(x)
         assert result["functions_discovered"] == 0
         assert result["functions_checked"] == 0
         assert result["functions_verified"] == 0
+        assert result["functions_skipped"] == 0
         assert result["functions_unverifiable"] == 0
+        assert result["counterexamples_found"] == 0
         assert result["issues"][0]["type"] == "unverifiable"
+
+    def test_verify_crosshair_unavailable_returns_consistent_counts(self):
+        """CrossHair-unavailable terminal results should preserve the full result schema."""
+        with patch.object(self.verifier, "_crosshair_available", False):
+            result = self.verifier.verify_code("def add(x: int, y: int) -> int:\n    return x + y\n")
+
+        assert result["is_verified"] is False
+        assert result["status"] == "crosshair_not_available"
+        assert result["functions_checked"] == 0
+        assert result["functions_verified"] == 0
+        assert result["functions_skipped"] == 0
+        assert result["functions_unverifiable"] == 0
+        assert result["functions_discovered"] == 0
+        assert result["counterexamples_found"] == 0
 
     @pytest.mark.skipif(not _crosshair_available, reason="CrossHair not installed")
     def test_verify_syntax_error(self):
@@ -173,6 +189,12 @@ def broken(
 """
         result = self.verifier.verify_code(code)
         assert result["status"] == "syntax_error"
+        assert result["functions_checked"] == 0
+        assert result["functions_verified"] == 0
+        assert result["functions_skipped"] == 0
+        assert result["functions_unverifiable"] == 0
+        assert result["functions_discovered"] == 0
+        assert result["counterexamples_found"] == 0
     
     @pytest.mark.skipif(not _crosshair_available, reason="CrossHair not installed")
     def test_verify_simple_function(self):

--- a/tests/test_symbolic_verifier.py
+++ b/tests/test_symbolic_verifier.py
@@ -7,6 +7,7 @@ These tests verify the symbolic execution engine works correctly.
 import pytest
 import sys
 import os
+from unittest.mock import patch
 
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
@@ -146,16 +147,22 @@ class TestCodeVerification:
     def setup_method(self):
         self.verifier = SymbolicVerifier(timeout_seconds=5)
     
-    @pytest.mark.skipif(not _crosshair_available, reason="CrossHair not installed")
     def test_verify_no_functions(self):
-        """Test verification of code with no functions."""
+        """Code with no functions must fail closed, not pass as verified."""
         code = """
 x = 1 + 2
 print(x)
 """
-        result = self.verifier.verify_code(code)
-        assert result["status"] == "no_functions_to_check"
-    
+        with patch.object(self.verifier, "_crosshair_available", True):
+            result = self.verifier.verify_code(code)
+        assert result["is_verified"] is False
+        assert result["status"] == "no_verifiable_functions"
+        assert result["functions_discovered"] == 0
+        assert result["functions_checked"] == 0
+        assert result["functions_verified"] == 0
+        assert result["functions_unverifiable"] == 0
+        assert result["issues"][0]["type"] == "unverifiable"
+
     @pytest.mark.skipif(not _crosshair_available, reason="CrossHair not installed")
     def test_verify_syntax_error(self):
         """Test verification handles syntax errors."""
@@ -175,6 +182,78 @@ def add(x: int, y: int) -> int:
         result = self.verifier.verify_code(code)
         # Simple addition should verify
         assert result["functions_checked"] > 0
+
+    def test_verify_untyped_function_fails_closed(self):
+        """Untyped functions must not be reported as verified."""
+        code = """
+def add(a, b):
+    return a + b
+"""
+        with patch.object(self.verifier, "_crosshair_available", True):
+            result = self.verifier.verify_code(code)
+
+        assert result["is_verified"] is False
+        assert result["status"] == "no_verifiable_functions"
+        assert result["functions_discovered"] == 1
+        assert result["functions_checked"] == 0
+        assert result["functions_skipped"] == 1
+        assert result["functions_unverifiable"] == 1
+        assert result["functions_verified"] == 0
+        assert any(issue["function"] == "add" for issue in result["issues"])
+
+    def test_verify_mixed_typed_and_untyped_functions_remains_unverifiable(self):
+        """A skipped function must prevent an overall verified result."""
+        code = """
+def typed_add(a: int, b: int) -> int:
+    return a + b
+
+def untyped_add(a, b):
+    return a + b
+"""
+        with patch.object(self.verifier, "_crosshair_available", True):
+            with patch.object(
+                self.verifier,
+                "_verify_function",
+                side_effect=[
+                    {
+                        "verified": True,
+                        "function": "typed_add",
+                        "skipped": False,
+                        "unverifiable": False,
+                        "issues": []
+                    },
+                    {
+                        "verified": False,
+                        "function": "untyped_add",
+                        "skipped": True,
+                        "unverifiable": True,
+                        "issues": [{
+                            "type": "unverifiable",
+                            "function": "untyped_add",
+                            "description": "Function skipped: no type annotations for symbolic verification"
+                        }]
+                    }
+                ]
+            ):
+                result = self.verifier.verify_code(code)
+
+        assert result["is_verified"] is False
+        assert result["status"] == "unverifiable"
+        assert result["functions_discovered"] == 2
+        assert result["functions_checked"] == 1
+        assert result["functions_verified"] == 1
+        assert result["functions_skipped"] == 1
+        assert result["functions_unverifiable"] == 1
+
+    def test_skipped_function_result_is_not_marked_verified(self):
+        """Function-level skip results must not claim successful verification."""
+        func_info = {"name": "add", "has_types": False}
+        result = self.verifier._verify_function("def add(a, b):\n    return a + b\n", func_info)
+
+        assert result["verified"] is False
+        assert result["skipped"] is True
+        assert result["unverifiable"] is True
+        assert result["issues"][0]["type"] == "unverifiable"
 
 
 class TestContractVerification:


### PR DESCRIPTION
## Summary
This PR fixes issue #128 by making `SymbolicVerifier` fail closed when no actual symbolic proof is performed.

Previously, `verify_code()` could return pass-like results when:
- the input contained no functions
- functions were present but untyped and therefore not symbolically verifiable
- mixed typed/untyped code left some functions skipped

That allowed absence of proof to be surfaced as successful verification.

## What changed
- code with no functions now returns a non-pass `no_verifiable_functions` result
- untyped functions are now marked as skipped + unverifiable, not verified
- aggregation now distinguishes:
  - functions discovered
  - functions checked
  - functions verified
  - functions skipped
  - functions unverifiable
  - counterexamples found
- final `is_verified=True` now requires:
  - at least one function actually checked
  - all checked functions proven
  - no skipped/unverifiable functions
  - no counterexamples

## Why
A symbolic verifier must not convert “not checked” into “verified”.

If no symbolic proof was performed, or if any function could not be proven, the result must fail closed.

## Validation
- `python -m pytest tests/test_symbolic_verifier.py -q`
- `python -m pytest -q`

Closes #128


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Verification results now include detailed status messages and granular function counters (checked, skipped, unverifiable, and discovered functions).
  * Functions lacking type annotations are now correctly marked as unverifiable rather than verified.
  * Enhanced status reporting to distinguish between verification errors, unverifiable functions, and successful verification outcomes.
  * Counterexample counts are now explicitly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->