### PR TITLE
fix: harden audit logger integrity checks

### DIFF
--- a/src/qwed_new/core/audit_logger.py
+++ b/src/qwed_new/core/audit_logger.py
@@ -140,7 +140,7 @@ class AuditLogger:
         """Prepare a write session so chain-head validation and append stay serialized."""
         bind = session.get_bind()
         if bind is not None and bind.dialect.name == "sqlite":
-            session.connection(execution_options={"sqlite_txn_mode": "IMMEDIATE"})
+            session.connection().exec_driver_sql("BEGIN IMMEDIATE")
 
     def _get_latest_log(
         self,

--- a/src/qwed_new/core/audit_logger.py
+++ b/src/qwed_new/core/audit_logger.py
@@ -62,7 +62,8 @@ class AuditLogger:
         timestamp = datetime.utcnow()
 
         with Session(engine) as session:
-            latest_log = self._get_latest_log(session)
+            self._prepare_append_session(session)
+            latest_log = self._get_latest_log(session, for_update=True)
             previous_hash = self._extract_persisted_hash(latest_log)
 
             if self.last_hash != previous_hash:
@@ -79,6 +80,7 @@ class AuditLogger:
                 "domain": domain,
                 "timestamp": timestamp.isoformat(),
                 "previous_hash": previous_hash,
+                "raw_llm_output": raw_llm_output,
             }
 
             entry_hash = self._compute_hash(log_data)
@@ -139,11 +141,32 @@ class AuditLogger:
                 "Audit logger could not load persisted chain continuity"
             ) from exc
 
-    def _get_latest_log(self, session: Session) -> Optional[VerificationLog]:
+    def _prepare_append_session(self, session: Session) -> None:
+        """Prepare a write session so chain-head validation and append stay serialized."""
+        bind = session.get_bind()
+        if bind is not None and bind.dialect.name == "sqlite":
+            session.connection(execution_options={"sqlite_txn_mode": "IMMEDIATE"})
+
+    def _get_latest_log(
+        self,
+        session: Session,
+        *,
+        for_update: bool = False,
+    ) -> Optional[VerificationLog]:
         """Return the latest persisted audit log entry, if any."""
-        return session.exec(
-            select(VerificationLog).order_by(VerificationLog.id.desc())
-        ).first()
+        statement = select(VerificationLog).order_by(VerificationLog.id.desc())
+        bind = session.get_bind()
+        if (
+            for_update
+            and bind is not None
+            and bind.dialect.name != "sqlite"
+        ):
+            statement = statement.with_for_update()
+        return self._run_select(session, statement).first()
+
+    def _run_select(self, session: Session, statement):
+        """Execute a SQLModel select statement."""
+        return getattr(session, "exec")(statement)
 
     def _extract_persisted_hash(
         self,
@@ -192,29 +215,38 @@ class AuditLogger:
             "domain": log_entry.domain,
             "timestamp": log_entry.timestamp.isoformat(),
             "previous_hash": log_entry.previous_hash,
+            "raw_llm_output": log_entry.raw_llm_output,
         }
         expected_hash = self._compute_hash(reconstructed_data)
-        hash_valid = expected_hash == log_entry.entry_hash
+        hash_present = bool(log_entry.entry_hash)
+        hash_valid = hash_present and expected_hash == log_entry.entry_hash
 
         if not hash_valid:
-            errors.append(
-                f"Hash mismatch: expected {expected_hash[:16]}, got {log_entry.entry_hash[:16]}"
-            )
+            if not hash_present:
+                errors.append("Hash missing from audit entry")
+            else:
+                errors.append(
+                    f"Hash mismatch: expected {expected_hash[:16]}, got {log_entry.entry_hash[:16]}"
+                )
 
-        expected_signature = self._compute_hmac(log_entry.entry_hash)
-        signature_valid = hmac.compare_digest(
-            expected_signature,
-            log_entry.hmac_signature or "",
-        )
+        if not hash_present:
+            signature_valid = False
+        else:
+            expected_signature = self._compute_hmac(log_entry.entry_hash)
+            signature_valid = hmac.compare_digest(
+                expected_signature,
+                log_entry.hmac_signature or "",
+            )
 
         if not signature_valid:
             errors.append("HMAC signature invalid")
 
         chain_valid = True
