### PR TITLE
fix(cache): enforce fail-closed Redis backend for distributed mode

### DIFF
--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -632,10 +632,12 @@ class RedisCache:
                 "tenant_id": self.tenant_id,
             }
         except Exception:
+            with self._fallback_lock:
+                degraded = self._fallback_cache is not None
             return {
                 "backend": "redis",
                 "mode": self.mode,
-                "degraded": self._fallback_cache is not None,
+                "degraded": degraded,
                 "backend_error": True,
                 "hits": self._hits,
                 "misses": self._misses,
@@ -700,43 +702,33 @@ def get_cache(
     # Redis path — per-(tenant_id, mode) singleton, locked to prevent races
     cache_key = (tenant_id, mode)
 
-    # Fast path: return existing cache without blocking.
-    with _cache_factory_lock:
-        cache = _redis_caches.get(cache_key)
-        if cache is not None:
-            return cache
-        # Check per-key cooldown before attempting a new connection.
-        retry_after = _redis_cache_retry_after.get(cache_key, 0.0)
-        if time.time() < retry_after:
-            raise CacheBackendUnavailableError(
-                f"RedisCache(mode={mode.value}): Redis backend unavailable "
-                f"(cooldown active for {retry_after - time.time():.0f}s). "
-                "Fail-closed."
-            )
-        # Prevent concurrent construction pile-up: if another thread is
-        # already constructing this cache_key, don't start a second
-        # blocking network call.
-        if cache_key in _constructing_events:
-            # Another thread is constructing; wait for it instead of pile-up.
-            event = _constructing_events[cache_key]
-            # Release factory lock while waiting so we don't block others.
-            _cache_factory_lock.release()
-            try:
-                event.wait(timeout=10.0)  # bounded wait
-            finally:
-                _cache_factory_lock.acquire()
-            # After wait, the cache should be in the dict (or cooldown set).
+    # Fast path: return existing cache without blocking. If another thread is
+    # already constructing this key, wait outside the factory lock and re-check.
+    while True:
+        with _cache_factory_lock:
             cache = _redis_caches.get(cache_key)
             if cache is not None:
                 return cache
-            # Construction failed. Do not hand out an unregistered local cache:
-            # it would silently lose writes and bypass EXPLICIT_DEGRADED markers.
+            # Check per-key cooldown before attempting a new connection.
+            retry_after = _redis_cache_retry_after.get(cache_key, 0.0)
+            if time.time() < retry_after:
+                raise CacheBackendUnavailableError(
+                    f"RedisCache(mode={mode.value}): Redis backend unavailable "
+                    f"(cooldown active for {retry_after - time.time():.0f}s). "
+                    "Fail-closed."
+                )
+            event = _constructing_events.get(cache_key)
+            if event is None:
+                event = Event()
+                _constructing_events[cache_key] = event
+                break
+
+        completed = event.wait(timeout=10.0)
+        if not completed and mode == CacheBackendMode.STRICT_DISTRIBUTED:
             raise CacheBackendUnavailableError(
-                f"RedisCache(mode={mode.value}): Construction by another thread failed. "
-                "Retry after cooldown."
+                f"RedisCache(mode={mode.value}): Cache construction timed out. "
+                "Fail-closed."
             )
-        event = Event()
-        _constructing_events[cache_key] = event
 
     # Construct outside the lock -- RedisCache.__init__ calls
     # get_redis_client() which may block on a 5-second network timeout.

--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -526,6 +526,7 @@ class RedisCache:
                 _STRICT_COOLDOWN_MSG
             )
 
+        redis_failed = False
         if client is not None:
             try:
                 ret = client.delete(key) > 0
@@ -535,10 +536,17 @@ class RedisCache:
 
             except Exception as exc:
                 self._handle_runtime_redis_error("invalidate", exc)
+                redis_failed = True
 
         fallback = None
         with self._fallback_lock:
             fallback = self._fallback_cache
+
+        if redis_failed:
+            raise CacheBackendUnavailableError(
+                "RedisCache(mode=EXPLICIT_DEGRADED): Redis invalidate failed. "
+                "Cannot confirm distributed deletion from node-local fallback."
+            )
 
         if fallback is not None:
             return fallback.invalidate(dsl_code, variables)
@@ -579,6 +587,7 @@ class RedisCache:
                 _STRICT_UNAVAILABLE_MSG +
                 _STRICT_COOLDOWN_MSG
             )
+        redis_failed = False
         if client is not None:
             try:
                 if pattern is None:
@@ -594,10 +603,17 @@ class RedisCache:
 
             except Exception as exc:
                 self._handle_runtime_redis_error("clear", exc)
+                redis_failed = True
 
         fallback = None
         with self._fallback_lock:
             fallback = self._fallback_cache
+
+        if redis_failed:
+            raise CacheBackendUnavailableError(
+                "RedisCache(mode=EXPLICIT_DEGRADED): Redis clear failed. "
+                "Cannot confirm distributed deletion from node-local fallback."
+            )
 
         if fallback is not None:
             return fallback.clear()
@@ -666,6 +682,55 @@ _constructing_events: Dict[tuple, Event] = {}  # signals when construction compl
 _cache_factory_lock = Lock()
 
 
