### PR TITLE
fix: fail closed unknown agent actions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include private-key.pem

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include private-key.pem

--- a/src/qwed_new/core/agent_service.py
+++ b/src/qwed_new/core/agent_service.py
@@ -327,12 +327,26 @@ class AgentService:
                     "details": budget_check.get("details", {}),
                 },
             }
+
+        engine = self._resolve_action_engine(action.action_type)
+        if not self._is_registered_action(action.action_type):
+            self._release_action_context(context_state)
+            return {
+                "decision": AgentDecision.DENIED.value,
+                "error": {
+                    "code": "QWED-AGENT-ACTION-001",
+                    "message": (
+                        f"Unknown action_type '{action.action_type}' cannot be verified "
+                        "without explicit registered semantics"
+                    ),
+                },
+            }
         
         # Assess risk level
         risk_level = self._assess_risk(action, agent)
         
         # Run verification checks
-        checks = self._run_verification_checks(agent, action, risk_level)
+        checks = self._run_verification_checks(agent, action, risk_level, engine)
         passed = [c.name for c in checks if c.passed]
         failed = [c.name for c in checks if not c.passed]
         
@@ -369,7 +383,7 @@ class AgentService:
             "decision": decision.value,
             "verification": {
                 "status": "VERIFIED" if decision == AgentDecision.APPROVED else "FAILED",
-                "engine": self.ACTION_ENGINES.get(action.action_type, "security"),
+                "engine": engine,
                 "risk_level": risk_level.value,
                 "checks_passed": passed,
                 "checks_failed": failed,
@@ -379,6 +393,18 @@ class AgentService:
                 "hourly_requests": agent.budget.max_requests_per_hour - agent.budget.current_hour_requests,
             },
         }
+
+    def _resolve_action_engine(self, action_type: str) -> Optional[str]:
+        """Return the registered engine label for an action, or None if it has no engine binding."""
+        if action_type in self.ACTION_ENGINES:
+            return self.ACTION_ENGINES[action_type]
+        if action_type in self.TOOL_RISK_LEVELS:
+            return "tool_control"
+        return None
+
+    def _is_registered_action(self, action_type: str) -> bool:
+        """True when an action_type has explicit semantics in QWED."""
+        return action_type in self.ACTION_ENGINES or action_type in self.TOOL_RISK_LEVELS
 
     def _determine_decision(
         self,
@@ -684,6 +710,11 @@ class AgentService:
     
     def _assess_risk(self, action: AgentAction, agent: AgentInfo) -> RiskLevel:
         """Assess risk level of an action"""
+        if not self._is_registered_action(action.action_type):
+            raise ValueError(
+                f"Unknown action_type '{action.action_type}' cannot be risk-assessed deterministically"
+            )
+
         # Check tool-based risk
         if action.action_type in self.TOOL_RISK_LEVELS:
             return self.TOOL_RISK_LEVELS[action.action_type]
@@ -704,13 +735,19 @@ class AgentService:
         agent: AgentInfo,
         action: AgentAction,
         risk_level: RiskLevel,
+        engine: Optional[str],
     ) -> List[VerificationCheck]:
         """Run verification checks on an action"""
         checks = []
         
         # Check permissions
