### PR TITLE
fix: require complete reasoning proof prerequisites

### DIFF
--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -80,9 +80,18 @@ class ReasoningVerifier:
         "percentage": ["percent", "%", "percentage", "rate"],
     }
     
-    # Cache for semantic parsing (LRU cache)
-    _cache: Dict[str, ReasoningValidation] = {}
     _cache_max_size: int = 1000
+    NON_SUBSTANTIVE_TRACE_MARKERS = (
+        "no llm provider",
+        "could not generate reasoning trace",
+        "no structured reasoning trace generated",
+        "failed to generate reasoning trace",
+        "n/a",
+        "unavailable",
+        "no reasoning",
+        "rate limit exceeded",
+    )
+
     def __init__(
         self, 
         providers: Optional[List[str]] = None,
@@ -103,6 +112,7 @@ class ReasoningVerifier:
         self.provider_names = providers or ["anthropic"]
         self.enable_cache = enable_cache
         self.cache_ttl = cache_ttl_seconds
+        self._cache: Dict[str, ReasoningValidation] = {}
         
         # Lazy-loaded providers
         self._providers: Dict[str, Any] = {}
@@ -400,7 +410,14 @@ class ReasoningVerifier:
 
         substantive = [
             entry for entry in reasoning_trace
-            if entry and (entry[0].isdigit() or entry.startswith("-"))
+            if (
+                entry
+                and (entry[0].isdigit() or entry.startswith("-"))
+                and not any(
+                    marker in entry.strip().lower()
+                    for marker in self.NON_SUBSTANTIVE_TRACE_MARKERS
+                )
+            )
         ]
         if not substantive:
             return ["Reasoning trace unavailable or non-substantive"]
@@ -633,7 +650,7 @@ Format as a numbered list."""
             [
                 query,
                 formula,
-                ",".join(self.provider_names),
+                ",".join(sorted(self.provider_names)),
                 "cross_validation=on" if enable_cross_validation else "cross_validation=off",
             ]
         )

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -19,7 +19,7 @@ import operator
 import re
 import hashlib
 from typing import Dict, Any, List, Optional, Callable
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 import time
 
 logger = logging.getLogger(__name__)
@@ -82,13 +82,6 @@ class ReasoningVerifier:
     # Cache for semantic parsing (LRU cache)
     _cache: Dict[str, ReasoningValidation] = {}
     _cache_max_size: int = 1000
-    NON_SUBSTANTIVE_TRACE_MARKERS = (
-        "No LLM provider available for reasoning trace",
-        "Could not generate reasoning trace",
-        "No structured reasoning trace generated",
-        "Failed to generate reasoning trace:",
-    )
-    
     def __init__(
         self, 
         providers: Optional[List[str]] = None,
@@ -209,7 +202,7 @@ class ReasoningVerifier:
         )
         if self.enable_cache and cache_key in self._cache:
             cached = self._cache[cache_key]
-            return replace(cached, cached=True)
+            return self._clone_cached_result(cached)
         
         issues = []
         
@@ -400,14 +393,16 @@ class ReasoningVerifier:
         return issues
 
     def _validate_reasoning_trace(self, reasoning_trace: List[str]) -> List[str]:
-        """Fail closed when the reasoning trace is unavailable or non-substantive."""
+        """Fail closed when the reasoning trace lacks substantive reasoning steps."""
         if not reasoning_trace:
             return ["Reasoning trace missing"]
 
-        for entry in reasoning_trace:
-            if any(entry.startswith(marker) for marker in self.NON_SUBSTANTIVE_TRACE_MARKERS):
-                return ["Reasoning trace unavailable or non-substantive"]
-
+        substantive = [
+            entry for entry in reasoning_trace
+            if entry and (entry[0].isdigit() or entry.startswith("-"))
+        ]
+        if not substantive:
+            return ["Reasoning trace unavailable or non-substantive"]
         return []
     
     # =========================================================================
@@ -648,6 +643,20 @@ Format as a numbered list."""
                 del self._cache[k]
         
         self._cache[key] = result
+
+    def _clone_cached_result(self, cached: ReasoningValidation) -> ReasoningValidation:
+        """Return an immutable-style copy of a cached validation result."""
+        return ReasoningValidation(
+            is_valid=cached.is_valid,
+            confidence=cached.confidence,
+            reasoning_trace=list(cached.reasoning_trace),
+            issues=list(cached.issues),
+            primary_formula=cached.primary_formula,
+            alternative_formula=cached.alternative_formula,
+            semantic_facts=dict(cached.semantic_facts) if cached.semantic_facts is not None else None,
+            cached=True,
+            verification_time_ms=cached.verification_time_ms,
+        )
     
     def clear_cache(self):
         """

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -82,6 +82,12 @@ class ReasoningVerifier:
     # Cache for semantic parsing (LRU cache)
     _cache: Dict[str, ReasoningValidation] = {}
     _cache_max_size: int = 1000
+    NON_SUBSTANTIVE_TRACE_MARKERS = (
+        "No LLM provider available for reasoning trace",
+        "Could not generate reasoning trace",
+        "No structured reasoning trace generated",
+        "Failed to generate reasoning trace:",
+    )
     
     def __init__(
         self, 
@@ -165,8 +171,7 @@ class ReasoningVerifier:
             provider = self._get_provider(name)
             if provider and provider != primary:
                 return provider
-        # If only one provider, return it anyway
-        return primary
+        return None
     
     # =========================================================================
     # Main Verification
@@ -215,6 +220,7 @@ class ReasoningVerifier:
         
         # 3. Generate reasoning trace from primary LLM
         reasoning_trace = self._generate_reasoning_trace(query, primary_task)
+        issues.extend(self._validate_reasoning_trace(reasoning_trace))
         
         # 4. Validate formula semantics
         formula_issues = self._validate_formula_semantics(facts, primary_task.expression)
@@ -222,11 +228,15 @@ class ReasoningVerifier:
         
         # 5. Cross-validate with secondary LLM
         alternative_formula = None
-        if enable_cross_validation and self.secondary_llm:
-            alt_result = self._cross_validate(query, primary_task.expression)
-            alternative_formula = alt_result.get("formula")
-            if alt_result.get("issues"):
-                issues.extend(alt_result["issues"])
+        if enable_cross_validation:
+            secondary = self.secondary_llm
+            if not secondary:
+                issues.append("Cross-validation requested but no distinct secondary provider is available")
+            else:
+                alt_result = self._cross_validate(query, primary_task.expression)
+                alternative_formula = alt_result.get("formula")
+                if alt_result.get("issues"):
+                    issues.extend(alt_result["issues"])
         
         # 6. Calculate confidence
         confidence = self._calculate_confidence(issues, facts, reasoning_trace, cot_steps)
@@ -385,6 +395,17 @@ class ReasoningVerifier:
             issues.append("No reasoning steps found for complex operation")
         
         return issues
+
+    def _validate_reasoning_trace(self, reasoning_trace: List[str]) -> List[str]:
+        """Fail closed when the reasoning trace is unavailable or non-substantive."""
+        if not reasoning_trace:
+            return ["Reasoning trace missing"]
+
+        for entry in reasoning_trace:
+            if any(entry.startswith(marker) for marker in self.NON_SUBSTANTIVE_TRACE_MARKERS):
+                return ["Reasoning trace unavailable or non-substantive"]
+
+        return []
     
     # =========================================================================
     # Reasoning Trace Generation

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -445,7 +445,11 @@ Format as a numbered list."""
             
             # Parse into list
             lines = trace_text.split('\n')
-            trace = [line.strip() for line in lines if line.strip() and (line[0].isdigit() or line.startswith('-'))]
+            trace = []
+            for line in lines:
+                stripped = line.strip()
+                if stripped and (stripped[0].isdigit() or stripped.startswith('-')):
+                    trace.append(stripped)
             
             return trace if trace else ["No structured reasoning trace generated"]
             

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -19,7 +19,7 @@ import operator
 import re
 import hashlib
 from typing import Dict, Any, List, Optional, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import time
 
 logger = logging.getLogger(__name__)
@@ -209,8 +209,7 @@ class ReasoningVerifier:
         )
         if self.enable_cache and cache_key in self._cache:
             cached = self._cache[cache_key]