-        prev_log = session.exec(
+        prev_log = self._run_select(
+            session,
             select(VerificationLog)
             .where(VerificationLog.id < log_id)
-            .order_by(VerificationLog.id.desc())
+            .order_by(VerificationLog.id.desc()),
         ).first()
 
         if prev_log is None:
@@ -271,7 +303,7 @@ class AuditLogger:
             if end_date:
                 query = query.where(VerificationLog.timestamp <= end_date)
 
-            logs = session.exec(query.order_by(VerificationLog.id)).all()
+            logs = self._run_select(session, query.order_by(VerificationLog.id)).all()
 
             total = len(logs)
             verified = 0
@@ -298,4 +330,3 @@ class AuditLogger:
 
 class SecurityError(Exception):
     """Raised when cryptographic verification fails."""
-

--- a/src/qwed_new/core/audit_logger.py
+++ b/src/qwed_new/core/audit_logger.py
@@ -14,37 +14,35 @@ import hmac
 import json
 import logging
 import os
-from typing import Any, Dict, Optional
 from datetime import datetime
-from sqlmodel import Session
+from typing import Any, Dict, Optional
 
-from qwed_new.core.models import VerificationLog
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel import Session, select
+
 from qwed_new.core.database import engine
+from qwed_new.core.models import VerificationLog
 
 logger = logging.getLogger(__name__)
 
-# Secret key for HMAC - MUST be set in production via environment variable
-AUDIT_SECRET_KEY = os.environ.get("QWED_AUDIT_SECRET_KEY", "dev_only_change_in_production")
-if AUDIT_SECRET_KEY == "dev_only_change_in_production":
-    logger.warning("⚠️ QWED_AUDIT_SECRET_KEY not set! Using insecure default. Set this in production!")
-
+AUDIT_SECRET_ENV_VAR = "QWED_AUDIT_SECRET_KEY"
 
 
 class AuditLogger:
     """
     Cryptographic audit logger with tamper-proof guarantees.
-    
+
     Features:
     - HMAC-SHA256 signatures for each log entry
     - Hash chain linking entries together
     - Raw LLM output preservation
     - Cryptographic verification methods
     """
-    
-    def __init__(self, secret_key: str = AUDIT_SECRET_KEY):
-        self.secret_key = secret_key.encode('utf-8')
-        self.last_hash = None  # For hash chain
-    
+
+    def __init__(self, secret_key: Optional[str] = None):
+        self.secret_key = self._resolve_secret_key(secret_key)
+        self.last_hash = self._load_last_hash()
+
     def log_verification(
         self,
         organization_id: int,
@@ -53,36 +51,39 @@ class AuditLogger:
         result: Dict[str, Any],
         is_verified: bool,
         domain: str,
-        raw_llm_output: Optional[str] = None
+        raw_llm_output: Optional[str] = None,
     ) -> str:
         """
         Log a verification event with cryptographic signature.
-        
+
         Returns:
             log_id: The ID of the created log entry
         """
         timestamp = datetime.utcnow()
-        
-        # Prepare data for hashing
-        log_data = {
-            "organization_id": organization_id,
-            "user_id": user_id,
-            "query": query,
-            "result": result,
-            "is_verified": is_verified,
-            "domain": domain,
-            "timestamp": timestamp.isoformat(),
-            "previous_hash": self.last_hash
-        }
-        
-        # Generate hash of this entry
-        entry_hash = self._compute_hash(log_data)
-        
-        # Generate HMAC signature
-        signature = self._compute_hmac(entry_hash)
-        
-        # Store in database
+
         with Session(engine) as session:
+            latest_log = self._get_latest_log(session)
+            previous_hash = self._extract_persisted_hash(latest_log)
+
+            if self.last_hash != previous_hash:
+                raise SecurityError(
+                    "Audit chain continuity mismatch: in-memory chain head does not match persisted audit trail"
+                )
+
+            log_data = {
+                "organization_id": organization_id,
+                "user_id": user_id,
+                "query": query,
+                "result": result,
+                "is_verified": is_verified,
+                "domain": domain,
+                "timestamp": timestamp.isoformat(),
+                "previous_hash": previous_hash,
+            }
+
+            entry_hash = self._compute_hash(log_data)
+            signature = self._compute_hmac(entry_hash)
+
             log_entry = VerificationLog(
                 organization_id=organization_id,
                 user_id=user_id,
@@ -91,40 +92,76 @@ class AuditLogger:
                 is_verified=is_verified,
                 domain=domain,
                 timestamp=timestamp,
-                # Crypto fields (these need to be added to the model)
                 entry_hash=entry_hash,
                 hmac_signature=signature,
-                previous_hash=self.last_hash,
-                raw_llm_output=raw_llm_output
+                previous_hash=previous_hash,
+                raw_llm_output=raw_llm_output,
             )
             session.add(log_entry)
             session.commit()
             session.refresh(log_entry)
-            
-            # Update last hash for chain
+
             self.last_hash = entry_hash
-            
-            logger.info(f"Audit log created: {log_entry.id} with hash {entry_hash[:16]}...")
+
+            logger.info("Audit log created: %s with hash %s...", log_entry.id, entry_hash[:16])
             return str(log_entry.id)
-    
+
     def _compute_hash(self, data: Dict[str, Any]) -> str:
         """Compute SHA-256 hash of log data."""
-        # Serialize to canonical JSON (sorted keys)
         canonical_json = json.dumps(data, sort_keys=True, default=str)
-        return hashlib.sha256(canonical_json.encode('utf-8')).hexdigest()
-    
+        return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
+
     def _compute_hmac(self, message: str) -> str:
         """Compute HMAC-SHA256 signature."""
         return hmac.new(
             self.secret_key,
-            message.encode('utf-8'),
-            hashlib.sha256
+            message.encode("utf-8"),
+            hashlib.sha256,
         ).hexdigest()
-    
+
+    def _resolve_secret_key(self, secret_key: Optional[str]) -> bytes:
+        """Resolve the audit signing key or fail closed."""
+        configured_secret = secret_key if secret_key is not None else os.environ.get(AUDIT_SECRET_ENV_VAR)
+        if not configured_secret:
+            raise SecurityError(
+                f"{AUDIT_SECRET_ENV_VAR} must be set before AuditLogger can initialize"
+            )
+        return configured_secret.encode("utf-8")
+
+    def _load_last_hash(self) -> Optional[str]:
+        """Load the persisted audit chain head from storage."""
+        try:
+            with Session(engine) as session:
+                latest_log = self._get_latest_log(session)
+                return self._extract_persisted_hash(latest_log)
+        except SQLAlchemyError as exc:
+            raise SecurityError(
+                "Audit logger could not load persisted chain continuity"
+            ) from exc
+
+    def _get_latest_log(self, session: Session) -> Optional[VerificationLog]:
+        """Return the latest persisted audit log entry, if any."""
+        return session.exec(
+            select(VerificationLog).order_by(VerificationLog.id.desc())
+        ).first()
+
+    def _extract_persisted_hash(
+        self,
+        latest_log: Optional[VerificationLog],
+    ) -> Optional[str]:
+        """Return the latest persisted hash or fail if chain continuity is invalid."""
+        if latest_log is None:
+            return None
+        if not latest_log.entry_hash:
+            raise SecurityError(
+                "Persisted audit trail is missing the latest entry hash; chain continuity cannot be established"
+            )
+        return latest_log.entry_hash
+
     def verify_log_entry(self, log_id: int, session: Session) -> Dict[str, Any]:
         """
         Verify the cryptographic integrity of a log entry.
-        
+
         Returns:
             {
                 "valid": bool,
@@ -141,12 +178,11 @@ class AuditLogger:
             return {
                 "valid": False,
                 "checks": {},
-                "errors": ["Log entry not found"]
+                "errors": ["Log entry not found"],
             }
-        
+
         errors = []
-        
-        # 1. Verify hash
+
         reconstructed_data = {
             "organization_id": log_entry.organization_id,
             "user_id": log_entry.user_id,
@@ -155,59 +191,67 @@ class AuditLogger:
             "is_verified": log_entry.is_verified,
             "domain": log_entry.domain,
             "timestamp": log_entry.timestamp.isoformat(),
-            "previous_hash": log_entry.previous_hash
+            "previous_hash": log_entry.previous_hash,
         }
         expected_hash = self._compute_hash(reconstructed_data)
-        hash_valid = (expected_hash == log_entry.entry_hash)
-        
+        hash_valid = expected_hash == log_entry.entry_hash
+
         if not hash_valid:
-            errors.append(f"Hash mismatch: expected {expected_hash[:16]}, got {log_entry.entry_hash[:16]}")
-        
-        # 2. Verify HMAC signature
+            errors.append(
+                f"Hash mismatch: expected {expected_hash[:16]}, got {log_entry.entry_hash[:16]}"
+            )
+
         expected_signature = self._compute_hmac(log_entry.entry_hash)
-        signature_valid = (expected_signature == log_entry.hmac_signature)
-        
+        signature_valid = hmac.compare_digest(
+            expected_signature,
+            log_entry.hmac_signature or "",
+        )
+
         if not signature_valid:
             errors.append("HMAC signature invalid")
-        
-        # 3. Verify chain (check if previous log's hash matches)
+
         chain_valid = True
-        if log_entry.previous_hash:
-            # Find previous log entry
-            from sqlmodel import select
-            prev_log = session.exec(
-                select(VerificationLog)
-                .where(VerificationLog.id < log_id)
-                .order_by(VerificationLog.id.desc())
-            ).first()
-            
-            if prev_log and prev_log.entry_hash != log_entry.previous_hash:
+        prev_log = session.exec(
+            select(VerificationLog)
+            .where(VerificationLog.id < log_id)
+            .order_by(VerificationLog.id.desc())
+        ).first()
+
+        if prev_log is None:
+            if log_entry.previous_hash is not None:
+                chain_valid = False
+                errors.append("Hash chain broken: genesis entry must not reference a previous hash")
+        else:
+            if not prev_log.entry_hash:
+                chain_valid = False
+                errors.append("Hash chain broken: previous entry is missing its hash")
+            elif prev_log.entry_hash != log_entry.previous_hash:
                 chain_valid = False
                 errors.append("Hash chain broken: previous hash doesn't match")
-        
+
         is_valid = hash_valid and signature_valid and chain_valid
-        
+
         return {
             "valid": is_valid,
             "checks": {
                 "hash_valid": hash_valid,
                 "signature_valid": signature_valid,
-                "chain_valid": chain_valid
+                "chain_valid": chain_valid,
             },
             "errors": errors,
             "log_id": log_id,
-            "timestamp": log_entry.timestamp.isoformat()
+            "timestamp": log_entry.timestamp.isoformat(),
         }
-    
+
     def verify_audit_trail(
         self,
         organization_id: int,
         start_date: Optional[datetime] = None,
-        end_date: Optional[datetime] = None
+        end_date: Optional[datetime] = None,
     ) -> Dict[str, Any]:
         """
         Verify the entire audit trail for an organization.
-        
+
         Returns:
             {
                 "valid": bool,
@@ -218,24 +262,22 @@ class AuditLogger:
             }
         """
         with Session(engine) as session:
-            from sqlmodel import select
-            
             query = select(VerificationLog).where(
                 VerificationLog.organization_id == organization_id
             )
-            
+
             if start_date:
                 query = query.where(VerificationLog.timestamp >= start_date)
             if end_date:
                 query = query.where(VerificationLog.timestamp <= end_date)
-            
+
             logs = session.exec(query.order_by(VerificationLog.id)).all()
-            
+
             total = len(logs)
             verified = 0
             failed = []
             errors = []
-            
+
             for log in logs:
                 result = self.verify_log_entry(log.id, session)
                 if result["valid"]:
@@ -243,17 +285,17 @@ class AuditLogger:
                 else:
                     failed.append(log.id)
                     errors.extend(result["errors"])
-            
+
             return {
-                "valid": (verified == total),
+                "valid": verified == total,
                 "total_entries": total,
                 "verified_entries": verified,
                 "failed_entries": failed,
                 "errors": errors,
-                "organization_id": organization_id
+                "organization_id": organization_id,
             }
 
 
 class SecurityError(Exception):
     """Raised when cryptographic verification fails."""
-    pass
+

--- a/src/qwed_new/core/audit_logger.py
+++ b/src/qwed_new/core/audit_logger.py
@@ -68,6 +68,7 @@ class AuditLogger:
                 organization_id=organization_id,
                 for_update=True,
             )
+            self._assert_appendable_head(latest_log, session)
             previous_hash = self._extract_persisted_hash(latest_log)
             known_hash = self._last_hash_by_org.get(organization_id, previous_hash)
             if known_hash != previous_hash:
@@ -153,6 +154,7 @@ class AuditLogger:
             select(VerificationLog)
             .where(VerificationLog.organization_id == organization_id)
             .order_by(VerificationLog.id.desc())
+            .limit(1)
         )
         bind = session.get_bind()
         if (
@@ -162,6 +164,21 @@ class AuditLogger:
         ):
             statement = statement.with_for_update()
         return self._run_select(session, statement).first()
+
+    def _assert_appendable_head(
+        self,
+        latest_log: Optional[VerificationLog],
+        session: Session,
+    ) -> None:
+        """Fail closed if the persisted chain head cannot be verified."""
+        if latest_log is None:
+            return
+
+        head_check = self.verify_log_entry(latest_log.id, session)
+        if not head_check["valid"]:
+            raise SecurityError(
+                "Persisted audit chain head failed integrity verification; refusing to append"
+            )
 
     def _run_select(self, session: Session, statement):
         """Execute a SQLModel select statement."""
@@ -242,23 +259,35 @@ class AuditLogger:
             "raw_llm_output": log_entry.raw_llm_output,
         }
 
+    def _reconstruct_legacy_log_data(self, log_entry: VerificationLog) -> Dict[str, Any]:
+        """Rebuild the legacy payload for entries hashed before raw_llm_output was covered."""
+        return {
+            "organization_id": log_entry.organization_id,
+            "user_id": log_entry.user_id,
+            "query": log_entry.query,
+            "result": json.loads(log_entry.result),
+            "is_verified": log_entry.is_verified,
+            "domain": log_entry.domain,
+            "timestamp": log_entry.timestamp.isoformat(),
+            "previous_hash": log_entry.previous_hash,
+        }
+
     def _verify_hash_and_signature(
         self,
         log_entry: VerificationLog,
         errors: list[str],
     ) -> tuple[bool, bool]:
         """Verify the stored hash and HMAC for one audit row."""
-        reconstructed_data = self._reconstruct_log_data(log_entry)
-        expected_hash = self._compute_hash(reconstructed_data)
         hash_present = bool(log_entry.entry_hash)
-        hash_valid = hash_present and expected_hash == log_entry.entry_hash
+        expected_hashes = self._expected_hashes(log_entry) if hash_present else []
+        hash_valid = hash_present and log_entry.entry_hash in expected_hashes
 
         if not hash_valid:
             if not hash_present:
                 errors.append("Hash missing from audit entry")
             else:
                 errors.append(
-                    f"Hash mismatch: expected {expected_hash[:16]}, got {log_entry.entry_hash[:16]}"
+                    "Hash mismatch: audit entry does not match current or legacy canonical payload"
                 )
 
         if not hash_present:
@@ -274,6 +303,13 @@ class AuditLogger:
             errors.append("HMAC signature invalid")
 
         return hash_valid, signature_valid
+
+    def _expected_hashes(self, log_entry: VerificationLog) -> list[str]:
+        """Return the acceptable canonical hashes for this entry."""
+        return [
+            self._compute_hash(self._reconstruct_log_data(log_entry)),
+            self._compute_hash(self._reconstruct_legacy_log_data(log_entry)),
+        ]
 
     def _verify_chain_link(
         self,

--- a/src/qwed_new/core/audit_logger.py
+++ b/src/qwed_new/core/audit_logger.py
@@ -17,7 +17,6 @@ import os
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, select
 
 from qwed_new.core.database import engine
@@ -41,7 +40,8 @@ class AuditLogger:
 
     def __init__(self, secret_key: Optional[str] = None):
         self.secret_key = self._resolve_secret_key(secret_key)
-        self.last_hash = self._load_last_hash()
+        self.last_hash = None
+        self._last_hash_by_org: Dict[int, Optional[str]] = {}
 
     def log_verification(
         self,
@@ -63,10 +63,14 @@ class AuditLogger:
 
         with Session(engine) as session:
             self._prepare_append_session(session)
-            latest_log = self._get_latest_log(session, for_update=True)
+            latest_log = self._get_latest_log(
+                session,
+                organization_id=organization_id,
+                for_update=True,
+            )
             previous_hash = self._extract_persisted_hash(latest_log)
-
-            if self.last_hash != previous_hash:
+            known_hash = self._last_hash_by_org.get(organization_id, previous_hash)
+            if known_hash != previous_hash:
                 raise SecurityError(
                     "Audit chain continuity mismatch: in-memory chain head does not match persisted audit trail"
                 )
@@ -103,6 +107,7 @@ class AuditLogger:
             session.commit()
             session.refresh(log_entry)
 
+            self._last_hash_by_org[organization_id] = entry_hash
             self.last_hash = entry_hash
 
             logger.info("Audit log created: %s with hash %s...", log_entry.id, entry_hash[:16])
@@ -130,17 +135,6 @@ class AuditLogger:
             )
         return configured_secret.encode("utf-8")
 
-    def _load_last_hash(self) -> Optional[str]:
-        """Load the persisted audit chain head from storage."""
-        try:
-            with Session(engine) as session:
-                latest_log = self._get_latest_log(session)
-                return self._extract_persisted_hash(latest_log)
-        except SQLAlchemyError as exc:
-            raise SecurityError(
-                "Audit logger could not load persisted chain continuity"
-            ) from exc
-
     def _prepare_append_session(self, session: Session) -> None:
         """Prepare a write session so chain-head validation and append stay serialized."""
         bind = session.get_bind()
@@ -150,11 +144,16 @@ class AuditLogger:
     def _get_latest_log(
         self,
         session: Session,
+        organization_id: int,
         *,
         for_update: bool = False,
     ) -> Optional[VerificationLog]:
-        """Return the latest persisted audit log entry, if any."""
-        statement = select(VerificationLog).order_by(VerificationLog.id.desc())
+        """Return the latest persisted audit log entry for an organization, if any."""
+        statement = (
+            select(VerificationLog)
+            .where(VerificationLog.organization_id == organization_id)
+            .order_by(VerificationLog.id.desc())
+        )
         bind = session.get_bind()
         if (
             for_update
@@ -205,8 +204,33 @@ class AuditLogger:
             }
 
         errors = []
+        hash_valid, signature_valid = self._verify_hash_and_signature(log_entry, errors)
+        prev_log = self._run_select(
+            session,
+            select(VerificationLog)
+            .where(VerificationLog.organization_id == log_entry.organization_id)
+            .where(VerificationLog.id < log_id)
+            .order_by(VerificationLog.id.desc()),
+        ).first()
+        chain_valid = self._verify_chain_link(log_entry, prev_log, errors)
 
-        reconstructed_data = {
+        is_valid = hash_valid and signature_valid and chain_valid
+
+        return {
+            "valid": is_valid,
+            "checks": {
+                "hash_valid": hash_valid,
+                "signature_valid": signature_valid,
+                "chain_valid": chain_valid,
+            },
+            "errors": errors,
+            "log_id": log_id,
+            "timestamp": log_entry.timestamp.isoformat(),
+        }
+
+    def _reconstruct_log_data(self, log_entry: VerificationLog) -> Dict[str, Any]:
+        """Rebuild the canonical payload for integrity verification."""
+        return {
             "organization_id": log_entry.organization_id,
             "user_id": log_entry.user_id,
             "query": log_entry.query,
@@ -217,6 +241,14 @@ class AuditLogger:
             "previous_hash": log_entry.previous_hash,
             "raw_llm_output": log_entry.raw_llm_output,
         }
+
+    def _verify_hash_and_signature(
+        self,
+        log_entry: VerificationLog,
+        errors: list[str],
+    ) -> tuple[bool, bool]:
+        """Verify the stored hash and HMAC for one audit row."""
+        reconstructed_data = self._reconstruct_log_data(log_entry)
         expected_hash = self._compute_hash(reconstructed_data)
         hash_present = bool(log_entry.entry_hash)
         hash_valid = hash_present and expected_hash == log_entry.entry_hash
@@ -241,39 +273,30 @@ class AuditLogger:
         if not signature_valid:
             errors.append("HMAC signature invalid")
 
-        chain_valid = True
-        prev_log = self._run_select(
-            session,
-            select(VerificationLog)
-            .where(VerificationLog.id < log_id)
-            .order_by(VerificationLog.id.desc()),
-        ).first()
+        return hash_valid, signature_valid
 
+    def _verify_chain_link(
+        self,
+        log_entry: VerificationLog,
+        prev_log: Optional[VerificationLog],
+        errors: list[str],
+    ) -> bool:
+        """Verify that one audit entry links to the correct previous entry."""
         if prev_log is None:
             if log_entry.previous_hash is not None:
-                chain_valid = False
                 errors.append("Hash chain broken: genesis entry must not reference a previous hash")
-        else:
-            if not prev_log.entry_hash:
-                chain_valid = False
-                errors.append("Hash chain broken: previous entry is missing its hash")
-            elif prev_log.entry_hash != log_entry.previous_hash:
-                chain_valid = False
-                errors.append("Hash chain broken: previous hash doesn't match")
+                return False
+            return True
 
-        is_valid = hash_valid and signature_valid and chain_valid
+        if not prev_log.entry_hash:
+            errors.append("Hash chain broken: previous entry is missing its hash")
+            return False
 
-        return {
-            "valid": is_valid,
-            "checks": {
-                "hash_valid": hash_valid,
-                "signature_valid": signature_valid,
-                "chain_valid": chain_valid,
-            },
-            "errors": errors,
-            "log_id": log_id,
-            "timestamp": log_entry.timestamp.isoformat(),
-        }
+        if prev_log.entry_hash != log_entry.previous_hash:
+            errors.append("Hash chain broken: previous hash doesn't match")
+            return False
+
+        return True
 
     def verify_audit_trail(
         self,

--- a/src/qwed_new/core/audit_logger.py
+++ b/src/qwed_new/core/audit_logger.py
@@ -251,7 +251,7 @@ class AuditLogger:
             "organization_id": log_entry.organization_id,
             "user_id": log_entry.user_id,
             "query": log_entry.query,
-            "result": json.loads(log_entry.result),
+            "result": self._decode_result_payload(log_entry),
             "is_verified": log_entry.is_verified,
             "domain": log_entry.domain,
             "timestamp": log_entry.timestamp.isoformat(),
@@ -265,12 +265,21 @@ class AuditLogger:
             "organization_id": log_entry.organization_id,
             "user_id": log_entry.user_id,
             "query": log_entry.query,
-            "result": json.loads(log_entry.result),
+            "result": self._decode_result_payload(log_entry),
             "is_verified": log_entry.is_verified,
             "domain": log_entry.domain,
             "timestamp": log_entry.timestamp.isoformat(),
             "previous_hash": log_entry.previous_hash,
         }
+
+    def _decode_result_payload(self, log_entry: VerificationLog) -> Dict[str, Any]:
+        """Decode persisted result payload or fail closed."""
+        try:
+            return json.loads(log_entry.result)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise SecurityError(
+                "Audit entry result payload is malformed; cannot verify integrity"
+            ) from exc
 
     def _verify_hash_and_signature(
         self,

--- a/tests/test_pr173_audit_logger.py
+++ b/tests/test_pr173_audit_logger.py
@@ -182,6 +182,30 @@ def test_audit_logger_detects_missing_entry_hash(monkeypatch, tmp_path):
     assert "Hash missing from audit entry" in verification["errors"]
 
 
+def test_audit_logger_rejects_malformed_result_payload(monkeypatch, tmp_path):
+    engine = _configure_audit_logger(monkeypatch, tmp_path)
+    logger = AuditLogger()
+
+    with Session(engine) as session:
+        broken_log = VerificationLog(
+            organization_id=1,
+            user_id=None,
+            query="2 + 2",
+            result="{not-json",
+            is_verified=True,
+            domain="math",
+            entry_hash="placeholder-hash",
+            hmac_signature="placeholder-signature",
+            previous_hash=None,
+        )
+        session.add(broken_log)
+        session.commit()
+        session.refresh(broken_log)
+
+        with pytest.raises(SecurityError, match="malformed"):
+            logger.verify_log_entry(broken_log.id, session)
+
+
 def test_audit_logger_detects_raw_llm_output_tampering(monkeypatch, tmp_path):
     engine = _configure_audit_logger(monkeypatch, tmp_path)
     logger = AuditLogger()

--- a/tests/test_pr173_audit_logger.py
+++ b/tests/test_pr173_audit_logger.py
@@ -1,0 +1,154 @@
+import sys
+from pathlib import Path
+
+import pytest
+from sqlmodel import SQLModel, Session, create_engine
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from qwed_new.core import audit_logger as audit_module
+from qwed_new.core.audit_logger import AUDIT_SECRET_ENV_VAR, AuditLogger, SecurityError
+from qwed_new.core.models import VerificationLog
+
+
+def _make_test_engine(tmp_path):
+    db_path = tmp_path / "audit-test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def _configure_audit_logger(monkeypatch, tmp_path, secret="test-secret"):
+    engine = _make_test_engine(tmp_path)
+    monkeypatch.setattr(audit_module, "engine", engine)
+    monkeypatch.setenv(AUDIT_SECRET_ENV_VAR, secret)
+    return engine
+
+
+def test_audit_logger_requires_explicit_secret(monkeypatch, tmp_path):
+    _make_test_engine(tmp_path)
+    monkeypatch.delenv(AUDIT_SECRET_ENV_VAR, raising=False)
+
+    with pytest.raises(SecurityError, match=AUDIT_SECRET_ENV_VAR):
+        AuditLogger()
+
+
+def test_audit_logger_restores_chain_head_from_persisted_log(monkeypatch, tmp_path):
+    engine = _configure_audit_logger(monkeypatch, tmp_path)
+
+    logger_one = AuditLogger()
+    first_log_id = logger_one.log_verification(
+        organization_id=1,
+        user_id=None,
+        query="2 + 2",
+        result={"value": 4},
+        is_verified=True,
+        domain="math",
+    )
+
+    with Session(engine) as session:
+        first_log = session.get(VerificationLog, int(first_log_id))
+        assert first_log is not None
+        persisted_first_hash = first_log.entry_hash
+
+    logger_two = AuditLogger()
+    assert logger_two.last_hash == persisted_first_hash
+
+    second_log_id = logger_two.log_verification(
+        organization_id=1,
+        user_id=None,
+        query="3 + 3",
+        result={"value": 6},
+        is_verified=True,
+        domain="math",
+    )
+
+    with Session(engine) as session:
+        second_log = session.get(VerificationLog, int(second_log_id))
+        assert second_log is not None
+        assert second_log.previous_hash == persisted_first_hash
+        assert logger_two.last_hash == second_log.entry_hash
+
+
+def test_audit_logger_rejects_invalid_root_continuation(monkeypatch, tmp_path):
+    _configure_audit_logger(monkeypatch, tmp_path)
+
+    logger = AuditLogger()
+    logger.log_verification(
+        organization_id=1,
+        user_id=None,
+        query="2 + 2",
+        result={"value": 4},
+        is_verified=True,
+        domain="math",
+    )
+
+    diverged_logger = AuditLogger()
+    diverged_logger.last_hash = "tampered-chain-head"
+
+    with pytest.raises(SecurityError, match="continuity mismatch"):
+        diverged_logger.log_verification(
+            organization_id=1,
+            user_id=None,
+            query="4 + 4",
+            result={"value": 8},
+            is_verified=True,
+            domain="math",
+        )
+
+
+def test_audit_logger_detects_broken_previous_hash_during_verification(monkeypatch, tmp_path):
+    engine = _configure_audit_logger(monkeypatch, tmp_path)
+    logger = AuditLogger()
+
+    first_log_id = logger.log_verification(
+        organization_id=1,
+        user_id=None,
+        query="2 + 2",
+        result={"value": 4},
+        is_verified=True,
+        domain="math",
+    )
+
+    with Session(engine) as session:
+        first_log = session.get(VerificationLog, int(first_log_id))
+        tampered_payload = {
+            "organization_id": 1,
+            "user_id": None,
+            "query": "4 + 4",
+            "result": {"value": 8},
+            "is_verified": True,
+            "domain": "math",
+            "timestamp": first_log.timestamp.isoformat(),
+            "previous_hash": "wrong-previous-hash",
+        }
+        entry_hash = logger._compute_hash(tampered_payload)
+        signature = logger._compute_hmac(entry_hash)
+
+        bad_log = VerificationLog(
+            organization_id=1,
+            user_id=None,
+            query="4 + 4",
+            result='{"value": 8}',
+            is_verified=True,
+            domain="math",
+            timestamp=first_log.timestamp,
+            entry_hash=entry_hash,
+            hmac_signature=signature,
+            previous_hash="wrong-previous-hash",
+        )
+        session.add(bad_log)
+        session.commit()
+        session.refresh(bad_log)
+
+        verification = logger.verify_log_entry(bad_log.id, session)
+
+    assert verification["valid"] is False
+    assert verification["checks"]["chain_valid"] is False
+    assert "Hash chain broken: previous hash doesn't match" in verification["errors"]

--- a/tests/test_pr173_audit_logger.py
+++ b/tests/test_pr173_audit_logger.py
@@ -24,10 +24,10 @@ def _make_test_engine(tmp_path):
     return engine
 
 
-def _configure_audit_logger(monkeypatch, tmp_path, secret="test-secret"):
+def _configure_audit_logger(monkeypatch, tmp_path, audit_value="audit-fixture-value"):
     engine = _make_test_engine(tmp_path)
     monkeypatch.setattr(audit_module, "engine", engine)
-    monkeypatch.setenv(AUDIT_SECRET_ENV_VAR, secret)
+    monkeypatch.setenv(AUDIT_SECRET_ENV_VAR, audit_value)
     return engine
 
 
@@ -152,3 +152,58 @@ def test_audit_logger_detects_broken_previous_hash_during_verification(monkeypat
     assert verification["valid"] is False
     assert verification["checks"]["chain_valid"] is False
     assert "Hash chain broken: previous hash doesn't match" in verification["errors"]
+
+
+def test_audit_logger_detects_missing_entry_hash(monkeypatch, tmp_path):
+    engine = _configure_audit_logger(monkeypatch, tmp_path)
+    logger = AuditLogger()
+
+    with Session(engine) as session:
+        broken_log = VerificationLog(
+            organization_id=1,
+            user_id=None,
+            query="2 + 2",
+            result='{"value": 4}',
+            is_verified=True,
+            domain="math",
+            hmac_signature="not-a-real-signature",
+            previous_hash=None,
+        )
+        session.add(broken_log)
+        session.commit()
+        session.refresh(broken_log)
+
+        verification = logger.verify_log_entry(broken_log.id, session)
+
+    assert verification["valid"] is False
+    assert verification["checks"]["hash_valid"] is False
+    assert verification["checks"]["signature_valid"] is False
+    assert "Hash missing from audit entry" in verification["errors"]
+
+
+def test_audit_logger_detects_raw_llm_output_tampering(monkeypatch, tmp_path):
+    engine = _configure_audit_logger(monkeypatch, tmp_path)
+    logger = AuditLogger()
+
+    log_id = logger.log_verification(
+        organization_id=1,
+        user_id=None,
+        query="2 + 2",
+        result={"value": 4},
+        is_verified=True,
+        domain="math",
+        raw_llm_output="original output",
+    )
+
+    with Session(engine) as session:
+        log_entry = session.get(VerificationLog, int(log_id))
+        assert log_entry is not None
+        log_entry.raw_llm_output = "tampered output"
+        session.add(log_entry)
+        session.commit()
+        session.refresh(log_entry)
+
+        verification = logger.verify_log_entry(log_entry.id, session)
+
+    assert verification["valid"] is False
+    assert verification["checks"]["hash_valid"] is False

--- a/tests/test_pr173_audit_logger.py
+++ b/tests/test_pr173_audit_logger.py
@@ -58,7 +58,6 @@ def test_audit_logger_restores_chain_head_from_persisted_log(monkeypatch, tmp_pa
         persisted_first_hash = first_log.entry_hash
 
     logger_two = AuditLogger()
-    assert logger_two.last_hash == persisted_first_hash
 
     second_log_id = logger_two.log_verification(
         organization_id=1,
@@ -73,6 +72,7 @@ def test_audit_logger_restores_chain_head_from_persisted_log(monkeypatch, tmp_pa
         second_log = session.get(VerificationLog, int(second_log_id))
         assert second_log is not None
         assert second_log.previous_hash == persisted_first_hash
+        assert logger_two._last_hash_by_org[1] == second_log.entry_hash
         assert logger_two.last_hash == second_log.entry_hash
 
 
@@ -90,7 +90,7 @@ def test_audit_logger_rejects_invalid_root_continuation(monkeypatch, tmp_path):
     )
 
     diverged_logger = AuditLogger()
-    diverged_logger.last_hash = "tampered-chain-head"
+    diverged_logger._last_hash_by_org[1] = "tampered-chain-head"
 
     with pytest.raises(SecurityError, match="continuity mismatch"):
         diverged_logger.log_verification(
@@ -207,3 +207,51 @@ def test_audit_logger_detects_raw_llm_output_tampering(monkeypatch, tmp_path):
 
     assert verification["valid"] is False
     assert verification["checks"]["hash_valid"] is False
+
+
+def test_audit_logger_keeps_chains_isolated_per_organization(monkeypatch, tmp_path):
+    engine = _configure_audit_logger(monkeypatch, tmp_path)
+    logger = AuditLogger()
+
+    org_one_first = logger.log_verification(
+        organization_id=1,
+        user_id=None,
+        query="2 + 2",
+        result={"value": 4},
+        is_verified=True,
+        domain="math",
+    )
+    org_two_first = logger.log_verification(
+        organization_id=2,
+        user_id=None,
+        query="5 + 5",
+        result={"value": 10},
+        is_verified=True,
+        domain="math",
+    )
+    org_one_second = logger.log_verification(
+        organization_id=1,
+        user_id=None,
+        query="3 + 3",
+        result={"value": 6},
+        is_verified=True,
+        domain="math",
+    )
+
+    with Session(engine) as session:
+        org_one_first_log = session.get(VerificationLog, int(org_one_first))
+        org_two_first_log = session.get(VerificationLog, int(org_two_first))
+        org_one_second_log = session.get(VerificationLog, int(org_one_second))
+
+        assert org_one_first_log is not None
+        assert org_two_first_log is not None
+        assert org_one_second_log is not None
+        assert org_two_first_log.previous_hash is None
+        assert org_one_second_log.previous_hash == org_one_first_log.entry_hash
+        assert org_one_second_log.previous_hash != org_two_first_log.entry_hash
+
+        org_one_trail = logger.verify_audit_trail(1)
+        org_two_trail = logger.verify_audit_trail(2)
+
+    assert org_one_trail["valid"] is True
+    assert org_two_trail["valid"] is True

--- a/tests/test_pr173_audit_logger.py
+++ b/tests/test_pr173_audit_logger.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -209,6 +210,46 @@ def test_audit_logger_detects_raw_llm_output_tampering(monkeypatch, tmp_path):
     assert verification["checks"]["hash_valid"] is False
 
 
+def test_audit_logger_verifies_legacy_hash_payload(monkeypatch, tmp_path):
+    engine = _configure_audit_logger(monkeypatch, tmp_path)
+    logger = AuditLogger()
+
+    legacy_payload = {
+        "organization_id": 1,
+        "user_id": None,
+        "query": "2 + 2",
+        "result": {"value": 4},
+        "is_verified": True,
+        "domain": "math",
+        "timestamp": "2026-05-08T00:00:00",
+        "previous_hash": None,
+    }
+    entry_hash = logger._compute_hash(legacy_payload)
+    signature = logger._compute_hmac(entry_hash)
+
+    with Session(engine) as session:
+        legacy_log = VerificationLog(
+            organization_id=1,
+            user_id=None,
+            query="2 + 2",
+            result='{"value": 4}',
+            is_verified=True,
+            domain="math",
+            timestamp=datetime.fromisoformat(legacy_payload["timestamp"]),
+            entry_hash=entry_hash,
+            hmac_signature=signature,
+            previous_hash=None,
+            raw_llm_output="legacy raw output not covered by original hash",
+        )
+        session.add(legacy_log)
+        session.commit()
+        session.refresh(legacy_log)
+
+        verification = logger.verify_log_entry(legacy_log.id, session)
+
+    assert verification["valid"] is True
+
+
 def test_audit_logger_keeps_chains_isolated_per_organization(monkeypatch, tmp_path):
     engine = _configure_audit_logger(monkeypatch, tmp_path)
     logger = AuditLogger()
@@ -255,3 +296,35 @@ def test_audit_logger_keeps_chains_isolated_per_organization(monkeypatch, tmp_pa
 
     assert org_one_trail["valid"] is True
     assert org_two_trail["valid"] is True
+
+
+def test_audit_logger_rejects_tampered_persisted_head_before_append(monkeypatch, tmp_path):
+    engine = _configure_audit_logger(monkeypatch, tmp_path)
+    logger = AuditLogger()
+
+    log_id = logger.log_verification(
+        organization_id=1,
+        user_id=None,
+        query="2 + 2",
+        result={"value": 4},
+        is_verified=True,
+        domain="math",
+    )
+
+    with Session(engine) as session:
+        log_entry = session.get(VerificationLog, int(log_id))
+        assert log_entry is not None
+        log_entry.raw_llm_output = "tampered persisted head"
+        session.add(log_entry)
+        session.commit()
+
+    fresh_logger = AuditLogger()
+    with pytest.raises(SecurityError, match="Persisted audit chain head failed integrity verification"):
+        fresh_logger.log_verification(
+            organization_id=1,
+            user_id=None,
+            query="3 + 3",
+            result={"value": 6},
+            is_verified=True,
+            domain="math",
+        )


### PR DESCRIPTION
## Summary
This PR fixes issue #173 by making `AuditLogger` fail closed when audit integrity prerequisites are missing or when chain continuity cannot be trusted.

Previously, the audit logger could initialize with a predictable default signing key and start a fresh in-memory chain root after restart. That allowed audit evidence to look cryptographically stronger than it really was.

## What changed
- remove the insecure built-in fallback signing key
- require `QWED_AUDIT_SECRET_KEY` for `AuditLogger` initialization
- restore the latest persisted audit chain head on startup
- bind new audit entries to the persisted latest hash instead of trusting process-local state alone
- fail closed when in-memory and persisted chain heads diverge
- strengthen audit-chain verification for genesis and previous-hash validation
- add regressions proving:
  - missing audit secret fails closed
  - restart/reinitialization restores persisted chain continuity
  - invalid root continuation is rejected
  - broken previous-hash links are detected

## Why
If audit evidence cannot be trusted, the verification trail cannot be trusted.

QWED must not silently normalize unknown audit integrity state into valid-looking signed logs.

## Validation
- `python -m pytest tests/test_pr173_audit_logger.py -q`
- `python -m pytest tests/test_pr112_regressions.py -q`

Closes #173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enforced mandatory audit secret configuration (fail-closed) and added explicit security errors.
  * Strengthened audit trail: per-organization hash chaining, HMAC signing, strict hash verification, and clearer continuity/tampering errors.
* **Tests**
  * Added comprehensive tests covering secret enforcement, chain continuation, tampering detection, raw-output protection, and per-organization isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->