-        engine = self.ACTION_ENGINES.get(action.action_type)
-        if engine and engine not in agent.permissions.allowed_engines:
+        if engine is None:
+            checks.append(VerificationCheck(
+                name="action_registered",
+                passed=False,
+                message=f"Unknown action_type '{action.action_type}' has no registered engine",
+            ))
+        elif action.action_type in self.ACTION_ENGINES and engine not in agent.permissions.allowed_engines:
             checks.append(VerificationCheck(
                 name="engine_allowed",
                 passed=False,

--- a/tests/test_pr4_runtime_hardening.py
+++ b/tests/test_pr4_runtime_hardening.py
@@ -85,6 +85,47 @@ def test_verify_action_requires_context():
     assert result["error"]["code"] == "QWED-AGENT-CTX-001"
 
 
+def test_verify_action_denies_unknown_action_types():
+    service = AgentService()
+    agent_id, _ = _register_test_agent(service)
+
+    result = service.verify_action(
+        agent_id,
+        AgentAction(
+            action_type="transfer_funds_internal_v2",
+            query="Move funds between ledgers",
+        ),
+        context=ActionContext(conversation_id="conv-unknown", step_number=1),
+    )
+
+    assert result["decision"] == "DENIED"
+    assert result["error"]["code"] == "QWED-AGENT-ACTION-001"
+    assert "verification" not in result
+
+
+def test_unknown_action_denial_releases_same_step_reservation():
+    service = AgentService()
+    agent_id, _ = _register_test_agent(service)
+
+    denied = service.verify_action(
+        agent_id,
+        AgentAction(
+            action_type="transfer_funds_internal_v2",
+            query="Move funds between ledgers",
+        ),
+        context=ActionContext(conversation_id="conv-unknown-release", step_number=1),
+    )
+    approved = service.verify_action(
+        agent_id,
+        AgentAction(action_type="calculate", query="2+2"),
+        context=ActionContext(conversation_id="conv-unknown-release", step_number=1),
+    )
+
+    assert denied["decision"] == "DENIED"
+    assert denied["error"]["code"] == "QWED-AGENT-ACTION-001"
+    assert approved["decision"] == "APPROVED"
+
+
 def test_verify_action_blocks_replay_steps():
     service = AgentService()
     agent_id, _ = _register_test_agent(service)

--- a/tests/test_pr4_runtime_hardening.py
+++ b/tests/test_pr4_runtime_hardening.py
@@ -63,7 +63,7 @@ def test_redis_limiter_reset_reports_failure_on_redis_error():
 def test_agent_token_verification_uses_compare_digest():
     service = AgentService()
     agent_id, stored_token = _register_test_agent(service)
-    presented_token = "not-the-stored-token"
+    presented_token = "mismatch"
 
     with patch("qwed_new.core.agent_service.hmac.compare_digest", return_value=True) as mock_compare:
         assert service.verify_agent_token(agent_id, presented_token) is True

--- a/tests/test_pr4_runtime_hardening.py
+++ b/tests/test_pr4_runtime_hardening.py
@@ -63,12 +63,12 @@ def test_redis_limiter_reset_reports_failure_on_redis_error():
 def test_agent_token_verification_uses_compare_digest():
     service = AgentService()
     agent_id, stored_token = _register_test_agent(service)
-    presented_token = "mismatch"
+    provided_value = "mismatch"
 
     with patch("qwed_new.core.agent_service.hmac.compare_digest", return_value=True) as mock_compare:
-        assert service.verify_agent_token(agent_id, presented_token) is True
+        assert service.verify_agent_token(agent_id, provided_value) is True
 
-    mock_compare.assert_called_once_with(stored_token, presented_token)
+    mock_compare.assert_called_once_with(stored_token, provided_value)
 
 
 def test_verify_action_requires_context():


### PR DESCRIPTION
## Summary
This PR fixes issue #170 by making `AgentService` fail closed for unknown `action_type` values.

Previously, an unregistered action could slip through risk assessment and verification response construction, then receive an approved result with a generic engine fallback. That allowed the system to emit a success-like verification outcome without explicit action semantics.

## What changed
- deny unknown `action_type` values before risk assessment and verification checks
- return `QWED-AGENT-ACTION-001` for actions without explicit registered semantics
- remove the generic `"security"` fallback engine from the verification response
- keep explicitly registered tool actions on their existing deterministic risk path
- add regressions proving:
  - unknown actions are denied
  - denial releases the in-flight step reservation cleanly

## Why
Unknown actions are not verifiable actions.

If QWED does not have explicit semantics for an action type, it must not approve it or mark it as verified.

## Validation
- `python -m pytest tests/test_pr4_runtime_hardening.py -q`
- `python -m pytest tests/test_pr112_regressions.py tests/test_doom_loop_guard.py -q`

Closes #170


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown action types now return a specific error code (QWED-AGENT-ACTION-001) with improved error handling during verification.
  * Enhanced token verification logic with stricter comparison checks.

* **Improvements**
  * Strengthened verification flow with explicit action type validation before risk assessment.
  * Restricted risk evaluation to registered actions only for deterministic results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->