-            cached.cached = True
-            return cached
+            return replace(cached, cached=True)
         
         issues = []
         

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -13,6 +13,7 @@ Enhanced Features:
 """
 
 import ast
+import copy
 from decimal import Decimal, localcontext
 import logging
 import operator
@@ -642,20 +643,30 @@ Format as a numbered list."""
             for k in oldest_keys:
                 del self._cache[k]
         
-        self._cache[key] = result
+        self._cache[key] = self._clone_result(result, cached=False)
 
     def _clone_cached_result(self, cached: ReasoningValidation) -> ReasoningValidation:
         """Return an immutable-style copy of a cached validation result."""
+        cloned = self._clone_result(cached, cached=True)
+        return cloned
+
+    def _clone_result(
+        self,
+        source: ReasoningValidation,
+        *,
+        cached: bool,
+    ) -> ReasoningValidation:
+        """Return a defensive copy of a validation result."""
         return ReasoningValidation(
-            is_valid=cached.is_valid,
-            confidence=cached.confidence,
-            reasoning_trace=list(cached.reasoning_trace),
-            issues=list(cached.issues),
-            primary_formula=cached.primary_formula,
-            alternative_formula=cached.alternative_formula,
-            semantic_facts=dict(cached.semantic_facts) if cached.semantic_facts is not None else None,
-            cached=True,
-            verification_time_ms=cached.verification_time_ms,
+            is_valid=source.is_valid,
+            confidence=source.confidence,
+            reasoning_trace=copy.deepcopy(source.reasoning_trace),
+            issues=copy.deepcopy(source.issues),
+            primary_formula=source.primary_formula,
+            alternative_formula=source.alternative_formula,
+            semantic_facts=copy.deepcopy(source.semantic_facts),
+            cached=cached,
+            verification_time_ms=source.verification_time_ms,
         )
     
     def clear_cache(self):

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -202,7 +202,11 @@ class ReasoningVerifier:
         start_time = time.time()
         
         # Check cache first
