### PR TITLE
fix: separate batch math simplification from proof

### DIFF
--- a/src/qwed_new/core/batch.py
+++ b/src/qwed_new/core/batch.py
@@ -239,9 +239,14 @@ class BatchVerificationService:
                 parsed = parse_expr(expression)
                 simplified = simplify(parsed)
                 return {
-                    "is_valid": True,
+                    "is_valid": False,
+                    "status": "SIMPLIFIED",
                     "simplified": str(simplified),
-                    "type": "math"
+                    "type": "math",
+                    "message": (
+                        "Expression simplified, but no equality or proof claim "
+                        "was provided"
+                    ),
                 }
         
         elif item.verification_type == VerificationType.CODE:

--- a/tests/test_pr174_batch_math.py
+++ b/tests/test_pr174_batch_math.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from qwed_new.core.batch import BatchItem, BatchVerificationService, VerificationType
+
+
+def test_batch_math_identity_verification_returns_valid():
+    service = BatchVerificationService()
+    item = BatchItem(
+        id="math-identity",
+        query="x + x = 2*x",
+        verification_type=VerificationType.MATH,
+    )
+
+    result = asyncio.run(service._verify_item(item, organization_id=1))
+
+    assert result["type"] == "math"
+    assert result["is_valid"] is True
+    assert result["message"] == "Identity verified"
+
+
+def test_batch_math_non_identity_verification_returns_invalid():
+    service = BatchVerificationService()
+    item = BatchItem(
+        id="math-not-equal",
+        query="x + x = x",
+        verification_type=VerificationType.MATH,
+    )
+
+    result = asyncio.run(service._verify_item(item, organization_id=1))
+
+    assert result["type"] == "math"
+    assert result["is_valid"] is False
+    assert result["message"] == "Not equal"
+
+
+def test_batch_math_simplification_only_is_not_reported_as_valid():
+    service = BatchVerificationService()
+    item = BatchItem(
+        id="math-simplified",
+        query="x + x",
+        verification_type=VerificationType.MATH,
+    )
+
+    result = asyncio.run(service._verify_item(item, organization_id=1))
+
+    assert result["type"] == "math"
+    assert result["is_valid"] is False
+    assert result["status"] == "SIMPLIFIED"
+    assert result["simplified"] == "2*x"
+    assert "no equality or proof claim" in result["message"]


### PR DESCRIPTION
## Summary
This PR fixes issue #174 by separating symbolic math transformation from proof outcomes in the batch verifier.

Previously, parseable non-equality math expressions were simplified and returned with `is_valid=True`, which made symbolic processing look like deterministic verification.

## What changed
- keep equality-based math verification on the existing proof path
- return non-proof symbolic expressions as explicit simplification results instead of valid proofs
- mark simplification-only results with:
  - `is_valid: false`
  - `status: "SIMPLIFIED"`
  - a message explaining that no equality or proof claim was provided
- add regressions proving:
  - verified identities still return valid
  - non-identities still return invalid
  - simplification-only expressions are not reported as verified

## Why
A transformed expression is not the same thing as a proven claim.

QWED should not normalize parse success or simplification into a success-like verification result.

## Validation
- `python -m pytest tests/test_pr174_batch_math.py -q`
- `python -m pytest tests/test_api_verify_math.py -q`

Closes #174


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Math verification now correctly distinguishes between verification requests (equality/proof) and simplification-only requests. When a math query lacks an equality claim, the system returns an invalid status while still providing the simplified result and clarifying feedback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-verification/pull/180)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->