+def _get_or_create_local_cache(tenant_id: Optional[int]) -> VerificationCache:
+    with _cache_factory_lock:
+        cache = _verification_caches.get(tenant_id)
+        if cache is None:
+            cache = VerificationCache()
+            _verification_caches[tenant_id] = cache
+    return cache
+
+
+def _raise_if_retry_cooldown_active(cache_key: tuple, mode: CacheBackendMode) -> None:
+    retry_after = _redis_cache_retry_after.get(cache_key, 0.0)
+    if time.time() < retry_after:
+        raise CacheBackendUnavailableError(
+            f"RedisCache(mode={mode.value}): Redis backend unavailable "
+            f"(cooldown active for {retry_after - time.time():.0f}s). "
+            "Fail-closed."
+        )
+
+
+def _await_or_claim_redis_cache_construction(
+    cache_key: tuple,
+    mode: CacheBackendMode,
+) -> tuple[Optional[RedisCache], Event]:
+    while True:
+        with _cache_factory_lock:
+            cache = _redis_caches.get(cache_key)
+            if cache is not None:
+                return cache, Event()
+            _raise_if_retry_cooldown_active(cache_key, mode)
+            event = _constructing_events.get(cache_key)
+            if event is None:
+                event = Event()
+                _constructing_events[cache_key] = event
+                return None, event
+
+        completed = event.wait(timeout=10.0)
+        if not completed and mode == CacheBackendMode.STRICT_DISTRIBUTED:
+            raise CacheBackendUnavailableError(
+                f"RedisCache(mode={mode.value}): Cache construction timed out. "
+                "Fail-closed."
+            )
+
+
+def _record_redis_cache_construction_failure(cache_key: tuple) -> None:
+    with _cache_factory_lock:
+        _constructing_events.pop(cache_key, None)
+        _redis_cache_retry_after[cache_key] = time.time() + RedisCache._CLIENT_RETRY_INTERVAL
+
+
 def get_cache(
     use_redis: bool = True,
     tenant_id: Optional[int] = None,
@@ -689,61 +754,26 @@ def get_cache(
         CacheBackendUnavailableError: when use_redis=True,
             mode=STRICT_DISTRIBUTED, and Redis is unavailable.
     """
-    global _verification_caches, _redis_caches, _redis_cache_retry_after
-
     if not use_redis or mode == CacheBackendMode.LOCAL_ONLY:
-        with _cache_factory_lock:
-            cache = _verification_caches.get(tenant_id)
-            if cache is None:
-                cache = VerificationCache()
-                _verification_caches[tenant_id] = cache
-        return cache
+        return _get_or_create_local_cache(tenant_id)
 
     # Redis path — per-(tenant_id, mode) singleton, locked to prevent races
     cache_key = (tenant_id, mode)
 
-    # Fast path: return existing cache without blocking. If another thread is
-    # already constructing this key, wait outside the factory lock and re-check.
-    while True:
-        with _cache_factory_lock:
-            cache = _redis_caches.get(cache_key)
-            if cache is not None:
-                return cache
-            # Check per-key cooldown before attempting a new connection.
-            retry_after = _redis_cache_retry_after.get(cache_key, 0.0)
-            if time.time() < retry_after:
-                raise CacheBackendUnavailableError(
-                    f"RedisCache(mode={mode.value}): Redis backend unavailable "
-                    f"(cooldown active for {retry_after - time.time():.0f}s). "
-                    "Fail-closed."
-                )
-            event = _constructing_events.get(cache_key)
-            if event is None:
-                event = Event()
-                _constructing_events[cache_key] = event
-                break
-
-        completed = event.wait(timeout=10.0)
-        if not completed and mode == CacheBackendMode.STRICT_DISTRIBUTED:
-            raise CacheBackendUnavailableError(
-                f"RedisCache(mode={mode.value}): Cache construction timed out. "
-                "Fail-closed."
-            )
+    cache, event = _await_or_claim_redis_cache_construction(cache_key, mode)
+    if cache is not None:
+        return cache
 
     # Construct outside the lock -- RedisCache.__init__ calls
     # get_redis_client() which may block on a 5-second network timeout.
     try:
         new_cache = RedisCache(tenant_id=tenant_id, mode=mode)
     except CacheBackendUnavailableError:
-        with _cache_factory_lock:
-            _constructing_events.pop(cache_key, None)
-            _redis_cache_retry_after[cache_key] = time.time() + RedisCache._CLIENT_RETRY_INTERVAL
+        _record_redis_cache_construction_failure(cache_key)
         event.set()  # Wake waiters after state is consistent
         raise
     except Exception:
-        with _cache_factory_lock:
-            _constructing_events.pop(cache_key, None)
-            _redis_cache_retry_after[cache_key] = time.time() + RedisCache._CLIENT_RETRY_INTERVAL
+        _record_redis_cache_construction_failure(cache_key)
         event.set()
         raise
 

--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -729,13 +729,12 @@ def get_cache(
             cache = _redis_caches.get(cache_key)
             if cache is not None:
                 return cache
-            # Construction failed; let caller handle normally.
-            if mode == CacheBackendMode.STRICT_DISTRIBUTED:
-                raise CacheBackendUnavailableError(
-                    _STRICT_UNAVAILABLE_MSG +
-                    "Construction by another thread failed."
-                )
-            return VerificationCache()
+            # Construction failed. Do not hand out an unregistered local cache:
+            # it would silently lose writes and bypass EXPLICIT_DEGRADED markers.
+            raise CacheBackendUnavailableError(
+                f"RedisCache(mode={mode.value}): Construction by another thread failed. "
+                "Retry after cooldown."
+            )
         event = Event()
         _constructing_events[cache_key] = event
 

--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -833,7 +833,7 @@ def cached_verify(
 
 
 # --- DEMO ---
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import time
 
     print("=" * 60)

--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -5,18 +5,81 @@ Caches verification results to reduce latency for repeated queries.
 Logic is universal - same problem = same answer.
 
 Addresses Gemini's feedback on latency:
-- Monty Hall: 12,115ms → ~1ms (cached)
-- Hamiltonian Path: 21,163ms → ~1ms (cached)
+- Monty Hall: 12,115ms -> ~1ms (cached)
+- Hamiltonian Path: 21,163ms -> ~1ms (cached)
+
+Issue #189: Redis fallback is now fail-closed by default.
+RedisCache in STRICT_DISTRIBUTED mode raises CacheBackendUnavailableError
+when Redis is unavailable instead of silently degrading to node-local state.
 """
 
 import hashlib
+import copy
 import json
 import time
-from typing import Dict, Any, Optional
+from enum import Enum
+from typing import Callable, Dict, Any, Optional, Union
 from dataclasses import dataclass, field
-from threading import Lock
+from threading import Event, Lock
 from collections import OrderedDict
 
+import logging
+
+_security_logger = logging.getLogger("qwed.cache.security")
+
+_STRICT_UNAVAILABLE_MSG = "RedisCache(mode=STRICT_DISTRIBUTED): Redis backend is unavailable. "
+_STRICT_COOLDOWN_MSG = "Fail-closed -- client in cooldown, not falling back to node-local cache."
+MSG_BACKEND_RECOVERED = "Redis connection restored; exiting node-local fallback mode."
+
+
+# ---------------------------------------------------------------------------
+# Backend mode contract
+# ---------------------------------------------------------------------------
+
+class CacheBackendMode(str, Enum):
+    """
+    Explicit contract for cache backend failure semantics.
+
+    STRICT_DISTRIBUTED (default for security-sensitive paths):
+        Redis unavailable at startup or runtime -> raise CacheBackendUnavailableError.
+        Never silently falls back to node-local state.
+        Use this wherever cache-backed enforcement (rate limits, replay
+        protection, policy gates) must be consistent across nodes.
+
+    EXPLICIT_DEGRADED:
+        Redis unavailable -> fall back to node-local VerificationCache,
+        but only if the caller explicitly opts in.
+        Every result from the fallback path is tagged with
+        _degraded_mode=True and _cache_backend="local_degraded" so
+        callers and auditors can detect the downgrade.
+        A structured security event is emitted on mode activation.
+
+    LOCAL_ONLY:
+        Never touches Redis. Pure in-memory VerificationCache.
+        For single-process use, tests, and the cached_verify() convenience
+        wrapper where distributed semantics are not required.
+    """
+    STRICT_DISTRIBUTED = "STRICT_DISTRIBUTED"
+    EXPLICIT_DEGRADED  = "EXPLICIT_DEGRADED"
+    LOCAL_ONLY         = "LOCAL_ONLY"
+
+
+class CacheBackendUnavailableError(RuntimeError):
+    """
+    Raised when STRICT_DISTRIBUTED mode cannot reach the Redis backend.
+
+    This is intentional fail-closed behavior. The caller must handle this
+    exception explicitly -- it must not be silently swallowed.
+
+    In distributed deployments this typically means the request should be
+    responded to with an UNVERIFIABLE result rather than proceeding with
+    a node-local cache state that may diverge from other nodes.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Cache entry
+# ---------------------------------------------------------------------------
 
 @dataclass
 class CacheEntry:
@@ -29,19 +92,23 @@ class CacheEntry:
     last_accessed: float = field(default_factory=time.time)
 
 
+# ---------------------------------------------------------------------------
+# In-memory LRU cache (unchanged, LOCAL_ONLY / EXPLICIT_DEGRADED fallback)
+# ---------------------------------------------------------------------------
+
 class VerificationCache:
     """
     LRU Cache for verification results.
-    
+
     Features:
     - Thread-safe
     - LRU eviction
     - TTL (time-to-live) support
     - Hit rate tracking
     """
-    
+
     def __init__(
-        self, 
+        self,
         max_size: int = 1000,
         ttl_seconds: int = 3600,  # 1 hour default
         enabled: bool = True
@@ -49,94 +116,97 @@ class VerificationCache:
         self.max_size = max_size
         self.ttl_seconds = ttl_seconds
         self.enabled = enabled
-        
+
         self._cache: OrderedDict[str, CacheEntry] = OrderedDict()
         self._lock = Lock()
-        
+
         # Metrics
         self._hits = 0
         self._misses = 0
-    
+
     def _generate_key(self, dsl_code: str, variables: Optional[list] = None) -> str:
-        """Generate a cache key from DSL code and variables."""
-        # Normalize the DSL (remove extra whitespace)
+        """Generate an unambiguous cache key from DSL code and optional variables."""
         normalized = ' '.join(dsl_code.split())
-        
-        # Include variables in key if provided
-        if variables:
-            normalized += json.dumps(variables, sort_keys=True)
-        
-        # Hash for fixed-length key
-        return hashlib.sha256(normalized.encode()).hexdigest()[:32]
-    
+        # Use a structured JSON object so "foo" + vars=[1] never collides with
+        # "foo[1]" + vars=None (plain string concatenation would cause that).
+        key_material = json.dumps(
+            {"dsl": normalized, "vars": variables},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(key_material.encode()).hexdigest()[:32]
+
     def get(self, dsl_code: str, variables: Optional[list] = None) -> Optional[Dict[str, Any]]:
         """
         Get cached result for DSL code.
-        
+
         Returns:
             Cached result dict or None if not found/expired
         """
         if not self.enabled:
             return None
-        
+
         key = self._generate_key(dsl_code, variables)
-        
+
         with self._lock:
             if key not in self._cache:
                 self._misses += 1
                 return None
-            
+
             entry = self._cache[key]
-            
+
             # Check TTL
             if time.time() - entry.created_at > self.ttl_seconds:
                 # Expired - remove and return None
                 del self._cache[key]
                 self._misses += 1
                 return None
-            
+
             # Hit! Update stats and move to end (LRU)
             entry.hit_count += 1
             entry.last_accessed = time.time()
             self._cache.move_to_end(key)
             self._hits += 1
-            
-            return entry.result
-    
+
+            return copy.deepcopy(entry.result)
+
     def set(
-        self, 
-        dsl_code: str, 
+        self,
+        dsl_code: str,
         result: Dict[str, Any],
         variables: Optional[list] = None
     ) -> None:
         """Cache a verification result."""
         if not self.enabled:
             return
-        
+
         key = self._generate_key(dsl_code, variables)
-        
+
         with self._lock:
-            # Evict oldest if at capacity
+            # If the key already exists, remove it first so the size
+            # calculation below is accurate (update-in-place, no extra eviction).
+            self._cache.pop(key, None)
+            # Evict oldest only when adding a genuinely new key would exceed capacity.
             while len(self._cache) >= self.max_size:
                 self._cache.popitem(last=False)
-            
+
             self._cache[key] = CacheEntry(
                 key=key,
                 dsl_code=dsl_code,
-                result=result,
+                result=copy.deepcopy(result),
                 created_at=time.time()
             )
-    
+
     def invalidate(self, dsl_code: str, variables: Optional[list] = None) -> bool:
         """Remove a specific entry from cache."""
         key = self._generate_key(dsl_code, variables)
-        
+
         with self._lock:
             if key in self._cache:
                 del self._cache[key]
                 return True
             return False
-    
+
     def clear(self) -> int:
         """Clear all cached entries. Returns count of cleared entries."""
         with self._lock:
@@ -145,14 +215,14 @@ class VerificationCache:
             self._hits = 0
             self._misses = 0
             return count
-    
+
     @property
     def stats(self) -> Dict[str, Any]:
         """Get cache statistics."""
         with self._lock:
             total = self._hits + self._misses
             hit_rate = (self._hits / total * 100) if total > 0 else 0
-            
+
             return {
                 "size": len(self._cache),
                 "max_size": self.max_size,
@@ -162,55 +232,135 @@ class VerificationCache:
                 "ttl_seconds": self.ttl_seconds,
                 "enabled": self.enabled
             }
-    
-    def __len__(self) -> int:
-        return len(self._cache)
-    
-    def __contains__(self, dsl_code: str) -> bool:
-        key = self._generate_key(dsl_code)
-        return key in self._cache
 
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._cache)
+
+    def __contains__(self, dsl_code: str) -> bool:
+        # Delegate to get() so TTL is respected and _lock is acquired.
+        return self.get(dsl_code) is not None
+
+
+# ---------------------------------------------------------------------------
+# Redis-backed distributed cache (fail-closed by default)
+# ---------------------------------------------------------------------------
 
 class RedisCache:
     """
     Redis-backed verification cache for distributed deployments.
-    
-    Features:
-    - Distributed cache across multiple instances
-    - Automatic TTL expiration
-    - Graceful fallback to in-memory if Redis unavailable
-    - Same interface as VerificationCache
+
+    Backend failure semantics are controlled by the ``mode`` parameter:
+
+    * STRICT_DISTRIBUTED (default) -- Redis unavailable at startup or
+      during a get/set/invalidate/clear call raises
+      CacheBackendUnavailableError.  No silent node-local fallback.
+
+    * EXPLICIT_DEGRADED -- Redis unavailable activates a node-local
+      VerificationCache fallback, but only after emitting a structured
+      security event.  Every result served from the fallback is tagged
+      with ``_degraded_mode=True`` and
+      ``_cache_backend="local_degraded"``.
+
+    Issue #189: the previous behaviour of silently falling back to
+    in-memory (fail-open) has been removed for STRICT_DISTRIBUTED mode.
     """
-    
+
     def __init__(
         self,
         ttl_math: int = 3600,      # 1 hour for deterministic math
         ttl_logic: int = 300,       # 5 minutes for logic
         ttl_default: int = 600,     # 10 minutes default
         tenant_id: Optional[int] = None,
-        enabled: bool = True
+        enabled: bool = True,
+        mode: CacheBackendMode = CacheBackendMode.STRICT_DISTRIBUTED,
     ):
         self.ttl_math = ttl_math
         self.ttl_logic = ttl_logic
         self.ttl_default = ttl_default
         self.tenant_id = tenant_id
         self.enabled = enabled
-        
+        self.mode = mode
+
+        # LOCAL_ONLY is not valid for RedisCache -- use VerificationCache directly
+        # or get_cache(use_redis=False). Reject at construction to surface misuse early.
+        if self.mode == CacheBackendMode.LOCAL_ONLY:
+            raise ValueError(
+                "RedisCache does not support mode=LOCAL_ONLY. "
+                "Use VerificationCache() directly, or get_cache(use_redis=False)."
+            )
+
         # Import here to avoid circular imports
         from qwed_new.core.redis_config import get_redis_client, CacheKeys
-        
+
         self._client = get_redis_client()
         self._cache_keys = CacheKeys
-        
-        # Metrics (stored in Redis for distributed tracking)
+
+        # Metrics
         self._hits = 0
         self._misses = 0
-        
-        # Fallback to in-memory if Redis unavailable
+
+        # Fallback cache -- only allowed in EXPLICIT_DEGRADED mode
         self._fallback_cache: Optional[VerificationCache] = None
+        self._fallback_lock = Lock()
+
         if self._client is None:
-            self._fallback_cache = VerificationCache()
-    
+            if self.mode == CacheBackendMode.STRICT_DISTRIBUTED:
+                raise CacheBackendUnavailableError(
+                    _STRICT_UNAVAILABLE_MSG +
+                    "Fail-closed -- refusing to silently degrade to node-local cache. "
+                    "To allow node-local fallback, use mode=EXPLICIT_DEGRADED explicitly. "
+                    "To disable Redis entirely, use mode=LOCAL_ONLY or VerificationCache directly."
+                )
+            elif self.mode == CacheBackendMode.EXPLICIT_DEGRADED:
+                self._fallback_cache = VerificationCache()
+                self._emit_security_event(
+                    "BACKEND_UNAVAILABLE_AT_STARTUP",
+                    "Redis unavailable at construction; activating node-local fallback. "
+                    "Results served from this node may diverge from other nodes."
+                )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _recover_from_fallback(self) -> None:
+        """Clear fallback state and emit recovery event (only on real transition)."""
+        with self._fallback_lock:
+            if self._fallback_cache is None:
+                return
+            self._fallback_cache = None
+            self._emit_security_event("BACKEND_RECOVERED", MSG_BACKEND_RECOVERED)
+
+    # Minimum seconds between connection retries when Redis is unavailable.
+    # Prevents hammering Redis on every request and keeps tests isolated.
+    _CLIENT_RETRY_INTERVAL: float = 30.0
+
+    def _try_get_client(self):
+        if self._client is not None:
+            return self._client
+        retry_after = getattr(self, "_client_retry_after", 0.0)
+        if time.time() < retry_after:
+            return None  # Still in cooldown
+        from qwed_new.core.redis_config import get_redis_client
+        client = get_redis_client()
+        if client is not None:
+            self._client = client
+        else:
+            self._client_retry_after = time.time() + self._CLIENT_RETRY_INTERVAL
+        return client
+
+    def _emit_security_event(self, event_type: str, detail: str) -> None:
+        """Emit a structured security event when backend state changes."""
+        _security_logger.warning(json.dumps({
+            "event": event_type,
+            "backend": "redis",
+            "mode": self.mode,
+            "tenant_id": self.tenant_id,
+            "detail": detail,
+            "timestamp": time.time(),
+        }))
+
     def _get_ttl(self, result_type: str = "default") -> int:
         """Get TTL based on result type."""
         if result_type == "math":
@@ -218,42 +368,105 @@ class RedisCache:
         elif result_type == "logic":
             return self.ttl_logic
         return self.ttl_default
-    
+
     def _generate_key(self, dsl_code: str, variables: Optional[list] = None) -> str:
-        """Generate a cache key from DSL code and variables."""
+        """Generate an unambiguous cache key from DSL code and optional variables."""
         normalized = ' '.join(dsl_code.split())
-        if variables:
-            normalized += json.dumps(variables, sort_keys=True)
-        query_hash = hashlib.sha256(normalized.encode()).hexdigest()[:32]
+        key_material = json.dumps(
+            {"dsl": normalized, "vars": variables},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        query_hash = hashlib.sha256(key_material.encode()).hexdigest()[:32]
         return self._cache_keys.verification_key(self.tenant_id, query_hash)
-    
+
+    def _handle_runtime_redis_error(self, operation: str, exc: Exception) -> None:
+        """
+        Handle a Redis error that occurs during get/set/invalidate/clear.
+
+        STRICT_DISTRIBUTED: raises CacheBackendUnavailableError immediately.
+        EXPLICIT_DEGRADED:  emits a security event (fallback already active
+                            from __init__, or activates it now if Redis died
+                            at runtime after a successful startup).
+        """
+        # Mark the client dead immediately so _try_get_client's cooldown path
+        # kicks in instead of retrying the same broken connection on every call.
+        self._client = None
+        self._client_retry_after = time.time() + self._CLIENT_RETRY_INTERVAL
+        # Also clear the module-level cached client so get_redis_client()
+        # creates a fresh connection instead of returning the stale object.
+        from qwed_new.core.redis_config import invalidate_redis_client
+        invalidate_redis_client()
+
+        if self.mode == CacheBackendMode.STRICT_DISTRIBUTED:
+            raise CacheBackendUnavailableError(
+                f"RedisCache(mode=STRICT_DISTRIBUTED): Redis {operation} failed: {exc}. "
+                "Fail-closed -- not falling back to node-local cache."
+            ) from exc
+
+        # EXPLICIT_DEGRADED: activate fallback lazily on runtime loss
+        with self._fallback_lock:
+            if self._fallback_cache is None:
+                self._fallback_cache = VerificationCache()
+                self._emit_security_event(
+                    "BACKEND_UNAVAILABLE_AT_RUNTIME",
+                    f"Redis {operation} failed: {exc}. "
+                    "Activating node-local fallback; results may diverge across nodes."
+                )
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
     def get(self, dsl_code: str, variables: Optional[list] = None) -> Optional[Dict[str, Any]]:
-        """Get cached result for DSL code."""
+        """
+        Get cached result for DSL code.
+
+        Raises:
+            CacheBackendUnavailableError: in STRICT_DISTRIBUTED mode when
+                Redis is unavailable (startup or runtime).
+        """
         if not self.enabled:
             return None
-        
-        # Fallback to in-memory
-        if self._fallback_cache:
-            return self._fallback_cache.get(dsl_code, variables)
-        
+
         key = self._generate_key(dsl_code, variables)
-        
-        try:
-            cached = self._client.get(key)
-            if cached is None:
-                self._misses += 1
-                return None
+
+        client = self._try_get_client()
+        if client is None and self.mode == CacheBackendMode.STRICT_DISTRIBUTED:
+            raise CacheBackendUnavailableError(
+                _STRICT_UNAVAILABLE_MSG +
+                _STRICT_COOLDOWN_MSG
+            )
+
+        cached = None
+        if client is not None:
+            try:
+                cached = client.get(key)
+            except Exception as exc:
+                self._handle_runtime_redis_error("get", exc)
+            else:
+                self._recover_from_fallback()
+                if cached is None:
+                    self._misses += 1
+                    return None
+                self._hits += 1
+                return json.loads(cached)  # JSON errors propagate naturally
+
+        # Snapshot under lock to avoid TOCTOU race with _recover_from_fallback()
+        with self._fallback_lock:
+            fallback = self._fallback_cache
+
+        if fallback is not None:
+            # EXPLICIT_DEGRADED path -- tag result so callers can detect downgrade
+            result = fallback.get(dsl_code, variables)
+            if result is not None:
+                result = dict(result)
+                result["_degraded_mode"] = True
+                result["_cache_backend"] = "local_degraded"
+            return result
             
-            self._hits += 1
-            return json.loads(cached)
-            
-        except Exception as e:
-            # Redis error - log and return None
-            import logging
-            logging.warning(f"Redis get error: {e}")
-            self._misses += 1
-            return None
-    
+        return None
+
     def set(
         self,
         dsl_code: str,
@@ -261,213 +474,383 @@ class RedisCache:
         variables: Optional[list] = None,
         result_type: str = "default"
     ) -> None:
-        """Cache a verification result."""
+        """
+        Cache a verification result.
+
+        Raises:
+            CacheBackendUnavailableError: in STRICT_DISTRIBUTED mode when
+                Redis is unavailable.
+        """
         if not self.enabled:
             return
-        
-        # Fallback to in-memory
-        if self._fallback_cache:
-            self._fallback_cache.set(dsl_code, result, variables)
-            return
-        
+
         key = self._generate_key(dsl_code, variables)
         ttl = self._get_ttl(result_type)
-        
-        try:
-            self._client.setex(key, ttl, json.dumps(result))
-        except Exception as e:
-            import logging
-            logging.warning(f"Redis set error: {e}")
-    
+
+        client = self._try_get_client()
+        if client is None and self.mode == CacheBackendMode.STRICT_DISTRIBUTED:
+            raise CacheBackendUnavailableError(
+                _STRICT_UNAVAILABLE_MSG +
+                _STRICT_COOLDOWN_MSG
+            )
+        payload = json.dumps(result)  # JSON errors propagate naturally — not a Redis issue
+
+        if client is not None:
+            try:
+                client.setex(key, ttl, payload)
+            except Exception as exc:
+                self._handle_runtime_redis_error("set", exc)
+            else:
+                self._recover_from_fallback()
+                return
+
+        # Snapshot under lock to avoid TOCTOU race with _recover_from_fallback()
+        with self._fallback_lock:
+            fallback = self._fallback_cache
+
+        if fallback is not None:
+            fallback.set(dsl_code, result, variables)
+
     def invalidate(self, dsl_code: str, variables: Optional[list] = None) -> bool:
-        """Remove a specific entry from cache."""
-        if self._fallback_cache:
-            return self._fallback_cache.invalidate(dsl_code, variables)
-        
+        """
+        Remove a specific entry from cache.
+
+        Raises:
+            CacheBackendUnavailableError: in STRICT_DISTRIBUTED mode when
+                Redis is unavailable.
+        """
         key = self._generate_key(dsl_code, variables)
-        
-        try:
-            return self._client.delete(key) > 0
-        except Exception:
-            return False
-    
-    def clear(self, pattern: str = None) -> int:
+        client = self._try_get_client()
+        if client is None and self.mode == CacheBackendMode.STRICT_DISTRIBUTED:
+            raise CacheBackendUnavailableError(
+                _STRICT_UNAVAILABLE_MSG +
+                _STRICT_COOLDOWN_MSG
+            )
+
+        if client is not None:
+            try:
+                ret = client.delete(key) > 0
+                
+                self._recover_from_fallback()
+                return ret
+
+            except Exception as exc:
+                self._handle_runtime_redis_error("invalidate", exc)
+
+        fallback = None
+        with self._fallback_lock:
+            fallback = self._fallback_cache
+
+        if fallback is not None:
+            return fallback.invalidate(dsl_code, variables)
+        return False
+
+    def _clear_redis_pattern(self, client, pattern: str) -> int:
+        """Helper to scan and delete keys matching a pattern.
+
+        Args:
+            client: Active Redis client (already validated by caller).
+            pattern: Key pattern to match.
+        """
+        cursor = 0
+        deleted = 0
+        while True:
+            cursor, keys = client.scan(cursor, match=pattern, count=100)
+            if keys:
+                deleted += client.delete(*keys)
+            if cursor == 0:
+                break
+        return deleted
+
+    def clear(self, pattern: Optional[str] = None) -> int:
         """
         Clear cached entries.
-        
+
         Args:
             pattern: Optional pattern to match (e.g., "qwed:verify:*")
                     If None, clears all QWED verification cache
+
+        Raises:
+            CacheBackendUnavailableError: in STRICT_DISTRIBUTED mode when
+                Redis is unavailable.
         """
-        if self._fallback_cache:
-            return self._fallback_cache.clear()
-        
-        try:
-            if pattern is None:
-                pattern = f"{self._cache_keys.VERIFICATION}:*"
-            
-            # Use SCAN to avoid blocking
-            cursor = 0
-            deleted = 0
-            while True:
-                cursor, keys = self._client.scan(cursor, match=pattern, count=100)
-                if keys:
-                    deleted += self._client.delete(*keys)
-                if cursor == 0:
-                    break
-            
-            self._hits = 0
-            self._misses = 0
-            return deleted
-            
-        except Exception as e:
-            import logging
-            logging.warning(f"Redis clear error: {e}")
-            return 0
-    
+        client = self._try_get_client()
+        if client is None and self.mode == CacheBackendMode.STRICT_DISTRIBUTED:
+            raise CacheBackendUnavailableError(
+                _STRICT_UNAVAILABLE_MSG +
+                _STRICT_COOLDOWN_MSG
+            )
+        if client is not None:
+            try:
+                if pattern is None:
+                    pattern = f"{self._cache_keys.VERIFICATION}:*"
+
+                deleted = self._clear_redis_pattern(client, pattern)
+
+                self._hits = 0
+                self._misses = 0
+
+                self._recover_from_fallback()
+                return deleted
+
+            except Exception as exc:
+                self._handle_runtime_redis_error("clear", exc)
+
+        fallback = None
+        with self._fallback_lock:
+            fallback = self._fallback_cache
+
+        if fallback is not None:
+            return fallback.clear()
+        return 0
+
     @property
     def stats(self) -> Dict[str, Any]:
         """Get cache statistics."""
-        if self._fallback_cache:
-            stats = self._fallback_cache.stats
-            stats["backend"] = "in-memory (fallback)"
+        with self._fallback_lock:
+            fallback = self._fallback_cache
+        if fallback is not None:
+            stats = fallback.stats
+            stats["backend"] = "local_degraded"
+            stats["mode"] = self.mode
+            stats["degraded"] = True
             return stats
-        
+
         total = self._hits + self._misses
         hit_rate = (self._hits / total * 100) if total > 0 else 0
-        
+
         try:
             info = self._client.info("memory")
             return {
                 "backend": "redis",
+                "mode": self.mode,
+                "degraded": False,
                 "hits": self._hits,
                 "misses": self._misses,
                 "hit_rate_percent": round(hit_rate, 2),
                 "redis_used_memory": info.get("used_memory_human"),
                 "enabled": self.enabled,
-                "tenant_id": self.tenant_id
+                "tenant_id": self.tenant_id,
             }
         except Exception:
             return {
                 "backend": "redis",
+                "mode": self.mode,
+                "degraded": self._fallback_cache is not None,
+                "backend_error": True,
                 "hits": self._hits,
                 "misses": self._misses,
                 "hit_rate_percent": round(hit_rate, 2),
-                "enabled": self.enabled
+                "enabled": self.enabled,
+                "tenant_id": self.tenant_id,
             }
 
 
-# Global cache singleton
-_verification_cache: Optional[VerificationCache] = None
-_redis_cache: Optional[RedisCache] = None
+# ---------------------------------------------------------------------------
+# Global cache factory
+# ---------------------------------------------------------------------------
+
+# Global singletons (kept for backward compat with existing callers)
+# _verification_caches is a per-tenant mapping to prevent cross-tenant leakage
+# in LOCAL_ONLY / no-Redis paths: VerificationCache._generate_key has no tenant
+# context, so we maintain separate instances per tenant_id.
+_verification_caches: Dict[Optional[int], VerificationCache] = {}
+# Per-(tenant_id, mode) RedisCache map — protected by _cache_factory_lock
+# to prevent concurrent callers racing and crossing tenant boundaries.
+_redis_caches: Dict[tuple, RedisCache] = {}
+# Per-(tenant_id, mode) timestamp — prevents get_cache() from holding the factory
+# lock while hammering a dead Redis connection on every call.
+_redis_cache_retry_after: Dict[tuple, float] = {}
+_constructing_events: Dict[tuple, Event] = {}  # signals when construction completes
+_cache_factory_lock = Lock()
 
 
-def get_cache(use_redis: bool = True, tenant_id: Optional[int] = None) -> VerificationCache:
+def get_cache(
+    use_redis: bool = True,
+    tenant_id: Optional[int] = None,
+    mode: CacheBackendMode = CacheBackendMode.STRICT_DISTRIBUTED,
+) -> "Union[VerificationCache, RedisCache]":
     """
     Get the appropriate verification cache.
-    
+
     Args:
-        use_redis: Whether to prefer Redis cache (falls back to in-memory if unavailable)
-        tenant_id: Optional tenant ID for multi-tenant isolation
-        
+        use_redis: Whether to use the Redis backend.
+        tenant_id: Optional tenant ID for multi-tenant isolation.
+        mode: Backend failure semantics (see CacheBackendMode).
+              Defaults to STRICT_DISTRIBUTED -- Redis unavailable raises
+              CacheBackendUnavailableError instead of silently degrading.
+
     Returns:
-        Cache instance (RedisCache or VerificationCache)
+        Cache instance.  May be RedisCache or VerificationCache depending
+        on use_redis and mode.
+
+    Raises:
+        CacheBackendUnavailableError: when use_redis=True,
+            mode=STRICT_DISTRIBUTED, and Redis is unavailable.
     """
-    global _verification_cache, _redis_cache
-    
-    if use_redis:
-        # Try Redis first
-        from qwed_new.core.redis_config import is_redis_available
-        
-        if is_redis_available():
-            if _redis_cache is None or _redis_cache.tenant_id != tenant_id:
-                _redis_cache = RedisCache(tenant_id=tenant_id)
-            return _redis_cache
-    
-    # Fallback to in-memory
-    if _verification_cache is None:
-        _verification_cache = VerificationCache()
-    return _verification_cache
+    global _verification_caches, _redis_caches, _redis_cache_retry_after
+
+    if not use_redis or mode == CacheBackendMode.LOCAL_ONLY:
+        with _cache_factory_lock:
+            cache = _verification_caches.get(tenant_id)
+            if cache is None:
+                cache = VerificationCache()
+                _verification_caches[tenant_id] = cache
+        return cache
+
+    # Redis path — per-(tenant_id, mode) singleton, locked to prevent races
+    cache_key = (tenant_id, mode)
+
+    # Fast path: return existing cache without blocking.
+    with _cache_factory_lock:
+        cache = _redis_caches.get(cache_key)
+        if cache is not None:
+            return cache
+        # Check per-key cooldown before attempting a new connection.
+        retry_after = _redis_cache_retry_after.get(cache_key, 0.0)
+        if time.time() < retry_after:
+            raise CacheBackendUnavailableError(
+                f"RedisCache(mode={mode.value}): Redis backend unavailable "
+                f"(cooldown active for {retry_after - time.time():.0f}s). "
+                "Fail-closed."
+            )
+        # Prevent concurrent construction pile-up: if another thread is
+        # already constructing this cache_key, don't start a second
+        # blocking network call.
+        if cache_key in _constructing_events:
+            # Another thread is constructing; wait for it instead of pile-up.
+            event = _constructing_events[cache_key]
+            # Release factory lock while waiting so we don't block others.
+            _cache_factory_lock.release()
+            try:
+                event.wait(timeout=10.0)  # bounded wait
+            finally:
+                _cache_factory_lock.acquire()
+            # After wait, the cache should be in the dict (or cooldown set).
+            cache = _redis_caches.get(cache_key)
+            if cache is not None:
+                return cache
+            # Construction failed; let caller handle normally.
+            if mode == CacheBackendMode.STRICT_DISTRIBUTED:
+                raise CacheBackendUnavailableError(
+                    _STRICT_UNAVAILABLE_MSG +
+                    "Construction by another thread failed."
+                )
+            return VerificationCache()
+        event = Event()
+        _constructing_events[cache_key] = event
+
+    # Construct outside the lock -- RedisCache.__init__ calls
+    # get_redis_client() which may block on a 5-second network timeout.
+    try:
+        new_cache = RedisCache(tenant_id=tenant_id, mode=mode)
+    except CacheBackendUnavailableError:
+        with _cache_factory_lock:
+            _constructing_events.pop(cache_key, None)
+            _redis_cache_retry_after[cache_key] = time.time() + RedisCache._CLIENT_RETRY_INTERVAL
+        event.set()  # Wake waiters after state is consistent
+        raise
+    except Exception:
+        with _cache_factory_lock:
+            _constructing_events.pop(cache_key, None)
+        event.set()
+        raise
+
+    # Insert into dict, THEN signal waiters so they always find the cache.
+    with _cache_factory_lock:
+        _constructing_events.pop(cache_key, None)
+        cache = _redis_caches.get(cache_key)
+        if cache is not None:
+            event.set()
+            return cache
+        _redis_caches[cache_key] = new_cache
+    event.set()  # Wake waiters — cache is now in the dict
+    return new_cache
 
 
 def cached_verify(
     dsl_code: str,
     variables: Optional[list] = None,
-    verify_fn: callable = None
+    verify_fn: Optional[Callable[[], Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """
-    Verify with caching.
-    
+    Verify with caching (single-process convenience wrapper).
+
+    Uses LOCAL_ONLY mode -- no Redis, no distributed semantics.
+    For distributed deployments, call get_cache(mode=STRICT_DISTRIBUTED)
+    directly and manage the cache lifecycle explicitly.
+
     Args:
         dsl_code: The QWED-DSL expression
         variables: Variable declarations
         verify_fn: Function to call on cache miss (should return result dict)
-        
+
     Returns:
         Verification result (from cache or fresh)
     """
-    cache = get_cache()
-    
+    # LOCAL_ONLY: deterministic, no distributed concerns
+    cache = get_cache(use_redis=False, mode=CacheBackendMode.LOCAL_ONLY)
+
     # Check cache first
     cached_result = cache.get(dsl_code, variables)
     if cached_result is not None:
         cached_result['_cached'] = True
         return cached_result
-    
+
     # Cache miss - compute result
     if verify_fn is None:
         raise ValueError("verify_fn required on cache miss")
-    
+
     result = verify_fn()
     result['_cached'] = False
-    
+
     # Only cache successful results
     if result.get('status') in ['SAT', 'UNSAT', 'SUCCESS']:
         cache.set(dsl_code, result, variables)
-    
+
     return result
 
 
 # --- DEMO ---
 if __name__ == "__main__":
     import time
-    
+
     print("=" * 60)
     print("QWED Verification Cache Demo")
     print("=" * 60)
-    
+
     cache = VerificationCache()
-    
+
     # Test DSL
     test_dsl = "(AND (GT x 5) (LT y 10))"
     test_result = {"status": "SAT", "model": {"x": "6", "y": "9"}}
-    
+
     # First access - cache miss
     print("\n1. First access (cache miss):")
     result = cache.get(test_dsl)
     print(f"   Result: {result}")
     print(f"   Stats: {cache.stats}")
-    
+
     # Set cache
     print("\n2. Caching result...")
     cache.set(test_dsl, test_result)
-    
+
     # Second access - cache hit
     print("\n3. Second access (cache hit):")
     result = cache.get(test_dsl)
     print(f"   Result: {result}")
     print(f"   Stats: {cache.stats}")
-    
+
     # Simulate latency savings
     print("\n4. Latency simulation:")
     print("   Without cache: ~12,000ms (Monty Hall benchmark)")
     print("   With cache:    ~0.01ms")
-    
+
     start = time.perf_counter()
     for _ in range(1000):
         cache.get(test_dsl)
     elapsed = (time.perf_counter() - start) * 1000
     print(f"   1000 cache lookups: {elapsed:.2f}ms ({elapsed/1000:.4f}ms per lookup)")
-    
+
     print(f"\n5. Final Stats: {cache.stats}")
     print("\n" + "=" * 60)

--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -493,9 +493,8 @@ class RedisCache:
                 _STRICT_UNAVAILABLE_MSG +
                 _STRICT_COOLDOWN_MSG
             )
-        payload = json.dumps(result)  # JSON errors propagate naturally — not a Redis issue
-
         if client is not None:
+            payload = json.dumps(result)  # JSON errors propagate naturally -- not a Redis issue
             try:
                 client.setex(key, ttl, payload)
             except Exception as exc:
@@ -753,6 +752,7 @@ def get_cache(
     except Exception:
         with _cache_factory_lock:
             _constructing_events.pop(cache_key, None)
+            _redis_cache_retry_after[cache_key] = time.time() + RedisCache._CLIENT_RETRY_INTERVAL
         event.set()
         raise
 

--- a/src/qwed_new/core/redis_config.py
+++ b/src/qwed_new/core/redis_config.py
@@ -26,44 +26,58 @@ _redis_available = None
 def get_redis_client():
     """
     Get the Redis client singleton with connection pooling.
-    
+
     Returns:
-        redis.Redis instance or None if Redis is unavailable
+        redis.Redis instance or None if Redis is unavailable.
+        Returns the cached client if one exists and is valid.
     """
     global _redis_client, _redis_available
-    
-    if _redis_available is False:
-        return None
-    
+
     if _redis_client is not None:
         return _redis_client
-    
+
     try:
         import redis
-        
-        _redis_client = redis.from_url(
+
+        # Build into a local variable first; only promote to the module-level
+        # singleton after a successful ping.  This avoids leaving a stale /
+        # broken client in the global on construction failure (which CodeQL
+        # correctly flags as an unused write when cleared in except blocks).
+        client = redis.from_url(
             REDIS_URL,
             max_connections=REDIS_MAX_CONNECTIONS,
             socket_timeout=REDIS_SOCKET_TIMEOUT,
             socket_connect_timeout=REDIS_SOCKET_TIMEOUT,
-            decode_responses=True  # Return strings instead of bytes
+            decode_responses=True,  # Return strings instead of bytes
         )
-        
-        # Test connection
-        _redis_client.ping()
+        client.ping()
+
+        _redis_client = client
         _redis_available = True
         logger.info(f"Redis connection established: {REDIS_URL}")
         return _redis_client
-        
+
     except ImportError:
-        logger.warning("redis-py not installed. Falling back to in-memory cache.")
-        _redis_available = False
+        logger.warning(
+            "redis-py not installed. Redis will be unavailable until it is installed."
+        )
         return None
     except Exception as e:
-        logger.warning(f"Redis connection failed: {e}. Falling back to in-memory cache.")
-        _redis_available = False
+        logger.warning(f"Redis connection failed: {e}. Will retry on next request.")
         return None
 
+
+def invalidate_redis_client() -> None:
+    """
+    Clear the cached module-level Redis client.
+
+    Called by RedisCache._handle_runtime_redis_error when the connection
+    breaks at runtime so that the next get_redis_client() call will
+    create a fresh connection instead of returning the stale object.
+    """
+    global _redis_client, _redis_available
+    _redis_client = None
+    _redis_available = None
 
 def is_redis_available() -> bool:
     """Check if Redis is available and connected."""
@@ -138,3 +152,15 @@ class CacheTTL:
     SQL_RESULT = 600        # 10 minutes
     CODE_RESULT = 600       # 10 minutes
     RATE_LIMIT_WINDOW = 60  # 1 minute sliding window
+
+
+def reset_redis_state() -> None:
+    """
+    Reset the module-level Redis singleton state.
+
+    For use in tests only -- allows each test to start with a clean
+    connection state so Redis availability can be simulated independently.
+    """
+    global _redis_client, _redis_available
+    _redis_client = None
+    _redis_available = None

--- a/tests/test_pr189_redis_failclosed.py
+++ b/tests/test_pr189_redis_failclosed.py
@@ -234,6 +234,19 @@ class TestExplicitDegradedRuntimeLoss:
 
         assert any("BACKEND_UNAVAILABLE_AT_RUNTIME" in r.message for r in caplog.records)
 
+    def test_invalidate_raises_on_runtime_redis_loss(self):
+        """
+        Redis-backed invalidation cannot be proven from a fresh local fallback;
+        report the backend failure explicitly instead of returning False.
+        """
+        cache, mock_client = self._make_degraded_cache_healthy_start()
+        mock_client.delete.side_effect = Exception("connection reset")
+
+        with pytest.raises(CacheBackendUnavailableError) as exc_info:
+            cache.invalidate("(= x 1)")
+
+        assert "invalidate failed" in str(exc_info.value)
+
     def test_cross_node_isolation_is_explicit_not_silent(self):
         """
         Two EXPLICIT_DEGRADED nodes with separate fallback caches produce

--- a/tests/test_pr189_redis_failclosed.py
+++ b/tests/test_pr189_redis_failclosed.py
@@ -670,6 +670,7 @@ class TestGetCacheAntiHammering:
         cache_mod._verification_caches.clear()
         cache_mod._redis_caches.clear()
         cache_mod._redis_cache_retry_after.clear()
+        cache_mod._constructing_events.clear()
         reset_redis_state()
 
     def test_second_call_raises_immediately_without_reconnect(self):
@@ -712,3 +713,19 @@ class TestGetCacheAntiHammering:
             with pytest.raises(CacheBackendUnavailableError):
                 get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
             mock_init.assert_not_called()
+
+    def test_explicit_degraded_waiter_raises_after_construction_failure(self):
+        """
+        A waiter must not receive a bare unregistered VerificationCache after
+        another EXPLICIT_DEGRADED construction attempt fails.
+        """
+        cache_key = (None, CacheBackendMode.EXPLICIT_DEGRADED)
+        event = cache_mod.Event()
+        event.set()
+        cache_mod._constructing_events[cache_key] = event
+
+        with pytest.raises(CacheBackendUnavailableError) as exc_info:
+            get_cache(use_redis=True, mode=CacheBackendMode.EXPLICIT_DEGRADED)
+
+        assert "EXPLICIT_DEGRADED" in str(exc_info.value)
+        assert "Construction by another thread failed" in str(exc_info.value)

--- a/tests/test_pr189_redis_failclosed.py
+++ b/tests/test_pr189_redis_failclosed.py
@@ -720,12 +720,51 @@ class TestGetCacheAntiHammering:
         another EXPLICIT_DEGRADED construction attempt fails.
         """
         cache_key = (None, CacheBackendMode.EXPLICIT_DEGRADED)
-        event = cache_mod.Event()
-        event.set()
-        cache_mod._constructing_events[cache_key] = event
+        cache_mod._redis_cache_retry_after[cache_key] = float("inf")
 
         with pytest.raises(CacheBackendUnavailableError) as exc_info:
             get_cache(use_redis=True, mode=CacheBackendMode.EXPLICIT_DEGRADED)
 
         assert "EXPLICIT_DEGRADED" in str(exc_info.value)
-        assert "Construction by another thread failed" in str(exc_info.value)
+        assert "cooldown active" in str(exc_info.value)
+
+    def test_strict_distributed_waiter_timeout_fails_closed(self):
+        """STRICT_DISTRIBUTED waiters should fail closed on construction timeout."""
+        cache_key = (None, CacheBackendMode.STRICT_DISTRIBUTED)
+
+        class TimeoutEvent:
+            def wait(self, timeout):
+                return False
+
+        cache_mod._constructing_events[cache_key] = TimeoutEvent()
+
+        with pytest.raises(CacheBackendUnavailableError) as exc_info:
+            get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
+
+        assert "timed out" in str(exc_info.value)
+
+    def test_explicit_degraded_waiter_rechecks_after_timeout(self):
+        """
+        EXPLICIT_DEGRADED waiters should not hard-fail on a bounded wait timeout;
+        they should keep waiting/rechecking until construction completes.
+        """
+        cache_key = (None, CacheBackendMode.EXPLICIT_DEGRADED)
+
+        class SlowEvent:
+            def __init__(self):
+                self.calls = 0
+
+            def wait(self, timeout):
+                self.calls += 1
+                if self.calls == 1:
+                    return False
+                cache_mod._redis_caches[cache_key] = VerificationCache()
+                return True
+
+        event = SlowEvent()
+        cache_mod._constructing_events[cache_key] = event
+
+        cache = get_cache(use_redis=True, mode=CacheBackendMode.EXPLICIT_DEGRADED)
+
+        assert isinstance(cache, VerificationCache)
+        assert event.calls == 2

--- a/tests/test_pr189_redis_failclosed.py
+++ b/tests/test_pr189_redis_failclosed.py
@@ -174,6 +174,22 @@ class TestExplicitDegradedStartupDown:
         assert hit["_degraded_mode"] is True
         assert hit["_cache_backend"] == "local_degraded"
 
+    def test_set_uses_fallback_without_json_serializing_when_redis_down(self):
+        """
+        EXPLICIT_DEGRADED fallback stores Python objects directly; Redis JSON
+        serialization must not run when no Redis client is available.
+        """
+        sentinel = object()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            cache = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+            cache.set("(= x 1)", {"status": "SAT", "sentinel": sentinel})
+            hit = cache.get("(= x 1)")
+
+        assert hit is not None
+        assert "sentinel" in hit
+        assert hit["_degraded_mode"] is True
+        assert hit["_cache_backend"] == "local_degraded"
+
     def test_stats_reports_degraded(self):
         """stats() must expose degraded=True when in fallback mode."""
         with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
@@ -516,6 +532,7 @@ class TestTenantIsolation:
         cache_mod._verification_caches.clear()
         cache_mod._redis_caches.clear()
         cache_mod._redis_cache_retry_after.clear()
+        cache_mod._constructing_events.clear()
         reset_redis_state()
 
     def test_different_tenants_get_different_caches(self):
@@ -678,3 +695,20 @@ class TestGetCacheAntiHammering:
             c1 = get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
             c2 = get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
         assert c1 is c2
+
+    def test_generic_construction_error_starts_retry_cooldown(self):
+        """
+        Non-availability RedisCache construction failures should also enter
+        cooldown so repeated callers do not hammer the factory path.
+        """
+        with patch.object(RedisCache, "__init__", side_effect=ValueError("bad mode")):
+            with pytest.raises(ValueError):
+                get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
+
+        cache_key = (None, CacheBackendMode.STRICT_DISTRIBUTED)
+        assert cache_mod._redis_cache_retry_after[cache_key] > 0
+
+        with patch.object(RedisCache, "__init__") as mock_init:
+            with pytest.raises(CacheBackendUnavailableError):
+                get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
+            mock_init.assert_not_called()

--- a/tests/test_pr189_redis_failclosed.py
+++ b/tests/test_pr189_redis_failclosed.py
@@ -1,0 +1,680 @@
+"""
+Tests for Issue #189: Redis fallback fail-closed fix.
+
+Verifies that:
+- STRICT_DISTRIBUTED mode never silently falls back to node-local cache
+- EXPLICIT_DEGRADED mode falls back with audit markers and security events
+- LOCAL_ONLY mode never touches Redis
+- cached_verify() uses LOCAL_ONLY (backward compatible, no breaking change)
+- Cross-node isolation is explicit, not silent
+"""
+import json
+import logging
+import pytest
+from unittest.mock import MagicMock, patch
+
+from qwed_new.core.cache import (
+    CacheBackendMode,
+    CacheBackendUnavailableError,
+    RedisCache,
+    VerificationCache,
+    get_cache,
+    cached_verify,
+)
+from qwed_new.core.redis_config import reset_redis_state
+import qwed_new.core.cache as cache_mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+
+# ---------------------------------------------------------------------------
+# STRICT_DISTRIBUTED: startup Redis down
+# ---------------------------------------------------------------------------
+
+class TestStrictDistributedStartupDown:
+
+    def test_raises_on_startup_redis_down(self):
+        """STRICT_DISTRIBUTED + Redis unavailable at startup -> raise, never fallback."""
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            with pytest.raises(CacheBackendUnavailableError) as exc_info:
+                RedisCache(mode=CacheBackendMode.STRICT_DISTRIBUTED)
+
+        assert "STRICT_DISTRIBUTED" in str(exc_info.value)
+        assert "Fail-closed" in str(exc_info.value)
+
+    def test_error_message_suggests_alternatives(self):
+        """Error message must guide caller to EXPLICIT_DEGRADED or LOCAL_ONLY."""
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            with pytest.raises(CacheBackendUnavailableError) as exc_info:
+                RedisCache(mode=CacheBackendMode.STRICT_DISTRIBUTED)
+
+        msg = str(exc_info.value)
+        assert "EXPLICIT_DEGRADED" in msg
+        assert "LOCAL_ONLY" in msg
+
+    def test_no_fallback_cache_created_on_strict(self):
+        """STRICT_DISTRIBUTED must never instantiate a VerificationCache fallback."""
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+            cache = RedisCache(mode=CacheBackendMode.STRICT_DISTRIBUTED)
+
+        assert cache._fallback_cache is None
+
+
+# ---------------------------------------------------------------------------
+# STRICT_DISTRIBUTED: runtime Redis error
+# ---------------------------------------------------------------------------
+
+class TestStrictDistributedRuntimeError:
+
+    def _make_strict_cache(self):
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+            cache = RedisCache(mode=CacheBackendMode.STRICT_DISTRIBUTED)
+        cache._client = mock_client
+        return cache, mock_client
+
+    def test_get_raises_on_runtime_redis_error(self):
+        """Runtime Redis error on get -> raise CacheBackendUnavailableError."""
+        cache, mock_client = self._make_strict_cache()
+        mock_client.get.side_effect = Exception("connection lost")
+
+        with pytest.raises(CacheBackendUnavailableError) as exc_info:
+            cache.get("(= x 1)")
+
+        assert "get" in str(exc_info.value).lower()
+
+    def test_set_raises_on_runtime_redis_error(self):
+        """Runtime Redis error on set -> raise CacheBackendUnavailableError."""
+        cache, mock_client = self._make_strict_cache()
+        mock_client.setex.side_effect = Exception("connection lost")
+
+        with pytest.raises(CacheBackendUnavailableError) as exc_info:
+            cache.set("(= x 1)", {"status": "SAT"})
+
+        assert "set" in str(exc_info.value).lower()
+
+    def test_invalidate_raises_on_runtime_redis_error(self):
+        """Runtime Redis error on invalidate -> raise CacheBackendUnavailableError."""
+        cache, mock_client = self._make_strict_cache()
+        mock_client.delete.side_effect = Exception("connection lost")
+
+        with pytest.raises(CacheBackendUnavailableError):
+            cache.invalidate("(= x 1)")
+
+    def test_clear_raises_on_runtime_redis_error(self):
+        """Runtime Redis error on clear -> raise CacheBackendUnavailableError."""
+        cache, mock_client = self._make_strict_cache()
+        mock_client.scan.side_effect = Exception("connection lost")
+
+        with pytest.raises(CacheBackendUnavailableError):
+            cache.clear()
+
+    def test_strict_never_activates_fallback_on_runtime_error(self):
+        """STRICT_DISTRIBUTED must never create _fallback_cache even after runtime error."""
+        cache, mock_client = self._make_strict_cache()
+        mock_client.get.side_effect = Exception("connection lost")
+
+        with pytest.raises(CacheBackendUnavailableError):
+            cache.get("(= x 1)")
+
+        assert cache._fallback_cache is None
+
+
+# ---------------------------------------------------------------------------
+# EXPLICIT_DEGRADED: startup Redis down
+# ---------------------------------------------------------------------------
+
+class TestExplicitDegradedStartupDown:
+
+    def test_activates_local_fallback_when_redis_down(self):
+        """EXPLICIT_DEGRADED + Redis down -> activates VerificationCache fallback."""
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            cache = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+
+        assert cache._fallback_cache is not None
+        assert isinstance(cache._fallback_cache, VerificationCache)
+
+    def test_emits_security_event_on_startup_fallback(self, caplog):
+        """EXPLICIT_DEGRADED fallback activation must emit a structured security event."""
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="qwed.cache.security"):
+                RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+
+        assert any("BACKEND_UNAVAILABLE_AT_STARTUP" in r.message for r in caplog.records)
+
+    def test_security_event_is_valid_json(self, caplog):
+        """Security event payload must be valid JSON for structured log parsing."""
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="qwed.cache.security"):
+                RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+
+        security_records = [r for r in caplog.records if "BACKEND_UNAVAILABLE" in r.message]
+        assert security_records, "No security event emitted"
+        event = json.loads(security_records[0].message)
+        assert event["event"] == "BACKEND_UNAVAILABLE_AT_STARTUP"
+        assert event["mode"] == CacheBackendMode.EXPLICIT_DEGRADED
+        assert "timestamp" in event
+
+    def test_get_tags_result_with_degraded_marker(self):
+        """Results from fallback path must carry _degraded_mode=True."""
+        # Patch for the full test body so _try_get_client() does not
+        # reconnect to a real Redis between construction and get().
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            cache = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+            result = {"status": "SAT", "verified": True}
+            cache.set("(= x 1)", result)
+            hit = cache.get("(= x 1)")
+
+        assert hit is not None
+        assert hit["_degraded_mode"] is True
+        assert hit["_cache_backend"] == "local_degraded"
+
+    def test_stats_reports_degraded(self):
+        """stats() must expose degraded=True when in fallback mode."""
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            cache = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+
+        s = cache.stats
+        assert s["degraded"] is True
+        assert s["backend"] == "local_degraded"
+
+
+# ---------------------------------------------------------------------------
+# EXPLICIT_DEGRADED: runtime Redis loss
+# ---------------------------------------------------------------------------
+
+class TestExplicitDegradedRuntimeLoss:
+
+    def _make_degraded_cache_healthy_start(self):
+        """Cache that starts healthy (Redis up) but will lose it at runtime."""
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+            cache = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+        cache._client = mock_client
+        return cache, mock_client
+
+    def test_activates_fallback_on_runtime_redis_loss(self):
+        """Redis dies at runtime -> EXPLICIT_DEGRADED activates fallback lazily."""
+        cache, mock_client = self._make_degraded_cache_healthy_start()
+        mock_client.get.side_effect = Exception("connection reset")
+
+        # Should not raise -- should activate fallback
+        result = cache.get("(= x 1)")
+        assert result is None  # miss (nothing in fallback yet)
+        assert cache._fallback_cache is not None
+
+    def test_emits_security_event_on_runtime_loss(self, caplog):
+        """Runtime Redis loss -> security event emitted."""
+        cache, mock_client = self._make_degraded_cache_healthy_start()
+        mock_client.get.side_effect = Exception("connection reset")
+
+        with caplog.at_level(logging.WARNING, logger="qwed.cache.security"):
+            cache.get("(= x 1)")
+
+        assert any("BACKEND_UNAVAILABLE_AT_RUNTIME" in r.message for r in caplog.records)
+
+    def test_cross_node_isolation_is_explicit_not_silent(self):
+        """
+        Two EXPLICIT_DEGRADED nodes with separate fallback caches produce
+        divergent state -- but the divergence is EXPLICIT via the degraded marker,
+        not silent.
+
+        This test documents the known limitation: cross-node consistency is
+        lost in EXPLICIT_DEGRADED. The audit marker is the explicit signal.
+        """
+        # Patch for the full test body — keeps Redis unavailable for all
+        # get()/set() calls so _try_get_client() stays in cooldown.
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            # Node A: Redis down, writes to fallback
+            node_a = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+            node_a.set("(= x 1)", {"status": "SAT", "verified": True})
+            hit_a = node_a.get("(= x 1)")
+
+            # Node B: own fallback — does not see A's data
+            node_b = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+            hit_b = node_b.get("(= x 1)")
+
+        # A has data, B doesn't -- divergence exists
+        assert hit_a is not None
+        assert hit_b is None  # cross-node isolation broken (expected, documented)
+
+        # But A's result is explicitly marked as degraded -- not silent
+        assert hit_a["_degraded_mode"] is True
+        assert hit_a["_cache_backend"] == "local_degraded"
+
+
+# ---------------------------------------------------------------------------
+# LOCAL_ONLY: never touches Redis
+# ---------------------------------------------------------------------------
+
+class TestLocalOnlyMode:
+
+    def test_local_only_never_calls_get_redis_client(self):
+        """LOCAL_ONLY must never attempt a Redis connection."""
+        with patch("qwed_new.core.redis_config.get_redis_client") as mock_get:
+            cache = get_cache(use_redis=False, mode=CacheBackendMode.LOCAL_ONLY)
+
+        mock_get.assert_not_called()
+        assert isinstance(cache, VerificationCache)
+
+    def test_local_only_consistent_within_process(self):
+        """LOCAL_ONLY provides consistent state within a single process."""
+        cache = VerificationCache()
+        cache.set("(= x 1)", {"status": "SAT"})
+        result = cache.get("(= x 1)")
+        assert result is not None
+        assert result["status"] == "SAT"
+
+
+# ---------------------------------------------------------------------------
+# get_cache() contract
+# ---------------------------------------------------------------------------
+
+class TestGetCacheContract:
+
+    def setup_method(self):
+        # Reset global singletons between tests
+        cache_mod._verification_caches.clear()
+        cache_mod._redis_caches.clear()
+        cache_mod._redis_cache_retry_after.clear()
+        reset_redis_state()
+
+    def test_strict_distributed_raises_when_redis_down(self):
+        """get_cache(mode=STRICT_DISTRIBUTED) + Redis down -> raise."""
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            with pytest.raises(CacheBackendUnavailableError):
+                get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
+
+    def test_local_only_returns_verification_cache(self):
+        """get_cache(use_redis=False) returns plain VerificationCache."""
+        cache = get_cache(use_redis=False, mode=CacheBackendMode.LOCAL_ONLY)
+        assert isinstance(cache, VerificationCache)
+
+    def test_explicit_degraded_returns_redis_cache_in_degraded_state(self):
+        """get_cache(mode=EXPLICIT_DEGRADED) + Redis down -> RedisCache in fallback."""
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            cache = get_cache(use_redis=True, mode=CacheBackendMode.EXPLICIT_DEGRADED)
+
+        assert isinstance(cache, RedisCache)
+        assert cache._fallback_cache is not None
+
+    def test_default_mode_is_strict_distributed(self):
+        """get_cache() default mode is STRICT_DISTRIBUTED (fail-closed by default)."""
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            with pytest.raises(CacheBackendUnavailableError):
+                get_cache(use_redis=True)  # no mode arg -> STRICT_DISTRIBUTED
+
+
+# ---------------------------------------------------------------------------
+# cached_verify() backward compat
+# ---------------------------------------------------------------------------
+
+class TestCachedVerifyBackwardCompat:
+
+    def setup_method(self):
+        cache_mod._verification_caches.clear()
+        cache_mod._redis_caches.clear()
+
+    def test_cached_verify_uses_local_only_no_redis(self):
+        """cached_verify() must never attempt Redis connection."""
+        with patch("qwed_new.core.redis_config.get_redis_client") as mock_get:
+            result = cached_verify(
+                "(= x 1)",
+                verify_fn=lambda: {"status": "SAT", "verified": True}
+            )
+
+        mock_get.assert_not_called()
+        assert result["status"] == "SAT"
+
+    def test_cached_verify_caches_on_second_call(self):
+        """cached_verify() returns cached result on second call."""
+        cache_mod._verification_caches.clear()
+
+        call_count = 0
+        def compute():
+            nonlocal call_count
+            call_count += 1
+            return {"status": "SAT", "verified": True}
+
+        cached_verify("(= x 42)", verify_fn=compute)
+        cached_verify("(= x 42)", verify_fn=compute)
+
+        assert call_count == 1  # second call served from cache
+
+    def test_cached_verify_no_degraded_marker(self):
+        """LOCAL_ONLY results must not carry _degraded_mode marker."""
+        cache_mod._verification_caches.clear()
+
+        r1 = cached_verify("(= y 7)", verify_fn=lambda: {"status": "SAT"})
+        assert "_degraded_mode" not in r1
+
+        # Cache hit also clean
+        r2 = cached_verify("(= y 7)", verify_fn=lambda: {"status": "SAT"})
+        assert "_degraded_mode" not in r2
+
+
+# ---------------------------------------------------------------------------
+# RedisCache rejects LOCAL_ONLY at construction
+# ---------------------------------------------------------------------------
+
+class TestRedisCacheLocalOnlyRejected:
+
+    def test_redis_cache_raises_on_local_only_mode(self):
+        """RedisCache(mode=LOCAL_ONLY) must raise ValueError -- misuse guard."""
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+            with pytest.raises(ValueError) as exc_info:
+                RedisCache(mode=CacheBackendMode.LOCAL_ONLY)
+
+        assert "LOCAL_ONLY" in str(exc_info.value)
+        assert "VerificationCache" in str(exc_info.value)
+
+    def test_redis_cache_raises_before_connecting_on_local_only(self):
+        """LOCAL_ONLY guard fires before any Redis connection attempt."""
+        with patch("qwed_new.core.redis_config.get_redis_client") as mock_get:
+            with pytest.raises(ValueError):
+                RedisCache(mode=CacheBackendMode.LOCAL_ONLY)
+        # get_redis_client must NOT have been called
+        mock_get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# VerificationCache __len__ and __contains__ correctness
+# ---------------------------------------------------------------------------
+
+class TestVerificationCacheContains:
+
+    def test_contains_returns_false_for_missing_key(self):
+        cache = VerificationCache()
+        assert ("(= x 1)" in cache) is False
+
+    def test_contains_returns_true_for_present_key(self):
+        cache = VerificationCache()
+        cache.set("(= x 1)", {"status": "SAT"})
+        assert ("(= x 1)" in cache) is True
+
+    def test_contains_returns_false_for_expired_entry(self):
+        """__contains__ must respect TTL -- expired entries are not present."""
+        cache = VerificationCache(ttl_seconds=-1)  # negative TTL guarantees immediate expiry
+        cache.set("(= x 1)", {"status": "SAT"})
+        # ttl=0 means immediately expired
+        assert ("(= x 1)" in cache) is False
+
+    def test_len_reflects_live_entries(self):
+        cache = VerificationCache()
+        assert len(cache) == 0
+        cache.set("(= x 1)", {"status": "SAT"})
+        assert len(cache) == 1
+
+
+# ---------------------------------------------------------------------------
+# Redis Recovery from Runtime Loss
+# ---------------------------------------------------------------------------
+
+class TestRedisRecovery:
+
+    def _make_degraded_cache(self):
+        """Build a RedisCache in EXPLICIT_DEGRADED with a live mock client."""
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+            cache = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+        # Inject client directly — bypasses _try_get_client cooldown so
+        # the test can exercise the recovery path synchronously.
+        cache._client = mock_client
+        return cache, mock_client
+
+    def test_recovers_when_redis_returns(self, caplog):
+        """If Redis fails and then recovers, fallback must be cleared."""
+        cache, mock_client = self._make_degraded_cache()
+
+        # 1. Healthy
+        mock_client.get.return_value = '{"status": "SAT"}'
+        assert cache.get("(= x 1)")["status"] == "SAT"
+
+        # 2. Redis dies -> activates fallback
+        mock_client.get.side_effect = Exception("connection reset")
+        cache.get("(= x 1)")
+        assert cache._fallback_cache is not None
+
+        # 3. Redis recovers -- _handle_runtime_redis_error set self._client = None
+        # and applied a cooldown. Re-inject the mock and reset cooldown to simulate
+        # Redis coming back without patching get_redis_client().
+        cache._client = mock_client
+        cache._client_retry_after = 0.0
+        mock_client.get.side_effect = None
+        mock_client.get.return_value = '{"status": "UNSAT"}'
+
+        with caplog.at_level(logging.WARNING, logger="qwed.cache.security"):
+            res = cache.get("(= x 1)")
+
+        # Result is from Redis now, no degraded marker
+        assert res["status"] == "UNSAT"
+        assert "_degraded_mode" not in res
+        
+        # Fallback cache must be cleared to exit degraded mode
+        assert cache._fallback_cache is None
+        
+        # Security event must be emitted
+        assert any("BACKEND_RECOVERED" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# stats() edge cases
+# ---------------------------------------------------------------------------
+
+class TestStatsEdgeCases:
+
+    def test_stats_reports_backend_error_on_strict_distributed(self):
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+            cache = RedisCache(mode=CacheBackendMode.STRICT_DISTRIBUTED)
+        cache._client = mock_client
+        mock_client.info.side_effect = Exception("timeout")
+
+        s = cache.stats
+        assert s["backend_error"] is True
+        assert s["degraded"] is False  # strict distributed never degrades
+
+    def test_stats_reports_degraded_on_explicit_degraded_error(self):
+        # Redis was up at init (mock_client returned), so _fallback_cache is None.
+        # If info() throws, degraded = _fallback_cache is not None = False.
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+            cache = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+        cache._client = mock_client
+        mock_client.info.side_effect = Exception("timeout")
+
+        s = cache.stats
+        assert s["backend_error"] is True
+        assert s["degraded"] is False  # no fallback is active
+
+    def test_stats_reports_degraded_true_when_fallback_active(self):
+        # Redis down at init -> _fallback_cache activated -> degraded = True
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            cache = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+        assert cache._fallback_cache is not None
+
+        # stats() when fallback is active returns the fallback cache's stats dict
+        # with backend="local_degraded" and degraded=True
+        s = cache.stats
+        assert s["degraded"] is True
+        assert s["backend"] == "local_degraded"
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation in LOCAL_ONLY / no-redis path
+# ---------------------------------------------------------------------------
+
+class TestTenantIsolation:
+
+    def setup_method(self, _):
+        cache_mod._verification_caches.clear()
+        cache_mod._redis_caches.clear()
+        cache_mod._redis_cache_retry_after.clear()
+        reset_redis_state()
+
+    def test_different_tenants_get_different_caches(self):
+        """Each tenant_id must return a distinct VerificationCache instance."""
+        c1 = get_cache(use_redis=False, tenant_id=1)
+        c2 = get_cache(use_redis=False, tenant_id=2)
+        assert c1 is not c2
+
+    def test_same_tenant_returns_same_instance(self):
+        c1 = get_cache(use_redis=False, tenant_id=1)
+        c2 = get_cache(use_redis=False, tenant_id=1)
+        assert c1 is c2
+
+    def test_tenant_a_data_invisible_to_tenant_b(self):
+        """Cache entries stored for tenant A must not appear for tenant B."""
+        c1 = get_cache(use_redis=False, tenant_id=1)
+        c1.set("(= x 1)", {"status": "SAT"})
+
+        c2 = get_cache(use_redis=False, tenant_id=2)
+        assert c2.get("(= x 1)") is None
+
+
+# ---------------------------------------------------------------------------
+# VerificationCache deep-copy boundary tests
+# ---------------------------------------------------------------------------
+
+class TestVerificationCacheDeepCopy:
+
+    def test_mutating_returned_result_does_not_corrupt_cache(self):
+        """get() must return a deep copy; mutating it must not affect the store."""
+        cache = VerificationCache()
+        cache.set("(= x 1)", {"status": "SAT", "meta": {"a": 1}})
+
+        result = cache.get("(= x 1)")
+        result["meta"]["a"] = 999  # mutate nested object
+
+        result2 = cache.get("(= x 1)")
+        assert result2["meta"]["a"] == 1  # original must be untouched
+
+    def test_mutating_stored_dict_does_not_corrupt_cache(self):
+        """set() must store a deep copy; mutating the input after set must not affect cache."""
+        original = {"status": "SAT", "meta": {"b": 2}}
+        cache = VerificationCache()
+        cache.set("(= x 2)", original)
+
+        original["meta"]["b"] = 888  # mutate original after set
+
+        result = cache.get("(= x 2)")
+        assert result["meta"]["b"] == 2  # cache must hold the original value
+
+
+# ---------------------------------------------------------------------------
+# _recover_from_fallback — only emits event on real state transition
+# ---------------------------------------------------------------------------
+
+class TestRecoverFromFallbackOnTransition:
+
+    def test_no_event_when_no_fallback_was_active(self, caplog):
+        """_recover_from_fallback must be a no-op when fallback is not active."""
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+            cache = RedisCache(mode=CacheBackendMode.STRICT_DISTRIBUTED)
+        cache._client = mock_client
+
+        with caplog.at_level(logging.WARNING, logger="qwed.cache.security"):
+            cache._recover_from_fallback()
+
+        events = [r.message for r in caplog.records if "BACKEND_RECOVERED" in r.message]
+        assert len(events) == 0, "No event expected when fallback was never active"
+
+    def test_event_emitted_only_on_first_recovery(self, caplog):
+        """BACKEND_RECOVERED event must appear exactly once when fallback transitions to None."""
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            cache = RedisCache(mode=CacheBackendMode.EXPLICIT_DEGRADED)
+        cache._client = mock_client
+
+        with caplog.at_level(logging.WARNING, logger="qwed.cache.security"):
+            cache._recover_from_fallback()  # real transition
+            cache._recover_from_fallback()  # should be no-op now
+
+        events = [r.message for r in caplog.records if "BACKEND_RECOVERED" in r.message]
+        assert len(events) == 1, f"Expected exactly 1 BACKEND_RECOVERED event, got {len(events)}"
+
+
+# ---------------------------------------------------------------------------
+# STRICT_DISTRIBUTED fail-closed during cooldown
+# ---------------------------------------------------------------------------
+
+class TestStrictDistributedCooldownFailClosed:
+    """
+    After a runtime Redis error, _handle_runtime_redis_error sets self._client = None
+    and starts a 30-second cooldown. During that window, _try_get_client() returns None.
+    All public methods must still raise CacheBackendUnavailableError, never silently
+    returning None / False / 0 — that would break the fail-closed contract.
+    """
+
+    def _make_strict_cache_with_dead_client(self):
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+            cache = RedisCache(mode=CacheBackendMode.STRICT_DISTRIBUTED)
+        # Put client into cooldown (as _handle_runtime_redis_error would)
+        cache._client = None
+        cache._client_retry_after = float("inf")  # Never retry in this test
+        return cache
+
+    def test_get_raises_during_cooldown(self):
+        cache = self._make_strict_cache_with_dead_client()
+        with pytest.raises(CacheBackendUnavailableError):
+            cache.get("(= x 1)")
+
+    def test_set_raises_during_cooldown(self):
+        cache = self._make_strict_cache_with_dead_client()
+        with pytest.raises(CacheBackendUnavailableError):
+            cache.set("(= x 1)", {"status": "SAT"})
+
+    def test_invalidate_raises_during_cooldown(self):
+        cache = self._make_strict_cache_with_dead_client()
+        with pytest.raises(CacheBackendUnavailableError):
+            cache.invalidate("(= x 1)")
+
+    def test_clear_raises_during_cooldown(self):
+        cache = self._make_strict_cache_with_dead_client()
+        with pytest.raises(CacheBackendUnavailableError):
+            cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# get_cache() anti-hammering cooldown
+# ---------------------------------------------------------------------------
+
+class TestGetCacheAntiHammering:
+
+    def setup_method(self, _):
+        cache_mod._verification_caches.clear()
+        cache_mod._redis_caches.clear()
+        cache_mod._redis_cache_retry_after.clear()
+        reset_redis_state()
+
+    def test_second_call_raises_immediately_without_reconnect(self):
+        """
+        If STRICT_DISTRIBUTED construction fails, the second get_cache() call must
+        raise CacheBackendUnavailableError without attempting a new connection
+        (avoids hammering Redis and holding the factory lock).
+        """
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=None):
+            with pytest.raises(CacheBackendUnavailableError):
+                get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
+
+        # Second call — still in cooldown window — must NOT call get_redis_client()
+        with patch("qwed_new.core.redis_config.get_redis_client") as mock_grk:
+            with pytest.raises(CacheBackendUnavailableError):
+                get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
+            mock_grk.assert_not_called()
+
+    def test_successful_construction_is_cached(self):
+        """Successful RedisCache is reused across get_cache() calls."""
+        mock_client = MagicMock()
+        with patch("qwed_new.core.redis_config.get_redis_client", return_value=mock_client):
+            c1 = get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
+            c2 = get_cache(use_redis=True, mode=CacheBackendMode.STRICT_DISTRIBUTED)
+        assert c1 is c2


### PR DESCRIPTION
## Problem

`RedisCache` silently fell back to a node-local `VerificationCache` when Redis
was unavailable. In a multi-node deployment this means:

- **Node A**: Redis down → writes to its own in-memory cache
- **Node B**: Redis down → reads from its own empty in-memory cache
- Same query, same tenant, two different outcomes — silently

This breaks distributed consistency at the enforcement boundary. Rate limits,
replay protection, and policy gates built on top of the shared cache can be
bypassed simply by routing requests to a cold or restarting node. Infrastructure
failure was silently converted into a security-mode downgrade with no operator
signal.

Closes #189.

---

## What Changed

### `CacheBackendMode` enum (new)

Three explicit operating modes — no hidden behavior:

| Mode | Redis unavailable | Use when |
|------|-------------------|----------|
| `STRICT_DISTRIBUTED` | Raises `CacheBackendUnavailableError` | Rate limits, replay protection, policy gates |
| `EXPLICIT_DEGRADED` | Falls back to node-local cache with audit marker + security event | Operator explicitly accepts consistency trade-off |
| `LOCAL_ONLY` | Never touches Redis | Single-process, tests, `cached_verify()` |

### `CacheBackendUnavailableError` (new)

Explicit, informative exception raised in `STRICT_DISTRIBUTED` mode. Message
includes guidance toward `EXPLICIT_DEGRADED` or `LOCAL_ONLY` so callers know
their options.

### `RedisCache` (modified)

- Accepts `mode: CacheBackendMode = STRICT_DISTRIBUTED`
- **Removed** unconditional `_fallback_cache = VerificationCache()` on Redis unavailable
- `STRICT_DISTRIBUTED` + no Redis at startup → raises immediately at construction
- `STRICT_DISTRIBUTED` + Redis error at runtime (get/set/invalidate/clear) → raises `CacheBackendUnavailableError`
- `EXPLICIT_DEGRADED` fallback activation emits a structured JSON security event to `qwed.cache.security` logger
- Every result served from the fallback path carries `_degraded_mode=True` and `_cache_backend="local_degraded"` — cross-node divergence is **explicit**, not silent
- `stats()` now exposes `mode` and `degraded` fields

### `get_cache()` (modified)

- Accepts `mode` parameter, defaults to `STRICT_DISTRIBUTED`
- `use_redis=False` or `LOCAL_ONLY` → returns plain `VerificationCache`

### `cached_verify()` (modified)

Explicitly uses `LOCAL_ONLY`. Its existing behaviour was already effectively
local-only via the silent fallback — this makes the intent clear and documented.
**No breaking change for existing callers.**

### `redis_config.py` (modified)

Added `reset_redis_state()` — resets module-level Redis singleton between tests
so Redis availability can be simulated independently per test case.

---

## Tests

`tests/test_pr189_redis_failclosed.py` — 25 new tests:

- `TestStrictDistributedStartupDown` — raises on startup, error message guides caller, no fallback created
- `TestStrictDistributedRuntimeError` — raises on get/set/invalidate/clear, never activates fallback
- `TestExplicitDegradedStartupDown` — activates fallback, emits valid JSON security event, tags results
- `TestExplicitDegradedRuntimeLoss` — runtime Redis loss activates fallback lazily, emits security event, documents cross-node isolation
- `TestLocalOnlyMode` — never calls `get_redis_client`, consistent within process
- `TestGetCacheContract` — default mode is `STRICT_DISTRIBUTED`, each mode returns correct type
- `TestCachedVerifyBackwardCompat` — never touches Redis, caches correctly, no `_degraded_mode` tag

**Full regression: 1198 passed, 82 skipped — zero regressions.**

---

## Backward Compatibility

| Caller | Before | After |
|--------|--------|-------|
| `VerificationCache` directly | In-memory only | Unchanged |
| `cached_verify()` | Silent local fallback | Explicit `LOCAL_ONLY` — same behavior |
| `RedisCache()` (no mode arg) | Silent fallback on Redis down | Raises `CacheBackendUnavailableError` — **breaking for distributed callers who relied on silent fallback** |
| `get_cache(use_redis=True)` | Silent fallback | Raises — same as above |

> Callers that previously relied on silent fallback must now either handle
> `CacheBackendUnavailableError` explicitly or opt into `EXPLICIT_DEGRADED`.
> This is intentional — the old behavior was the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote cache outages now surface explicit errors in strict mode; degraded-mode returns are clearly marked when a local fallback is used.

* **New Features**
  * Per-tenant in-memory verification cache with TTL+LRU, deep-copy isolation, hit/miss stats, length/containment checks.
  * Structured security events emitted on degraded activation and recovery.
  * Verify helper now defaults to local-only operation.

* **Refactor**
  * Cache backend now operates in strict, explicit-degraded, or local-only modes.

* **Tests / Chores**
  * Expanded test coverage for all modes and a test helper to reset cache/redis state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->