### PR TITLE
fix: fail closed secure executor safety fallback

### DIFF
--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -189,14 +189,24 @@ class SecureCodeExecutor:
             
         except ImportError:
             logger.error("CodeVerifier not available; blocking execution")
-            is_basic_safe, advisory_reason = self._basic_safety_check(code)
-            advisory_suffix = ""
-            if not is_basic_safe and advisory_reason:
-                advisory_suffix = f" Advisory-only fallback also flagged: {advisory_reason}"
-            return (
-                False,
-                f"CodeVerifier unavailable; cannot validate code safety.{advisory_suffix}",
+            return self._build_fail_closed_safety_denial(code)
+        except Exception as e:
+            logger.error(
+                "CodeVerifier failed during safety validation; blocking execution: %s",
+                _sanitize_log_msg(str(e)),
             )
+            return self._build_fail_closed_safety_denial(code)
+
+    def _build_fail_closed_safety_denial(self, code: str) -> Tuple[bool, str]:
+        """Return a deterministic fail-closed denial when CodeVerifier cannot be used."""
+        is_basic_safe, advisory_reason = self._basic_safety_check(code)
+        advisory_suffix = ""
+        if not is_basic_safe and advisory_reason:
+            advisory_suffix = f" Advisory-only fallback also flagged: {advisory_reason}"
+        return (
+            False,
+            f"CodeVerifier unavailable; cannot validate code safety.{advisory_suffix}",
+        )
     
     def _basic_safety_check(self, code: str) -> Tuple[bool, Optional[str]]:
         """Basic safety check if CodeVerifier is not available."""

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -188,9 +188,15 @@ class SecureCodeExecutor:
             return True, None
             
         except ImportError:
-            logger.warning("CodeVerifier not available, using basic validation")
-            # Fallback: basic keyword check
-            return self._basic_safety_check(code)
+            logger.error("CodeVerifier not available; blocking execution")
+            is_basic_safe, advisory_reason = self._basic_safety_check(code)
+            advisory_suffix = ""
+            if not is_basic_safe and advisory_reason:
+                advisory_suffix = f" Advisory-only fallback also flagged: {advisory_reason}"
+            return (
+                False,
+                f"CodeVerifier unavailable; cannot validate code safety.{advisory_suffix}",
+            )
     
     def _basic_safety_check(self, code: str) -> Tuple[bool, Optional[str]]:
         """Basic safety check if CodeVerifier is not available."""

--- a/tests/test_secure_executor_coverage.py
+++ b/tests/test_secure_executor_coverage.py
@@ -145,7 +145,7 @@ class TestSecureExecutorCoverage(unittest.TestCase):
             executor.client = MagicMock()
             executor.client.ping.return_value = None
 
-            success, error, result = executor.execute("import os; os.system('ls')", {})
+            success, error, result = executor.execute("import os; result = os.name", {})
 
             self.assertFalse(success)
             self.assertIn("CodeVerifier unavailable", error)
@@ -153,6 +153,15 @@ class TestSecureExecutorCoverage(unittest.TestCase):
             self.assertIn("dangerous operation", error)
             self.assertIsNone(result)
             executor.client.containers.run.assert_not_called()
+
+    def test_code_verifier_runtime_failure_fails_closed(self):
+        """Runtime failures inside CodeVerifier must block execution deterministically."""
+        executor = SecureCodeExecutor()
+        with patch("qwed_new.core.code_verifier.CodeVerifier.verify_code", side_effect=RuntimeError("engine down")):
+            is_safe, reason = executor._is_safe_code("print('hello')")
+
+        self.assertFalse(is_safe)
+        self.assertIn("CodeVerifier unavailable", reason)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_secure_executor_coverage.py
+++ b/tests/test_secure_executor_coverage.py
@@ -114,19 +114,45 @@ class TestSecureExecutorCoverage(unittest.TestCase):
         with self.assertRaises(ExecutionError):
             executor._run_in_container("/tmp", "exec_1")
 
-    def test_code_verifier_fallback_and_safety_check(self):
-        """Test fallback to basic safety check when CodeVerifier missing."""
-        # 1. Mock import error for CodeVerifier
+    def test_code_verifier_import_error_fails_closed(self):
+        """CodeVerifier import failures must block execution safety checks."""
         with patch.dict("sys.modules", {"qwed_new.core.code_verifier": None}):
-             executor = SecureCodeExecutor()
-             # 2. Test Safe Code
-             is_safe, _ = executor._is_safe_code("print('hello')")
-             self.assertTrue(is_safe)
-             
-             # 3. Test Unsafe Code (loop coverage)
-             is_safe, reason = executor._is_safe_code("import os; os.system('ls')")
-             self.assertFalse(is_safe)
-             self.assertIn("dangerous operation", reason)
+            executor = SecureCodeExecutor()
+
+            is_safe, reason = executor._is_safe_code("print('hello')")
+            self.assertFalse(is_safe)
+            self.assertIn("CodeVerifier unavailable", reason)
+
+    def test_execute_fails_closed_when_code_verifier_missing(self):
+        """Execution must not proceed when CodeVerifier cannot be imported."""
+        with patch.dict("sys.modules", {"qwed_new.core.code_verifier": None}):
+            executor = SecureCodeExecutor()
+            executor.client = MagicMock()
+            executor.client.ping.return_value = None
+
+            success, error, result = executor.execute("print('hello')", {})
+
+            self.assertFalse(success)
+            self.assertIn("Code safety validation failed", error)
+            self.assertIn("CodeVerifier unavailable", error)
+            self.assertIsNone(result)
+            executor.client.containers.run.assert_not_called()
+
+    def test_execute_import_error_returns_advisory_reason_without_authorizing(self):
+        """Heuristic fallback may inform the error but must never authorize execution."""
+        with patch.dict("sys.modules", {"qwed_new.core.code_verifier": None}):
+            executor = SecureCodeExecutor()
+            executor.client = MagicMock()
+            executor.client.ping.return_value = None
+
+            success, error, result = executor.execute("import os; os.system('ls')", {})
+
+            self.assertFalse(success)
+            self.assertIn("CodeVerifier unavailable", error)
+            self.assertIn("Advisory-only fallback also flagged", error)
+            self.assertIn("dangerous operation", error)
+            self.assertIsNone(result)
+            executor.client.containers.run.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
This PR fixes issue #166 by making `SecureCodeExecutor` fail closed when `CodeVerifier` is unavailable.

Previously, an import failure in the primary code safety verifier caused the executor to fall back to a basic keyword check that could still authorize execution. That weakened the execution boundary from structured verification to heuristic filtering.

## What changed
- removed the permissive execution path that used `_basic_safety_check()` as an authorization fallback
- `CodeVerifier` import failure now blocks execution with a fail-closed safety result
- kept the basic keyword scan as advisory-only context in the error message
- added regressions proving:
  - import failure blocks even otherwise safe code
  - execution does not reach `containers.run()` when the verifier is unavailable
  - advisory fallback can add context without authorizing execution

## Why
If the primary verification boundary is unavailable, execution must not proceed.

A heuristic blacklist may be useful for diagnostics, but it must not replace the main verifier as an execution gate.

## Validation
- `tests/test_secure_executor_coverage.py`
- `tests/test_secure_executor.py`
- `tests/test_pr117_regressions.py`

Closes #166


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced code execution security by enforcing stricter validation policies when verification tools become unavailable. The system now blocks execution in these scenarios rather than falling back to basic checks, improving overall safety and protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->