### PR TITLE
fix: bind reasoning cache to verification context

### DIFF
--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -658,7 +658,7 @@ Format as a numbered list."""
             [
                 query,
                 formula,
-                ",".join(sorted(self.provider_names)),
+                ",".join(self.provider_names),
                 "cross_validation=on" if enable_cross_validation else "cross_validation=off",
             ]
         )

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -13,6 +13,7 @@ Enhanced Features:
 """
 
 import ast
+import copy
 from decimal import Decimal, localcontext
 import logging
 import operator
@@ -37,6 +38,13 @@ class ReasoningValidation:
     semantic_facts: Optional[Dict[str, Any]] = None
     cached: bool = False
     verification_time_ms: float = 0.0
+
+
+@dataclass
+class ReasoningCacheEntry:
+    """A cached reasoning validation bound to its creation time."""
+    result: ReasoningValidation
+    created_at: float
 
 
 @dataclass
@@ -79,8 +87,6 @@ class ReasoningVerifier:
         "percentage": ["percent", "%", "percentage", "rate"],
     }
     
-    # Cache for semantic parsing (LRU cache)
-    _cache: Dict[str, ReasoningValidation] = {}
     _cache_max_size: int = 1000
     
     def __init__(
@@ -103,6 +109,7 @@ class ReasoningVerifier:
         self.provider_names = providers or ["anthropic"]
         self.enable_cache = enable_cache
         self.cache_ttl = cache_ttl_seconds
+        self._cache: Dict[str, ReasoningCacheEntry] = {}
         
         # Lazy-loaded providers
         self._providers: Dict[str, Any] = {}
@@ -197,11 +204,15 @@ class ReasoningVerifier:
         start_time = time.time()
         
         # Check cache first
-        cache_key = self._get_cache_key(query, primary_task.expression)
-        if self.enable_cache and cache_key in self._cache:
-            cached = self._cache[cache_key]
-            cached.cached = True
-            return cached
+        cache_key = self._get_cache_key(
+            query,
+            primary_task.expression,
+            enable_cross_validation=enable_cross_validation,
+        )
+        if self.enable_cache:
+            cached_result = self._get_cached_result(cache_key, start_time)
+            if cached_result is not None:
+                return cached_result
         
         issues = []
         
@@ -597,11 +608,34 @@ Format as a numbered list."""
     # Caching
     # =========================================================================
     
-    def _get_cache_key(self, query: str, formula: str) -> str:
-        """Generate cache key for query + formula."""
-        content = f"{query}||{formula}"
+    def _get_cache_key(
+        self,
+        query: str,
+        formula: str,
+        *,
+        enable_cross_validation: bool,
+    ) -> str:
+        """Generate a cache key bound to verification context."""
+        content = "||".join(
+            [
+                query,
+                formula,
+                ",".join(sorted(self.provider_names)),
+                "cross_validation=on" if enable_cross_validation else "cross_validation=off",
+            ]
+        )
         return hashlib.sha256(content.encode()).hexdigest()[:16]
-    
+
+    def _get_cached_result(self, key: str, now: float) -> Optional[ReasoningValidation]:
+        """Return a cached result only if it is still fresh."""
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        if now - entry.created_at > self.cache_ttl:
+            del self._cache[key]
+            return None
+        return self._clone_result(entry.result, cached=True)
+
     def _cache_result(self, key: str, result: ReasoningValidation):
         """Cache a result with size limit."""
         if len(self._cache) >= self._cache_max_size:
@@ -609,8 +643,30 @@ Format as a numbered list."""
             oldest_keys = list(self._cache.keys())[:100]
             for k in oldest_keys:
                 del self._cache[k]
-        
-        self._cache[key] = result
+
+        self._cache[key] = ReasoningCacheEntry(
+            result=self._clone_result(result, cached=False),
+            created_at=time.time(),
+        )
+
+    def _clone_result(
+        self,
+        source: ReasoningValidation,
+        *,
+        cached: bool,
+    ) -> ReasoningValidation:
+        """Return a defensive copy of a reasoning validation result."""
+        return ReasoningValidation(
+            is_valid=source.is_valid,
+            confidence=source.confidence,
+            reasoning_trace=copy.deepcopy(source.reasoning_trace),
+            issues=copy.deepcopy(source.issues),
+            primary_formula=source.primary_formula,
+            alternative_formula=source.alternative_formula,
+            semantic_facts=copy.deepcopy(source.semantic_facts),
+            cached=cached,
+            verification_time_ms=source.verification_time_ms,
+        )
     
     def clear_cache(self):
         """

--- a/tests/test_pr112_regressions.py
+++ b/tests/test_pr112_regressions.py
@@ -18,6 +18,7 @@ from qwed_new.api import main as api_main
 from qwed_new.core.agent_service import AgentService
 from qwed_new.core.consensus_verifier import ConsensusVerifier
 from qwed_new.core.logic_verifier import LogicVerifier
+from qwed_new.core import reasoning_verifier as reasoning_module
 from qwed_new.core.reasoning_verifier import ReasoningVerifier
 from qwed_new.core import symbolic_verifier as symbolic_module
 from qwed_new.core.symbolic_verifier import SymbolicVerifier
@@ -92,6 +93,162 @@ def test_reasoning_verifier_safe_arithmetic_and_fallback():
     assert verifier._safe_arithmetic_eval("1 + 2 * 3") == Decimal("7")
     assert verifier._safe_arithmetic_eval("2 ** 3") == Decimal("8")
     assert verifier._formulas_equivalent("1/0", "1") is False
+
+
+def test_reasoning_verifier_cache_separates_cross_validation_modes():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 12 and 3\n2. Divide them to get 4"
+
+        def translate(self, _query):
+            return SimpleNamespace(expression="12 / 3")
+
+    verifier = ReasoningVerifier(providers=["anthropic", "openai"], enable_cache=True)
+    verifier.clear_cache()
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+    verifier._provider_loaders["openai"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="12 / 3", reasoning="1. We divide 12 by 3.")
+    query = "What is 12 divided by 3?"
+
+    first = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+    second = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=True,
+    )
+
+    assert first.cached is False
+    assert second.cached is False
+
+
+def test_reasoning_verifier_cache_separates_provider_configurations():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 12 and 3\n2. Divide them to get 4"
+
+        def translate(self, _query):
+            return SimpleNamespace(expression="12 / 3")
+
+    verifier = ReasoningVerifier(providers=["anthropic", "openai"], enable_cache=True)
+    verifier.clear_cache()
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+    verifier._provider_loaders["openai"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="12 / 3", reasoning="1. We divide 12 by 3.")
+    query = "What is 12 divided by 3?"
+
+    first = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+    verifier.provider_names = ["anthropic"]
+    second = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert first.cached is False
+    assert second.cached is False
+
+
+def test_reasoning_verifier_cache_ttl_expires_entries(monkeypatch):
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 12 and 3\n2. Divide them to get 4"
+
+    current_time = {"value": 1000.0}
+    monkeypatch.setattr(reasoning_module.time, "time", lambda: current_time["value"])
+
+    verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=True, cache_ttl_seconds=1)
+    verifier.clear_cache()
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="12 / 3", reasoning="1. We divide 12 by 3.")
+    query = "What is 12 divided by 3?"
+
+    first = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+    current_time["value"] += 2.0
+    second = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert first.cached is False
+    assert second.cached is False
+
+
+def test_reasoning_verifier_cache_miss_result_does_not_mutate_cached_copy():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 12 and 3\n2. Divide them to get 4"
+
+    verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=True)
+    verifier.clear_cache()
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="12 / 3", reasoning="1. We divide 12 by 3.")
+    query = "What is 12 divided by 3?"
+
+    first = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+    first.issues.append("caller mutation")
+    first.reasoning_trace.append("999. fake step")
+
+    second = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert first.cached is False
+    assert second.cached is True
+    assert "caller mutation" not in second.issues
+    assert "999. fake step" not in second.reasoning_trace
+
+
+def test_reasoning_verifier_cache_is_not_shared_between_instances():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 12 and 3\n2. Divide them to get 4"
+
+    first_verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=True)
+    second_verifier = ReasoningVerifier(providers=["anthropic"], enable_cache=True)
+    first_verifier.clear_cache()
+    second_verifier.clear_cache()
+    first_verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+    second_verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="12 / 3", reasoning="1. We divide 12 by 3.")
+    query = "What is 12 divided by 3?"
+
+    first_result = first_verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+    second_result = second_verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=False,
+    )
+
+    assert first_result.cached is False
+    assert second_result.cached is False
 
 
 def test_symbolic_verifier_reports_bounds_transform_error(monkeypatch):

--- a/tests/test_pr112_regressions.py
+++ b/tests/test_pr112_regressions.py
@@ -251,6 +251,38 @@ def test_reasoning_verifier_cache_separates_provider_configurations():
     assert second.cached is False
 
 
+def test_reasoning_verifier_cache_separates_provider_order():
+    class DummyProvider:
+        def complete(self, _prompt):
+            return "1. Extract 12 and 3\n2. Divide them to get 4"
+
+        def translate(self, _query):
+            return SimpleNamespace(expression="12 / 3")
+
+    verifier = ReasoningVerifier(providers=["anthropic", "openai"], enable_cache=True)
+    verifier.clear_cache()
+    verifier._provider_loaders["anthropic"] = lambda: DummyProvider()
+    verifier._provider_loaders["openai"] = lambda: DummyProvider()
+
+    task = SimpleNamespace(expression="12 / 3", reasoning="1. We divide 12 by 3.")
+    query = "What is 12 divided by 3?"
+
+    first = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=True,
+    )
+    verifier.provider_names = ["openai", "anthropic"]
+    second = verifier.verify_understanding(
+        query=query,
+        primary_task=task,
+        enable_cross_validation=True,
+    )
+
+    assert first.cached is False
+    assert second.cached is False
+
+
 def test_reasoning_verifier_cache_ttl_expires_entries(monkeypatch):
     class DummyProvider:
         def complete(self, _prompt):


### PR DESCRIPTION
## Summary
This PR fixes issue #172 by binding `ReasoningVerifier` cache entries to the full verification context and enforcing cache freshness deterministically.

Previously, cached reasoning results were keyed only by `query + formula`, shared across verifier instances, and reused without TTL enforcement. That allowed stale or context-mismatched verification results to replay under different provider configurations or verification modes.

## What changed
- bind cache keys to:
  - query
  - primary formula
  - sorted provider list
  - `enable_cross_validation`
- move the reasoning cache from class-level shared state to per-instance state
- enforce `cache_ttl_seconds` on cache lookup
- store and return defensive copies so caller mutation cannot corrupt cached results
- add regressions proving:
  - cross-validation mode changes invalidate cache reuse
  - provider configuration changes invalidate cache reuse
  - TTL expiry forces recomputation
  - cache miss results cannot poison future cached reads
  - cache entries do not leak across verifier instances

## Why
A proof is only valid for the context in which it was produced.

If cache identity ignores verification mode, provider configuration, freshness, or instance isolation, stale proof can be replayed as current proof.

## Validation
- `python -m pytest tests/test_pr112_regressions.py -q`
- `python -m pytest tests/test_unused_import_cleanup_regressions.py -q`

Closes #172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved caching mechanism in reasoning verification with time-based expiration to ensure fresher cached results and better isolation across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->