### PR TITLE
test: exercise release boundary manifest block

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include private-key.pem


### PR DESCRIPTION
## Summary
This draft PR intentionally exercises QWED Security's ReleaseBoundaryGuard by adding a `MANIFEST.in` entry that includes a sensitive-looking artifact path.

## What changed
- added `MANIFEST.in`
- added `include private-key.pem` as a deterministic release-boundary trigger

## Why
This PR is a controlled validation of QWED Security's release-boundary enforcement.

Expected behavior:
- QWED Security should block the PR
- the blocker should come from `ReleaseBoundaryGuard`
- the finding should explain that the manifest can include sensitive material in the published artifact

## Validation target
This PR should confirm that release-boundary checks are working end-to-end on GitHub, not just in local tests.

## Notes
- This PR is intentionally unsafe and should not be merged
- it exists only to verify the release-boundary enforcement path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->