-        cache_key = self._get_cache_key(query, primary_task.expression)
+        cache_key = self._get_cache_key(
+            query,
+            primary_task.expression,
+            enable_cross_validation=enable_cross_validation,
+        )
         if self.enable_cache and cache_key in self._cache:
             cached = self._cache[cache_key]
             cached.cached = True
@@ -618,9 +622,22 @@ Format as a numbered list."""
     # Caching
     # =========================================================================
     
-    def _get_cache_key(self, query: str, formula: str) -> str:
-        """Generate cache key for query + formula."""
-        content = f"{query}||{formula}"
+    def _get_cache_key(
+        self,
+        query: str,
+        formula: str,
+        *,
+        enable_cross_validation: bool,
+    ) -> str:
+        """Generate cache key for the full verification mode."""
+        content = "||".join(
+            [
+                query,
+                formula,
+                ",".join(self.provider_names),
+                "cross_validation=on" if enable_cross_validation else "cross_validation=off",
+            ]
+        )
         return hashlib.sha256(content.encode()).hexdigest()[:16]
     
     def _cache_result(self, key: str, result: ReasoningValidation):

--- a/tests/test_pr112_regressions.py
+++ b/tests/test_pr112_regressions.py
@@ -167,6 +167,26 @@ def test_reasoning_verifier_accepts_indented_numbered_trace():
     assert result.reasoning_trace == ["1. Extract 10 and 5", "2. Add them to get 15"]
 
 
+def test_reasoning_verifier_rejects_numbered_placeholder_trace():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. N/A\n2. unavailable"
+
+    verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=False)
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="10 + 5", reasoning="1. Add 10 and 5")
+
+    result = verifier.verify_understanding(
+        query="Alice has 10 apples and gets 5 more. How many apples does she have?",
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert result.is_valid is False
+    assert "Reasoning trace unavailable or non-substantive" in result.issues
+
+
 def test_reasoning_verifier_cache_miss_result_does_not_mutate_cached_copy():
     class DummyProvider:
         def complete(self, _prompt):
@@ -197,6 +217,36 @@ def test_reasoning_verifier_cache_miss_result_does_not_mutate_cached_copy():
     assert second.cached is True
     assert "caller mutation" not in second.issues
     assert "999. fake step" not in second.reasoning_trace
+
+
+def test_reasoning_verifier_cache_is_not_shared_between_instances():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 10 and 5\n2. Add them to get 15"
+
+    first_verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=True)
+    second_verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=True)
+    first_verifier.clear_cache()
+    second_verifier.clear_cache()
+    first_verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+    second_verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="10 + 5", reasoning="1. Add 10 and 5")
+    query = "Alice has 10 apples and gets 5 more. How many apples does she have?"
+
+    first_result = first_verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+    second_result = second_verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert first_result.cached is False
+    assert second_result.cached is False
 
 
 def test_reasoning_verifier_cache_separates_cross_validation_modes():

--- a/tests/test_pr112_regressions.py
+++ b/tests/test_pr112_regressions.py
@@ -130,6 +130,65 @@ def test_reasoning_verifier_requires_distinct_cross_validation_provider():
     assert "Cross-validation requested but no distinct secondary provider is available" in result.issues
 
 
+def test_reasoning_verifier_cache_separates_cross_validation_modes():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 10 and 5\n2. Add them to get 15"
+
+    verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=True)
+    verifier.clear_cache()
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="10 + 5", reasoning="1. Add 10 and 5")
+    query = "Alice has 10 apples and gets 5 more. How many apples does she have?"
+
+    without_cross_validation = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+    with_cross_validation = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=True,
+    )
+
+    assert without_cross_validation.is_valid is True
+    assert without_cross_validation.cached is False
+    assert with_cross_validation.is_valid is False
+    assert with_cross_validation.cached is False
+    assert "Cross-validation requested but no distinct secondary provider is available" in with_cross_validation.issues
+
+
+def test_reasoning_verifier_returns_cached_result_for_same_verification_mode():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 10 and 5\n2. Add them to get 15"
+
+    verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=True)
+    verifier.clear_cache()
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="10 + 5", reasoning="1. Add 10 and 5")
+    query = "Alice has 10 apples and gets 5 more. How many apples does she have?"
+
+    first = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+    second = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert first.is_valid is True
+    assert first.cached is True
+    assert second.is_valid is True
+    assert second.cached is True
+
+
 def test_symbolic_verifier_reports_bounds_transform_error(monkeypatch):
     verifier = SymbolicVerifier()
     code = """

