### PR TITLE
fix(cache): bind VerificationCache keys to trust context — closes #187

### DIFF
--- a/qwed_sdk/cache.py
+++ b/qwed_sdk/cache.py
@@ -10,6 +10,7 @@ across trust boundaries.
 This design prevents cross-context replay of verification artifacts (Issue #187).
 """
 
+import os
 import sqlite3
 import hashlib
 import json
@@ -44,6 +45,28 @@ class CacheContext:
     policy_version: str
     tenant_id: Optional[str] = None
     env_fingerprint: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        """Reject blank required trust-context fields at construction time.
+
+        Empty or whitespace-only values for the required fields collapse
+        distinct verification contexts into the same fingerprint, allowing
+        replay of VERIFIED results across different trust boundaries.
+        """
+        for _field in ("provider", "model", "policy_version"):
+            _val = getattr(self, _field)
+            if not isinstance(_val, str) or not _val.strip():
+                raise ValueError(
+                    f"CacheContext.{_field} must be a non-empty string, got {_val!r}"
+                )
+        if self.tenant_id is not None and not self.tenant_id.strip():
+            raise ValueError(
+                "CacheContext.tenant_id must be None or a non-empty string"
+            )
+        if self.env_fingerprint is not None and not self.env_fingerprint.strip():
+            raise ValueError(
+                "CacheContext.env_fingerprint must be None or a non-empty string"
+            )
 
     def canonical_dict(self) -> Dict[str, Any]:
         """Return a deterministic dict for key derivation."""
@@ -122,11 +145,15 @@ class VerificationCache:
         else:
             self.cache_dir = Path.home() / ".qwed" / "cache"
 
-        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        # Owner-only directory: prevents other local users reading tenant metadata
+        self.cache_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(self.cache_dir, 0o700)
         self.db_path = self.cache_dir / "verifications.db"
 
         self.stats = CacheStats()
         self._init_db()
+        # Owner-only DB file: tighten after _init_db creates the file
+        os.chmod(self.db_path, 0o600)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -204,7 +231,7 @@ class VerificationCache:
         cursor = conn.cursor()
 
         cursor.execute("""
-            SELECT result, created_at, access_count, context_fingerprint
+            SELECT result, created_at, access_count, context_json
             FROM cache_v2
             WHERE key = ? AND context_fingerprint = ?
         """, (key, ctx_fp))
@@ -216,9 +243,14 @@ class VerificationCache:
             self.stats.misses += 1
             return None
 
-        result_json, created_at, access_count, stored_fp = row
+        result_json, created_at, access_count, stored_context_json = row
 
-        # Re-validate fingerprint (defence-in-depth)
+        # Real replay guard: re-derive the fingerprint from the stored canonical
+        # context JSON and compare it against the expected fingerprint.  The SQL
+        # WHERE clause already filters by context_fingerprint, but an attacker
+        # with direct DB write access could bypass that.  Re-hashing the stored
+        # JSON here catches any tampering with stored context data.
+        stored_fp = hashlib.sha256(stored_context_json.encode()).hexdigest()
         if stored_fp != ctx_fp:
             conn.close()
             self.stats.misses += 1
@@ -260,7 +292,7 @@ class VerificationCache:
         ctx_fp = self._hash_context(context)
         normalized = self._normalize_query(query)
         result_json = json.dumps(result)
-        context_json = json.dumps(context.canonical_dict(), sort_keys=True)
+        context_json = json.dumps(context.canonical_dict(), sort_keys=True, separators=(",", ":"))
         now = int(time.time())
 
         conn = sqlite3.connect(self.db_path)

--- a/qwed_sdk/cache.py
+++ b/qwed_sdk/cache.py
@@ -152,15 +152,24 @@ class VerificationCache:
 
         self.stats = CacheStats()
         self._init_db()
-        # Owner-only DB file: tighten after _init_db creates the file
-        os.chmod(self.db_path, 0o600)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
     def _init_db(self) -> None:
-        """Initialize SQLite database with the v2 context-bound schema."""
+        """Initialize SQLite database with the v2 context-bound schema.
+
+        The DB file is pre-created with 0o600 permissions via os.open() before
+        sqlite3.connect() is called, closing the TOCTOU window where the file
+        would briefly be world-readable under a permissive umask.
+        """
+        # Pre-create the file with owner-only perms to close the TOCTOU window.
+        # O_CREAT | O_WRONLY with mode 0o600 ensures the file is never visible
+        # to other users, even for the brief instant before chmod would run.
+        if not self.db_path.exists():
+            fd = os.open(str(self.db_path), os.O_CREAT | os.O_WRONLY, 0o600)
+            os.close(fd)
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
 
@@ -299,10 +308,15 @@ class VerificationCache:
         cursor = conn.cursor()
 
         cursor.execute("""
-            INSERT OR REPLACE INTO cache_v2
+            INSERT INTO cache_v2
                 (key, context_fingerprint, query, context_json, result,
                  created_at, accessed_at, access_count)
             VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+            ON CONFLICT(key, context_fingerprint) DO UPDATE SET
+                result       = excluded.result,
+                context_json = excluded.context_json,
+                accessed_at  = excluded.accessed_at,
+                access_count = access_count + 1
         """, (key, ctx_fp, normalized, context_json, result_json, now, now))
 
         conn.commit()

--- a/qwed_sdk/cache.py
+++ b/qwed_sdk/cache.py
@@ -1,8 +1,13 @@
 """
-QWED Cache Module - Smart caching for verification results.
+QWED Cache Module — Context-bound caching for verification results.
 
-Saves API costs and speeds up repeated queries.
-Uses SQLite for persistent storage.
+Verification cache entries are context-bound: a cache hit requires an exact
+match of both the normalized query **and** all trust-bound context dimensions
+(provider, model, policy version, tenant/session scope).  A mismatch on any
+dimension is a deterministic cache miss — the cache never returns a result
+across trust boundaries.
+
+This design prevents cross-context replay of verification artifacts (Issue #187).
 """
 
 import sqlite3
@@ -14,6 +19,47 @@ from typing import Optional, Dict, Any
 from dataclasses import dataclass
 
 
+# ---------------------------------------------------------------------------
+# Public context type
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CacheContext:
+    """Trust-bound context dimensions required for every cache operation.
+
+    All fields participate in the cache key.  Omitting or changing any field
+    causes a deterministic cache miss — the cache never falls back to a
+    query-only match.
+
+    Attributes:
+        provider:        Provider / API endpoint identifier (e.g. "openai").
+        model:           Model / deployment name (e.g. "gpt-4o").
+        policy_version:  Verifier policy version string (e.g. "v1").
+        tenant_id:       Optional tenant or session scope identifier.
+        env_fingerprint: Optional environment / config fingerprint for
+                         additional binding.
+    """
+    provider: str
+    model: str
+    policy_version: str
+    tenant_id: Optional[str] = None
+    env_fingerprint: Optional[str] = None
+
+    def canonical_dict(self) -> Dict[str, Any]:
+        """Return a deterministic dict for key derivation."""
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "policy_version": self.policy_version,
+            "tenant_id": self.tenant_id,
+            "env_fingerprint": self.env_fingerprint,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
 @dataclass
 class CacheStats:
     """Cache statistics."""
@@ -21,7 +67,7 @@ class CacheStats:
     misses: int = 0
     total_entries: int = 0
     cache_size_bytes: int = 0
-    
+
     @property
     def hit_rate(self) -> float:
         """Calculate cache hit rate."""
@@ -29,229 +75,256 @@ class CacheStats:
         return self.hits / total if total > 0 else 0.0
 
 
+# ---------------------------------------------------------------------------
+# VerificationCache
+# ---------------------------------------------------------------------------
+
 class VerificationCache:
-    """
-    Smart cache for verification results.
-    
-    Features:
-    - SQLite-based persistent storage
-    - SHA256 hashing for cache keys
-    - TTL (time-to-live) expiration
-    - Size limits (max 1000 entries)
-    - Query normalization
-    
-    Example:
+    """Context-bound cache for verification results.
+
+    Cache hits require an exact match of both the normalized query **and**
+    the trust-bound :class:`CacheContext`.  A mismatch on any context
+    dimension is a deterministic cache miss.  This prevents cross-session,
+    cross-provider, and cross-policy replay of verification artifacts.
+
+    Legacy entries stored without a context fingerprint are **never** returned.
+
+    Example::
+
+        from qwed_sdk.cache import CacheContext, VerificationCache
+
+        ctx = CacheContext(provider="openai", model="gpt-4o", policy_version="v1")
         cache = VerificationCache()
-        
-        # Cache miss (first time)
-        result = cache.get("2+2")  # None
-        cache.set("2+2", {"verified": True, "value": 4})
-        
-        # Cache hit (instant!)
-        result = cache.get("2+2")  # {"verified": True, "value": 4}
+
+        result = cache.get("2+2", ctx)       # None (miss)
+        cache.set("2+2", {"verified": True}, ctx)
+        result = cache.get("2+2", ctx)       # hit
+
+        # Different context — deterministic miss (replay prevention)
+        ctx2 = CacheContext(provider="claude", model="claude-opus-4-5", policy_version="v1")
+        result = cache.get("2+2", ctx2)      # None
     """
-    
-    DEFAULT_TTL = 86400  # 24 hours
+
+    DEFAULT_TTL = 86400   # 24 hours
     MAX_ENTRIES = 1000
-    
+
     def __init__(self, cache_dir: Optional[str] = None, ttl: int = DEFAULT_TTL):
-        """
-        Initialize cache.
-        
+        """Initialize cache.
+
         Args:
-            cache_dir: Directory for cache DB (default: ~/.qwed/cache)
-            ttl: Time-to-live in seconds (default: 24 hours)
+            cache_dir: Directory for cache DB (default: ~/.qwed/cache).
+            ttl:       Time-to-live in seconds (default: 24 hours).
         """
         self.ttl = ttl
-        
-        # Setup cache directory
+
         if cache_dir:
             self.cache_dir = Path(cache_dir)
         else:
             self.cache_dir = Path.home() / ".qwed" / "cache"
-        
+
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.db_path = self.cache_dir / "verifications.db"
-        
-        # Stats tracking
+
         self.stats = CacheStats()
-        
-        # Initialize database
         self._init_db()
-    
-    def _init_db(self):
-        """Initialize SQLite database with schema."""
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _init_db(self) -> None:
+        """Initialize SQLite database with the v2 context-bound schema."""
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
-        
-        # Create table
+
+        # v2 table: composite PRIMARY KEY (key, context_fingerprint) ensures
+        # that identical queries stored under different contexts never collide.
         cursor.execute("""
-            CREATE TABLE IF NOT EXISTS cache (
-                key TEXT PRIMARY KEY,
-                query TEXT NOT NULL,
-                result TEXT NOT NULL,
-                created_at INTEGER NOT NULL,
-                accessed_at INTEGER NOT NULL,
-                access_count INTEGER DEFAULT 1
+            CREATE TABLE IF NOT EXISTS cache_v2 (
+                key                 TEXT NOT NULL,
+                context_fingerprint TEXT NOT NULL,
+                query               TEXT NOT NULL,
+                context_json        TEXT NOT NULL,
+                result              TEXT NOT NULL,
+                created_at          INTEGER NOT NULL,
+                accessed_at         INTEGER NOT NULL,
+                access_count        INTEGER DEFAULT 1,
+                PRIMARY KEY (key, context_fingerprint)
             )
         """)
-        
-        # Create index for faster lookups
+
         cursor.execute("""
-            CREATE INDEX IF NOT EXISTS idx_created_at 
-            ON cache(created_at)
+            CREATE INDEX IF NOT EXISTS idx_v2_created_at
+            ON cache_v2(created_at)
         """)
-        
+
         conn.commit()
         conn.close()
-        
-        # Update stats
         self._update_stats()
-    
+
     def _normalize_query(self, query: str) -> str:
-        """
-        Normalize query for consistent caching.
-        
-        - Lowercase
-        - Strip whitespace
-        - Remove extra spaces
-        """
+        """Normalize query for consistent caching."""
         return " ".join(query.lower().strip().split())
-    
+
     def _hash_query(self, query: str) -> str:
-        """Generate SHA256 hash for query."""
+        """Generate SHA-256 hash for the normalized query."""
         normalized = self._normalize_query(query)
         return hashlib.sha256(normalized.encode()).hexdigest()
-    
-    def get(self, query: str) -> Optional[Dict[str, Any]]:
-        """
-        Get cached result for query.
-        
-        Returns None if not found or expired.
+
+    def _hash_context(self, context: CacheContext) -> str:
+        """Generate SHA-256 hash for the canonical context dict."""
+        canonical = json.dumps(
+            context.canonical_dict(), sort_keys=True, separators=(",", ":")
+        )
+        return hashlib.sha256(canonical.encode()).hexdigest()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get(self, query: str, context: CacheContext) -> Optional[Dict[str, Any]]:
+        """Return cached result for (query, context) or ``None`` on miss.
+
+        A miss is returned when:
+        - No entry exists for this (query, context) pair.
+        - The entry has expired (TTL).
+        - The stored context fingerprint does not match *context* (replay guard).
+
+        Args:
+            query:   The verification query string.
+            context: Trust-bound context that must match exactly.
+
+        Returns:
+            The cached result dict, or ``None`` on any miss.
         """
         key = self._hash_query(query)
-        
+        ctx_fp = self._hash_context(context)
+
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
-        
-        # Get entry
+
         cursor.execute("""
-            SELECT result, created_at, access_count
-            FROM cache
-            WHERE key = ?
-        """, (key,))
-        
+            SELECT result, created_at, access_count, context_fingerprint
+            FROM cache_v2
+            WHERE key = ? AND context_fingerprint = ?
+        """, (key, ctx_fp))
+
         row = cursor.fetchone()
-        
+
         if not row:
             conn.close()
             self.stats.misses += 1
             return None
-        
-        result_json, created_at, access_count = row
-        
-        # Check TTL
+
+        result_json, created_at, access_count, stored_fp = row
+
+        # Re-validate fingerprint (defence-in-depth)
+        if stored_fp != ctx_fp:
+            conn.close()
+            self.stats.misses += 1
+            return None
+
+        # TTL check
         age = time.time() - created_at
         if age > self.ttl:
-            # Expired, delete
-            cursor.execute("DELETE FROM cache WHERE key = ?", (key,))
+            cursor.execute(
+                "DELETE FROM cache_v2 WHERE key = ? AND context_fingerprint = ?",
+                (key, ctx_fp),
+            )
             conn.commit()
             conn.close()
             self.stats.misses += 1
             return None
-        
-        # Update access stats
+
         cursor.execute("""
-            UPDATE cache
+            UPDATE cache_v2
             SET accessed_at = ?, access_count = ?
-            WHERE key = ?
-        """, (int(time.time()), access_count + 1, key))
-        
+            WHERE key = ? AND context_fingerprint = ?
+        """, (int(time.time()), access_count + 1, key, ctx_fp))
+
         conn.commit()
         conn.close()
-        
-        # Cache hit!
+
         self.stats.hits += 1
         return json.loads(result_json)
-    
-    def set(self, query: str, result: Dict[str, Any]):
-        """
-        Cache verification result.
-        
+
+    def set(self, query: str, result: Dict[str, Any], context: CacheContext) -> None:
+        """Store a verification result bound to (query, context).
+
         Args:
-            query: Original query
-            result: Verification result dict
+            query:   The verification query string.
+            result:  Verification result dict to cache.
+            context: Trust-bound context to bind this entry to.
         """
         key = self._hash_query(query)
+        ctx_fp = self._hash_context(context)
         normalized = self._normalize_query(query)
         result_json = json.dumps(result)
+        context_json = json.dumps(context.canonical_dict(), sort_keys=True)
         now = int(time.time())
-        
+
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
-        
-        # Insert or replace
+
         cursor.execute("""
-            INSERT OR REPLACE INTO cache (key, query, result, created_at, accessed_at)
-            VALUES (?, ?, ?, ?, ?)
-        """, (key, normalized, result_json, now, now))
-        
+            INSERT OR REPLACE INTO cache_v2
+                (key, context_fingerprint, query, context_json, result,
+                 created_at, accessed_at, access_count)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+        """, (key, ctx_fp, normalized, context_json, result_json, now, now))
+
         conn.commit()
-        
-        # Check size limit
-        cursor.execute("SELECT COUNT(*) FROM cache")
+
+        cursor.execute("SELECT COUNT(*) FROM cache_v2")
         count = cursor.fetchone()[0]
-        
+
         if count > self.MAX_ENTRIES:
-            # Remove oldest entries
             to_remove = count - self.MAX_ENTRIES
             cursor.execute("""
-                DELETE FROM cache
-                WHERE key IN (
-                    SELECT key FROM cache
+                DELETE FROM cache_v2
+                WHERE (key, context_fingerprint) IN (
+                    SELECT key, context_fingerprint FROM cache_v2
                     ORDER BY accessed_at ASC
                     LIMIT ?
                 )
             """, (to_remove,))
             conn.commit()
-        
+
         conn.close()
         self._update_stats()
-    
-    def clear(self):
+
+    def clear(self) -> None:
         """Clear all cached entries."""
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
-        cursor.execute("DELETE FROM cache")
+        cursor.execute("DELETE FROM cache_v2")
         conn.commit()
         conn.close()
-        
         self.stats = CacheStats()
         self._update_stats()
-    
-    def _update_stats(self):
-        """Update cache statistics."""
+
+    # ------------------------------------------------------------------
+    # Stats
+    # ------------------------------------------------------------------
+
+    def _update_stats(self) -> None:
+        """Update cache statistics from the database."""
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
-        
-        # Count entries
-        cursor.execute("SELECT COUNT(*) FROM cache")
+        cursor.execute("SELECT COUNT(*) FROM cache_v2")
         self.stats.total_entries = cursor.fetchone()[0]
-        
-        # Calculate cache size
-        cursor.execute("SELECT SUM(LENGTH(result)) FROM cache")
+        cursor.execute("SELECT SUM(LENGTH(result)) FROM cache_v2")
         size = cursor.fetchone()[0]
         self.stats.cache_size_bytes = size or 0
-        
         conn.close()
-    
+
     def get_stats(self) -> CacheStats:
-        """Get current cache statistics."""
+        """Return current cache statistics."""
         self._update_stats()
         return self.stats
-    
-    def print_stats(self):
-        """Print cache statistics with colors."""
+
+    def print_stats(self) -> None:
+        """Print cache statistics."""
         stats = self.get_stats()
 
         brand = info = success = value = reset = ""
@@ -266,7 +339,6 @@ class VerificationCache:
             reset = Style.RESET_ALL
             has_color = True
         except ImportError:
-            # colorama is optional; keep plain-text output fallback.
             has_color = False
 
         if has_color:

--- a/qwed_sdk/qwed_local.py
+++ b/qwed_sdk/qwed_local.py
@@ -600,10 +600,12 @@ class QWEDLocal:
         
         # Initialize cache if enabled
         if self.use_cache:
-            from qwed_sdk.cache import VerificationCache
+            from qwed_sdk.cache import CacheContext, VerificationCache
             self._cache = VerificationCache(ttl=cache_ttl)
+            self._CacheContext = CacheContext
         else:
             self._cache = None
+            self._CacheContext = None
         
         # Initialize PII detector (optional)
         self.mask_pii = mask_pii
@@ -784,7 +786,12 @@ class QWEDLocal:
         
         # Check cache first (save $$!)
         if self._cache:
-            cached_result = self._cache.get(query)
+            _math_ctx = self._CacheContext(
+                provider=self.provider or "local",
+                model=self.model,
+                policy_version="v1",
+            )
+            cached_result = self._cache.get(query, _math_ctx)
             if cached_result:
                 if HAS_COLOR and os.getenv("QWED_QUIET") != "1":
                     print(f"{QWED.SUCCESS}⚡ Cache HIT{QWED.RESET} {QWED.INFO}(saved API call!){QWED.RESET}")
@@ -856,7 +863,7 @@ SymPy code:"""
                         "confidence": result.confidence,
                         "evidence": result.evidence
                     }
-                    self._cache.set(query, cache_data)
+                    self._cache.set(query, cache_data, _math_ctx)
                 
                 # Show result with branding
                 if HAS_COLOR and os.getenv("QWED_QUIET") != "1":
@@ -908,7 +915,12 @@ SymPy code:"""
         
         # Check cache first
         if self._cache:
-            cached_result = self._cache.get(query)
+            _logic_ctx = self._CacheContext(
+                provider=self.provider or "local",
+                model=self.model,
+                policy_version="v1",
+            )
+            cached_result = self._cache.get(query, _logic_ctx)
             if cached_result:
                 if HAS_COLOR and os.getenv("QWED_QUIET") != "1":
                     print(f"{QWED.SUCCESS}⚡ Cache HIT{QWED.RESET} {QWED.INFO}(saved API call!){QWED.RESET}")
@@ -996,7 +1008,7 @@ Z3 code:"""
                         "confidence": verification_result.confidence,
                         "evidence": verification_result.evidence
                     }
-                    self._cache.set(query, cache_data)
+                    self._cache.set(query, cache_data, _logic_ctx)
                 
                 # Show result
                 if HAS_COLOR and os.getenv("QWED_QUIET") != "1":
@@ -1048,7 +1060,12 @@ Z3 code:"""
         # Check cache first
         cache_key = f"code:{code}"
         if self._cache:
-            cached_result = self._cache.get(cache_key)
+            _code_ctx = self._CacheContext(
+                provider=self.provider or "local",
+                model="ast",
+                policy_version="v1",
+            )
+            cached_result = self._cache.get(cache_key, _code_ctx)
             if cached_result:
                 if HAS_COLOR and os.getenv("QWED_QUIET") != "1":
                     print(f"{QWED.SUCCESS}⚡ Cache HIT{QWED.RESET} {QWED.INFO}(saved API call!){QWED.RESET}")
@@ -1112,7 +1129,7 @@ Z3 code:"""
                     "confidence": result.confidence,
                     "evidence": result.evidence
                 }
-                self._cache.set(cache_key, cache_data)
+                self._cache.set(cache_key, cache_data, _code_ctx)
             
             # Show result
             if HAS_COLOR and os.getenv("QWED_QUIET") != "1":

--- a/qwed_sdk/qwed_local.py
+++ b/qwed_sdk/qwed_local.py
@@ -602,10 +602,10 @@ class QWEDLocal:
         if self.use_cache:
             from qwed_sdk.cache import CacheContext, VerificationCache
             self._cache = VerificationCache(ttl=cache_ttl)
-            self._CacheContext = CacheContext
+            self._cache_context_class = CacheContext
         else:
             self._cache = None
-            self._CacheContext = None
+            self._cache_context_class = None
         
         # Initialize PII detector (optional)
         self.mask_pii = mask_pii
@@ -786,7 +786,7 @@ class QWEDLocal:
         
         # Check cache first (save $$!)
         if self._cache:
-            _math_ctx = self._CacheContext(
+            _math_ctx = self._cache_context_class(
                 provider=self.provider or "local",
                 model=self.model,
                 policy_version="v1",
@@ -915,7 +915,7 @@ SymPy code:"""
         
         # Check cache first
         if self._cache:
-            _logic_ctx = self._CacheContext(
+            _logic_ctx = self._cache_context_class(
                 provider=self.provider or "local",
                 model=self.model,
                 policy_version="v1",
@@ -1060,7 +1060,7 @@ Z3 code:"""
         # Check cache first
         cache_key = f"code:{code}"
         if self._cache:
-            _code_ctx = self._CacheContext(
+            _code_ctx = self._cache_context_class(
                 provider=self.provider or "local",
                 model="ast",
                 policy_version="v1",

--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -36,8 +36,9 @@ assert result is not None, "Should be cache HIT"
 assert result["value"] == 4, "Value should be 4"
 print("  ✅ Cache HIT works")
 
-# Query normalization (case)
-result = cache.get("2+2".upper(), ctx)
+# Query normalization (case) — use a word query where case actually changes
+cache.set("Verify Math Query", {"verified": True, "value": "ok"}, ctx)
+result = cache.get("verify math query", ctx)   # lowercase lookup
 assert result is not None, "Should normalize case"
 print("  ✅ Case normalization works")
 

--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -1,126 +1,65 @@
 """
-Quick test script for QWEDLocal with Caching + CLI simulation.
+Smoke test for VerificationCache context-bound API.
 
-Run this to test:
-1. Cache functionality
-2. QWEDLocal with mock LLM
+Updated for Issue #187: get/set now require a CacheContext argument.
 """
 
 import sys
 sys.path.insert(0, ".")
 
-from qwed_sdk.qwed_local import QWEDLocal, VerificationResult
-from qwed_sdk.cache import VerificationCache
+from qwed_sdk.cache import CacheContext, VerificationCache
 
 print("=" * 60)
-print("🧪 Testing QWEDLocal Cache + CLI Features")
+print("🧪 Testing VerificationCache (context-bound, Issue #187)")
 print("=" * 60)
+
+ctx = CacheContext(provider="openai", model="gpt-4o", policy_version="v1")
 
 # Test 1: Cache Basic Functionality
 print("\n1️⃣ Testing Cache...")
 cache = VerificationCache()
-cache.clear()  # Start fresh!
+cache.clear()
 print("  ✅ Cache cleared (starting fresh)")
 
-# First query (miss)
-result = cache.get("2+2")
+# Cache miss
+result = cache.get("2+2", ctx)
 assert result is None, "Should be cache MISS"
 print("  ✅ Cache MISS works")
 
 # Set cache
-cache.set("2+2", {"verified": True, "value": 4, "confidence": 1.0, "evidence": {}})
+cache.set("2+2", {"verified": True, "value": 4, "confidence": 1.0, "evidence": {}}, ctx)
 print("  ✅ Cache SET works")
 
-# Second query (hit!)
-result = cache.get("2+2")
+# Cache hit
+result = cache.get("2+2", ctx)
 assert result is not None, "Should be cache HIT"
 assert result["value"] == 4, "Value should be 4"
 print("  ✅ Cache HIT works")
 
-# Test case normalization
-result = cache.get("2+2".upper())  # "2+2" -> normalized same
+# Query normalization (case)
+result = cache.get("2+2".upper(), ctx)
 assert result is not None, "Should normalize case"
 print("  ✅ Case normalization works")
 
-# Test with extra whitespace
-cache.set("   Test   Query   ", {"verified": True, "value": "test"})
-result = cache.get("test query")  # Should normalize to same
+# Whitespace normalization
+cache.set("   Test   Query   ", {"verified": True, "value": "test"}, ctx)
+result = cache.get("test query", ctx)
 assert result is not None, "Should normalize whitespace"
 print("  ✅ Whitespace normalization works")
+
+# Context mismatch → miss
+ctx_b = CacheContext(provider="claude", model="claude-opus-4-5", policy_version="v1")
+result = cache.get("2+2", ctx_b)
+assert result is None, "Cross-context lookup must be a miss"
+print("  ✅ Cross-context miss works (replay prevention)")
 
 # Print stats
 print("\n📊 Cache Stats:")
 cache.print_stats()
 
-# Clear cache
 cache.clear()
 print("✅ Cache cleared")
 
 print("\n" + "=" * 60)
-print("2️⃣ Testing QWEDLocal Initialization...")
-print("=" * 60)
-
-# Test with caching enabled
-try:
-    client = QWEDLocal(
-        base_url="http://localhost:11434/v1",
-        model="llama3",
-        cache=True
-    )
-    print("  ✅ Client with cache initialized")
-    print(f"  ✅ Cache enabled: {client.use_cache}")
-    
-    # Test cache_stats property
-    stats = client.cache_stats
-    print(f"  ✅ Cache stats accessible: {stats}")
-    
-except Exception as e:
-    print(f"  ❌ Error: {e}")
-
-# Test without caching
-try:
-    client_no_cache = QWEDLocal(
-        base_url="http://localhost:11434/v1",
-        model="llama3", 
-        cache=False
-    )
-    print("  ✅ Client without cache initialized")
-    print(f"  ✅ Cache disabled: {not client_no_cache.use_cache}")
-    
-except Exception as e:
-    print(f"  ❌ Error: {e}")
-
-print("\n" + "=" * 60)
-print("3️⃣ Manual CLI Test Instructions")
-print("=" * 60)
-
-print("""
-To test the CLI, run these commands manually:
-
-1. Install in development mode:
-   pip install -e .
-
-2. Test basic verification:
-   qwed verify "What is 2+2?"
-   
-3. Test with Ollama (if running):
-   qwed verify "derivative of x^2" --base-url http://localhost:11434/v1 --model llama3
-
-4. Test cache stats:
-   qwed cache stats
-
-5. Test interactive mode:
-   qwed interactive
-   > What is 2+2?
-   > exit
-
-6. Test help:
-   qwed --help
-   qwed verify --help
-
-""")
-
-print("=" * 60)
 print("✅ All automated tests PASSED!")
 print("=" * 60)
-print("\n👆 Follow manual CLI test instructions above!")

--- a/tests/test_pr114_regressions.py
+++ b/tests/test_pr114_regressions.py
@@ -66,10 +66,11 @@ def test_unreadable_code_challenge_requires_allow_unsafe_exec(monkeypatch):
 
 
 def test_cache_print_stats_falls_back_without_colorama(tmp_path, monkeypatch):
-    from qwed_sdk.cache import VerificationCache
+    from qwed_sdk.cache import CacheContext, VerificationCache
 
     cache = VerificationCache(cache_dir=str(tmp_path))
-    cache.set("2+2", {"verified": True, "value": 4})
+    ctx = CacheContext(provider="openai", model="gpt-4o", policy_version="v1")
+    cache.set("2+2", {"verified": True, "value": 4}, ctx)
 
     original_import = builtins.__import__
 

--- a/tests/test_pr187_cache_context_binding.py
+++ b/tests/test_pr187_cache_context_binding.py
@@ -1,0 +1,207 @@
+"""
+Regression tests for Issue #187:
+VerificationCache cache key is query-only, enabling cross-context replay.
+
+Acceptance criteria:
+- Cache hit occurs ONLY when query and all context-bound fields match exactly.
+- Context mismatch always yields miss.
+- Legacy (query-only) entries are never auto-trusted.
+- Tests cover provider switch, policy version change, session/tenant change.
+"""
+
+import pytest
+from pathlib import Path
+
+from qwed_sdk.cache import CacheContext, VerificationCache
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ctx(**overrides) -> CacheContext:
+    defaults = dict(provider="openai", model="gpt-4o", policy_version="v1", tenant_id=None)
+    defaults.update(overrides)
+    return CacheContext(**defaults)
+
+
+RESULT_A = {"status": "VERIFIED", "verified": True, "provider": "openai"}
+RESULT_B = {"status": "VERIFIED", "verified": True, "provider": "claude"}
+
+
+# ---------------------------------------------------------------------------
+# Core context-binding tests
+# ---------------------------------------------------------------------------
+
+class TestContextBinding:
+    """Cache key must include all context dimensions, not query alone."""
+
+    def test_hit_on_exact_context_match(self, tmp_path):
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx = _make_ctx()
+        cache.set("2+2", RESULT_A, ctx)
+
+        result = cache.get("2+2", ctx)
+
+        assert result is not None
+        assert result["verified"] is True
+
+    def test_miss_on_provider_change(self, tmp_path):
+        """Provider switch must yield a cache miss — replay prevention."""
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx_a = _make_ctx(provider="openai")
+        ctx_b = _make_ctx(provider="claude")
+
+        cache.set("2+2", RESULT_A, ctx_a)
+        result = cache.get("2+2", ctx_b)
+
+        assert result is None, "Different provider must not return cached result from provider_a"
+
+    def test_miss_on_model_change(self, tmp_path):
+        """Model change must yield a cache miss."""
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx_a = _make_ctx(model="gpt-4o")
+        ctx_b = _make_ctx(model="gpt-3.5-turbo")
+
+        cache.set("what is 1+1?", {"verified": True}, ctx_a)
+        result = cache.get("what is 1+1?", ctx_b)
+
+        assert result is None
+
+    def test_miss_on_policy_version_change(self, tmp_path):
+        """Policy version change must yield a cache miss."""
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx_v1 = _make_ctx(policy_version="v1")
+        ctx_v2 = _make_ctx(policy_version="v2")
+
+        cache.set("derivative of x^2", {"verified": True}, ctx_v1)
+        result = cache.get("derivative of x^2", ctx_v2)
+
+        assert result is None
+
+    def test_miss_on_tenant_change(self, tmp_path):
+        """Tenant/session scope change must yield a cache miss."""
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx_tenant_a = _make_ctx(tenant_id="tenant-alpha")
+        ctx_tenant_b = _make_ctx(tenant_id="tenant-beta")
+
+        cache.set("is x > 0?", {"verified": True}, ctx_tenant_a)
+        result = cache.get("is x > 0?", ctx_tenant_b)
+
+        assert result is None
+
+    def test_miss_on_env_fingerprint_change(self, tmp_path):
+        """Environment fingerprint change must yield a cache miss."""
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx_env1 = _make_ctx(env_fingerprint="hash-abc")
+        ctx_env2 = _make_ctx(env_fingerprint="hash-def")
+
+        cache.set("2+2", RESULT_A, ctx_env1)
+        result = cache.get("2+2", ctx_env2)
+
+        assert result is None
+
+    def test_same_query_different_context_both_stored_independently(self, tmp_path):
+        """Different contexts for the same query must be stored as independent entries."""
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx_a = _make_ctx(provider="openai")
+        ctx_b = _make_ctx(provider="claude")
+
+        cache.set("2+2", RESULT_A, ctx_a)
+        cache.set("2+2", RESULT_B, ctx_b)
+
+        assert cache.get("2+2", ctx_a)["provider"] == "openai"
+        assert cache.get("2+2", ctx_b)["provider"] == "claude"
+
+    def test_query_normalization_still_applies(self, tmp_path):
+        """Query normalization (case, whitespace) must still produce a hit within same context."""
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx = _make_ctx()
+
+        cache.set("  2 + 2  ", RESULT_A, ctx)
+        result = cache.get("2 + 2", ctx)
+
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# TTL behaviour
+# ---------------------------------------------------------------------------
+
+class TestTTL:
+    def test_expired_entry_is_a_miss(self, tmp_path, monkeypatch):
+        import qwed_sdk.cache as cache_module
+
+        current_time = {"value": 1000.0}
+        monkeypatch.setattr(cache_module.time, "time", lambda: current_time["value"])
+
+        cache = VerificationCache(cache_dir=str(tmp_path), ttl=10)
+        ctx = _make_ctx()
+        cache.set("2+2", RESULT_A, ctx)
+
+        current_time["value"] += 15.0  # advance past TTL
+        result = cache.get("2+2", ctx)
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Stats and helpers
+# ---------------------------------------------------------------------------
+
+class TestStats:
+    def test_hit_increments_hit_counter(self, tmp_path):
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx = _make_ctx()
+        cache.set("2+2", RESULT_A, ctx)
+        cache.get("2+2", ctx)
+
+        assert cache.stats.hits == 1
+        assert cache.stats.misses == 0
+
+    def test_miss_increments_miss_counter(self, tmp_path):
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx = _make_ctx()
+        cache.get("unseen query", ctx)
+
+        assert cache.stats.hits == 0
+        assert cache.stats.misses == 1
+
+    def test_context_mismatch_increments_miss_counter(self, tmp_path):
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx_a = _make_ctx(provider="openai")
+        ctx_b = _make_ctx(provider="claude")
+        cache.set("2+2", RESULT_A, ctx_a)
+        cache.get("2+2", ctx_b)  # context mismatch
+
+        assert cache.stats.misses == 1
+
+    def test_clear_resets_all_entries(self, tmp_path):
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx = _make_ctx()
+        cache.set("2+2", RESULT_A, ctx)
+        cache.clear()
+
+        assert cache.get("2+2", ctx) is None
+        assert cache.get_stats().total_entries == 0
+
+    def test_print_stats_plain_fallback(self, tmp_path, capsys):
+        """print_stats must work without colorama installed."""
+        import builtins
+        original_import = builtins.__import__
+
+        def fake_import(name, globals_=None, locals_=None, fromlist=(), level=0):
+            if name == "colorama":
+                raise ImportError("colorama unavailable in test")
+            return original_import(name, globals_, locals_, fromlist, level)
+
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx = _make_ctx()
+        cache.set("2+2", RESULT_A, ctx)
+
+        import unittest.mock as mock
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            cache.print_stats()
+
+        output = capsys.readouterr().out
+        assert "Cache Statistics" in output

--- a/tests/test_pr187_cache_context_binding.py
+++ b/tests/test_pr187_cache_context_binding.py
@@ -9,9 +9,10 @@ Acceptance criteria:
 - Tests cover provider switch, policy version change, session/tenant change.
 """
 
-import pytest
+import sqlite3
 from pathlib import Path
 
+import qwed_sdk.cache as cache_module
 from qwed_sdk.cache import CacheContext, VerificationCache
 
 
@@ -123,6 +124,33 @@ class TestContextBinding:
 
         assert result is not None
 
+    def test_legacy_v1_entry_is_never_returned(self, tmp_path):
+        """Legacy query-only rows stored in the old 'cache' table must never be returned.
+
+        A direct DB insert into the legacy table simulates an upgrade scenario
+        where old entries exist.  get() must treat them as misses — they have no
+        context fingerprint and cannot satisfy the trust-bound hit contract.
+        """
+        cache = VerificationCache(cache_dir=str(tmp_path))
+        ctx = _make_ctx()
+
+        # Insert a legacy-style row directly into a hypothetical 'cache' v1 table
+        legacy_key = cache._hash_query("2+2")
+        db_path = Path(tmp_path) / "verifications.db"
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS cache "
+                "(key TEXT PRIMARY KEY, result TEXT, created_at INTEGER)"
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO cache (key, result, created_at) VALUES (?, ?, ?)",
+                (legacy_key, '{"verified": true, "value": 4}', 1_000_000),
+            )
+            conn.commit()
+
+        # get() must never touch the legacy table — deterministic miss
+        assert cache.get("2+2", ctx) is None
+
 
 # ---------------------------------------------------------------------------
 # TTL behaviour
@@ -130,16 +158,13 @@ class TestContextBinding:
 
 class TestTTL:
     def test_expired_entry_is_a_miss(self, tmp_path, monkeypatch):
-        import qwed_sdk.cache as cache_module
-
-        current_time = {"value": 1000.0}
-        monkeypatch.setattr(cache_module.time, "time", lambda: current_time["value"])
+        monkeypatch.setattr(cache_module.time, "time", lambda: 1000.0)
 
         cache = VerificationCache(cache_dir=str(tmp_path), ttl=10)
         ctx = _make_ctx()
         cache.set("2+2", RESULT_A, ctx)
 
-        current_time["value"] += 15.0  # advance past TTL
+        monkeypatch.setattr(cache_module.time, "time", lambda: 1015.0)  # advance past TTL
         result = cache.get("2+2", ctx)
 
         assert result is None

--- a/tests/test_pr187_cache_context_binding.py
+++ b/tests/test_pr187_cache_context_binding.py
@@ -13,17 +13,16 @@ import sqlite3
 from pathlib import Path
 
 import qwed_sdk.cache as cache_module
-from qwed_sdk.cache import CacheContext, VerificationCache
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_ctx(**overrides) -> CacheContext:
+def _make_ctx(**overrides) -> "cache_module.CacheContext":
     defaults = dict(provider="openai", model="gpt-4o", policy_version="v1", tenant_id=None)
     defaults.update(overrides)
-    return CacheContext(**defaults)
+    return cache_module.CacheContext(**defaults)
 
 
 RESULT_A = {"status": "VERIFIED", "verified": True, "provider": "openai"}
@@ -38,7 +37,7 @@ class TestContextBinding:
     """Cache key must include all context dimensions, not query alone."""
 
     def test_hit_on_exact_context_match(self, tmp_path):
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx = _make_ctx()
         cache.set("2+2", RESULT_A, ctx)
 
@@ -49,7 +48,7 @@ class TestContextBinding:
 
     def test_miss_on_provider_change(self, tmp_path):
         """Provider switch must yield a cache miss — replay prevention."""
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx_a = _make_ctx(provider="openai")
         ctx_b = _make_ctx(provider="claude")
 
@@ -60,7 +59,7 @@ class TestContextBinding:
 
     def test_miss_on_model_change(self, tmp_path):
         """Model change must yield a cache miss."""
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx_a = _make_ctx(model="gpt-4o")
         ctx_b = _make_ctx(model="gpt-3.5-turbo")
 
@@ -71,7 +70,7 @@ class TestContextBinding:
 
     def test_miss_on_policy_version_change(self, tmp_path):
         """Policy version change must yield a cache miss."""
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx_v1 = _make_ctx(policy_version="v1")
         ctx_v2 = _make_ctx(policy_version="v2")
 
@@ -82,7 +81,7 @@ class TestContextBinding:
 
     def test_miss_on_tenant_change(self, tmp_path):
         """Tenant/session scope change must yield a cache miss."""
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx_tenant_a = _make_ctx(tenant_id="tenant-alpha")
         ctx_tenant_b = _make_ctx(tenant_id="tenant-beta")
 
@@ -93,7 +92,7 @@ class TestContextBinding:
 
     def test_miss_on_env_fingerprint_change(self, tmp_path):
         """Environment fingerprint change must yield a cache miss."""
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx_env1 = _make_ctx(env_fingerprint="hash-abc")
         ctx_env2 = _make_ctx(env_fingerprint="hash-def")
 
@@ -104,7 +103,7 @@ class TestContextBinding:
 
     def test_same_query_different_context_both_stored_independently(self, tmp_path):
         """Different contexts for the same query must be stored as independent entries."""
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx_a = _make_ctx(provider="openai")
         ctx_b = _make_ctx(provider="claude")
 
@@ -116,7 +115,7 @@ class TestContextBinding:
 
     def test_query_normalization_still_applies(self, tmp_path):
         """Query normalization (case, whitespace) must still produce a hit within same context."""
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx = _make_ctx()
 
         cache.set("  2 + 2  ", RESULT_A, ctx)
@@ -131,7 +130,7 @@ class TestContextBinding:
         where old entries exist.  get() must treat them as misses — they have no
         context fingerprint and cannot satisfy the trust-bound hit contract.
         """
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx = _make_ctx()
 
         # Insert a legacy-style row directly into a hypothetical 'cache' v1 table
@@ -160,7 +159,7 @@ class TestTTL:
     def test_expired_entry_is_a_miss(self, tmp_path, monkeypatch):
         monkeypatch.setattr(cache_module.time, "time", lambda: 1000.0)
 
-        cache = VerificationCache(cache_dir=str(tmp_path), ttl=10)
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path), ttl=10)
         ctx = _make_ctx()
         cache.set("2+2", RESULT_A, ctx)
 
@@ -176,7 +175,7 @@ class TestTTL:
 
 class TestStats:
     def test_hit_increments_hit_counter(self, tmp_path):
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx = _make_ctx()
         cache.set("2+2", RESULT_A, ctx)
         cache.get("2+2", ctx)
@@ -185,7 +184,7 @@ class TestStats:
         assert cache.stats.misses == 0
 
     def test_miss_increments_miss_counter(self, tmp_path):
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx = _make_ctx()
         cache.get("unseen query", ctx)
 
@@ -193,7 +192,7 @@ class TestStats:
         assert cache.stats.misses == 1
 
     def test_context_mismatch_increments_miss_counter(self, tmp_path):
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx_a = _make_ctx(provider="openai")
         ctx_b = _make_ctx(provider="claude")
         cache.set("2+2", RESULT_A, ctx_a)
@@ -202,7 +201,7 @@ class TestStats:
         assert cache.stats.misses == 1
 
     def test_clear_resets_all_entries(self, tmp_path):
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx = _make_ctx()
         cache.set("2+2", RESULT_A, ctx)
         cache.clear()
@@ -213,6 +212,8 @@ class TestStats:
     def test_print_stats_plain_fallback(self, tmp_path, capsys):
         """print_stats must work without colorama installed."""
         import builtins
+        import unittest.mock as mock
+
         original_import = builtins.__import__
 
         def fake_import(name, globals_=None, locals_=None, fromlist=(), level=0):
@@ -220,11 +221,10 @@ class TestStats:
                 raise ImportError("colorama unavailable in test")
             return original_import(name, globals_, locals_, fromlist, level)
 
-        cache = VerificationCache(cache_dir=str(tmp_path))
+        cache = cache_module.VerificationCache(cache_dir=str(tmp_path))
         ctx = _make_ctx()
         cache.set("2+2", RESULT_A, ctx)
 
-        import unittest.mock as mock
         with mock.patch("builtins.__import__", side_effect=fake_import):
             cache.print_stats()
 


### PR DESCRIPTION
## Summary
`VerificationCache` computed its lookup key from the normalized query
string only (`_hash_query(query)`).  This allowed any caller to replay a
prior `VERIFIED` result from a completely different provider, model,
policy version, or tenant session — a replay attack at the trust boundary.

## Root cause
`_hash_query()` → `SHA-256(normalized_query)`.  Context (provider, model,
policy, tenant) was never part of the key, so two identical query strings
always hit the same cache slot regardless of their trust context.

## Fix

### New `CacheContext` datatype
```python
ctx = CacheContext(
    provider="openai",
    model="gpt-4o",
    policy_version="v1",
    tenant_id="tenant-alpha",       # optional
    env_fingerprint="sha256-...",   # optional
)
```

### Context-bound composite key
Key = `SHA-256(normalized_query)` × `SHA-256(canonical_context_json)`

### Schema v2 (`cache_v2`)

* Composite `PRIMARY KEY (key, context_fingerprint)` — physically impossible for two contexts to collide.
* `context_fingerprint` stored per-entry and re-validated on every read (defence-in-depth).
* Legacy `cache` (v1) table entries are never returned — they are dead weight that no path reaches.

### API change
`get()` and `set()` now require a `CacheContext` argument:

```python
cache.get("2+2", ctx)           # ✅
cache.set("2+2", result, ctx)   # ✅
cache.get("2+2")                # ❌ TypeError
```

### Tests (`test_pr187_cache_context_binding.py`)
All acceptance criteria covered:

* ✅ Hit on exact context match
* ✅ Miss on provider change (replay prevention)
* ✅ Miss on model change
* ✅ Miss on policy version change
* ✅ Miss on tenant/session change
* ✅ Miss on env fingerprint change
* ✅ Same query, different contexts stored independently
* ✅ Query normalization still applies within same context
* ✅ TTL expiry yields miss
* ✅ Stats counters (hits, misses, context-mismatch)

16/16 tests passing ✅

## Acceptance criteria

* Cache hit only when query + all context-bound fields match exactly
* Context mismatch always yields miss
* Legacy cache entries never auto-trusted
* Tests cover provider switch, policy version change, session/tenant change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache now binds verification results to context (provider, model, policy version, tenant ID, environment), ensuring cache hits only occur when all context dimensions match, preventing results from being shared across different trust boundaries.

* **Tests**
  * Added comprehensive test coverage for context-bound caching behavior, including TTL expiration, cache statistics, and cross-context lookup validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-verification/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->