--- a/tests/test_pr112_regressions.py
+++ b/tests/test_pr112_regressions.py
@@ -94,6 +94,42 @@ def test_reasoning_verifier_safe_arithmetic_and_fallback():
     assert verifier._formulas_equivalent("1/0", "1") is False
 
 
+def test_reasoning_verifier_fails_closed_without_trace_provider():
+    verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=False)
+    verifier._provider_loaders["anthropic"] = lambda: None
+
+    task = SimpleNamespace(expression="10 + 5", reasoning="")
+
+    result = verifier.verify_understanding(
+        query="Alice has 10 apples and gets 5 more. How many apples does she have?",
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert result.is_valid is False
+    assert "Reasoning trace unavailable or non-substantive" in result.issues
+
+
+def test_reasoning_verifier_requires_distinct_cross_validation_provider():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 10 and 5\n2. Add them to get 15"
+
+    verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=False)
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="10 + 5", reasoning="1. Add 10 and 5")
+
+    result = verifier.verify_understanding(
+        query="Alice has 10 apples and gets 5 more. How many apples does she have?",
+        primary_task=task,
+        enable_cross_validation=True,
+    )
+
+    assert result.is_valid is False
+    assert "Cross-validation requested but no distinct secondary provider is available" in result.issues
+
+
 def test_symbolic_verifier_reports_bounds_transform_error(monkeypatch):
     verifier = SymbolicVerifier()
     code = """

--- a/tests/test_pr112_regressions.py
+++ b/tests/test_pr112_regressions.py
@@ -184,9 +184,10 @@ def test_reasoning_verifier_returns_cached_result_for_same_verification_mode():
     )
 
     assert first.is_valid is True
-    assert first.cached is True
+    assert first.cached is False
     assert second.is_valid is True
     assert second.cached is True
+    assert second is not first
 
 
 def test_symbolic_verifier_reports_bounds_transform_error(monkeypatch):

--- a/tests/test_pr112_regressions.py
+++ b/tests/test_pr112_regressions.py
@@ -134,7 +134,7 @@ def test_reasoning_verifier_rejects_unstructured_failure_trace():
     verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=False)
     task = SimpleNamespace(expression="10 + 5", reasoning="")
 
-    verifier._provider_loaders["anthropic"] = lambda: object()
+    verifier._provider_loaders["anthropic"] = object
     verifier._generate_reasoning_trace = lambda _query, _task: ["Rate limit exceeded, trace unavailable"]
 
     result = verifier.verify_understanding(
@@ -145,6 +145,38 @@ def test_reasoning_verifier_rejects_unstructured_failure_trace():
 
     assert result.is_valid is False
     assert "Reasoning trace unavailable or non-substantive" in result.issues
+
+
+def test_reasoning_verifier_cache_miss_result_does_not_mutate_cached_copy():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 10 and 5\n2. Add them to get 15"
+
+    verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=True)
+    verifier.clear_cache()
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="10 + 5", reasoning="1. Add 10 and 5")
+    query = "Alice has 10 apples and gets 5 more. How many apples does she have?"
+
+    first = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+    first.issues.append("caller mutation")
+    first.reasoning_trace.append("999. fake step")
+
+    second = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert first.cached is False
+    assert second.cached is True
+    assert "caller mutation" not in second.issues
+    assert "999. fake step" not in second.reasoning_trace
 
 
 def test_reasoning_verifier_cache_separates_cross_validation_modes():

--- a/tests/test_pr112_regressions.py
+++ b/tests/test_pr112_regressions.py
@@ -147,6 +147,26 @@ def test_reasoning_verifier_rejects_unstructured_failure_trace():
     assert "Reasoning trace unavailable or non-substantive" in result.issues
 
 
+def test_reasoning_verifier_accepts_indented_numbered_trace():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "  1. Extract 10 and 5\n    2. Add them to get 15"
+
+    verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=False)
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="10 + 5", reasoning="1. Add 10 and 5")
+
+    result = verifier.verify_understanding(
+        query="Alice has 10 apples and gets 5 more. How many apples does she have?",
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert result.is_valid is True
+    assert result.reasoning_trace == ["1. Extract 10 and 5", "2. Add them to get 15"]
+
+
 def test_reasoning_verifier_cache_miss_result_does_not_mutate_cached_copy():
     class DummyProvider:
         def complete(self, _prompt):

--- a/tests/test_pr112_regressions.py
+++ b/tests/test_pr112_regressions.py
@@ -130,6 +130,23 @@ def test_reasoning_verifier_requires_distinct_cross_validation_provider():
     assert "Cross-validation requested but no distinct secondary provider is available" in result.issues
 
 
+def test_reasoning_verifier_rejects_unstructured_failure_trace():
+    verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=False)
+    task = SimpleNamespace(expression="10 + 5", reasoning="")
+
+    verifier._provider_loaders["anthropic"] = lambda: object()
+    verifier._generate_reasoning_trace = lambda _query, _task: ["Rate limit exceeded, trace unavailable"]
+
+    result = verifier.verify_understanding(
+        query="Alice has 10 apples and gets 5 more. How many apples does she have?",
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert result.is_valid is False
+    assert "Reasoning trace unavailable or non-substantive" in result.issues
+
+
 def test_reasoning_verifier_cache_separates_cross_validation_modes():
     class DummyProvider:
         def complete(self, _prompt):


### PR DESCRIPTION
## Summary
This PR fixes issue #171 by making `ReasoningVerifier` fail closed when required proof prerequisites are missing.

Previously, reasoning validation could still return a valid result when no usable reasoning trace was available or when cross-validation was requested but no distinct secondary provider existed.

## What changed
- require a substantive reasoning trace before reasoning verification can pass
- treat placeholder or failure trace outputs as blocking issues
- require a distinct secondary provider when cross-validation is requested
- stop treating the primary provider as a fallback secondary cross-validation path
- add regressions proving:
  - missing trace provider fails closed
  - cross-validation without a distinct secondary provider fails closed

## Why
Absence of issues is not proof.

If QWED cannot produce the required reasoning evidence or cannot actually run cross-validation, the result must not be marked valid.

## Validation
- `python -m pytest tests/test_pr112_regressions.py -q`
- `python -m pytest tests/test_unused_import_cleanup_regressions.py -q`

Closes #171


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Flags incomplete or non‑substantive reasoning traces and rejects unstructured/invalid traces.
  * Prevents silent fallback to the primary validator when a distinct secondary validator is requested; records an explanatory issue.
  * Ensures cached verification results are returned as defensive copies to avoid accidental mutation and mode leakage.

* **Chores**
  * Cache keys now distinguish cross‑validation mode and validator configuration.

* **Tests**
  * Added tests for reasoning parsing, cross‑validation requirements, cache immutability, and cache isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->