### PR TITLE
chore(release): v5.1.2 — Security patch (CWE-95 SymPy injection fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the QWED Protocol will be documented in this file.
 
 ## [Unreleased]
 
+## [5.1.2] - 2026-06-14
+### Security: SymPy Expression Injection Fix (CWE-95)
+
+Emergency patch fixing a **High severity (CVSS 8.8) authenticated RCE vulnerability** in SymPy `parse_expr()` across all math verification paths.
+
+#### Security Fix
+- **CWE-95 mitigation**: Added `safe_parse_expr()` wrapper with denylist, stripped `__builtins__`, allow-listed math namespace, per-call global dict copy, and post-parse validation. Replaced all 17 direct `parse_expr()` call sites in `main.py`, `verifier.py`, `batch.py`, and `validator.py`.
+- **Symbol consistency**: Added `get_safe_symbol()` to ensure calculus variables (`n`, Greek letters) match special SymPy assumptions, preventing incorrect `diff`/`integrate`/`limit` results.
+- **Defense-in-depth**: Pre-parse AST depth limit, post-parse SymPy tree depth validation, `sympy.Expr` type enforcement, `extra_symbols` key/value validation, and sanitized exception handling.
+
+#### Fixes and Hardening
+- **Cache Redis fail-closed**: Enforced fail-closed Redis backend for distributed cache mode (PR #199).
+- **Benchmarks CI**: CodSpeed performance benchmark workflow added (PR #198).
+- **TS SDK lockfile**: Restored `package-lock.json` for reliable `npm ci` in publish workflow (PR #197).
+
+#### Included PRs since v5.1.1
+- `#197` fix(ts-sdk): lockfile restore for npm ci publish
+- `#198` ci: CodSpeed performance benchmarks
+- `#199` fix(cache): fail-closed Redis backend for distributed mode
+- `#200` fix(math): restrict sympy expression parsing (CWE-95)
+
 ## [5.1.1] - 2026-05-21
 ### Release Consistency and Fail-Closed Follow-Through
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@
 
 ---
 
-## Release Update: v5.1.1
+## Release Update: v5.1.2
 
-`v5.1.1` is a patch release focused on **fail-closed follow-through and release consistency** after `v5.1.0`.
+`v5.1.2` is an **emergency security patch** fixing a **High severity (CVSS 8.8) authenticated RCE vulnerability** via unsafe SymPy `parse_expr()` calls.
 
-- Tightens cache trust-context binding to prevent cross-context verification replay
-- Hardens attestation and audit paths toward stricter fail-closed behavior
-- Cleans up proof-path handling across reasoning, symbolic, batch, and agent-service flows
-- Aligns package versions, API version markers, SDK metadata, and deployment references for a clean release boundary
+- **CWE-95 fix**: All 17 direct `parse_expr()` calls replaced with `safe_parse_expr()` — denylist + stripped builtins + allow-listed math namespace
+- **Calculus symbol consistency**: Fixed `n` variable mismatch in derivatives, integrals, and limits
+- **Defense-in-depth**: AST depth limits, SymPy tree validation, relational expression rejection
+- Cache Redis fail-closed hardening, CodSpeed benchmarks, TS SDK lockfile fixes
 
-If you're upgrading from `v5.1.0`, review the [changelog](CHANGELOG.md) for deployment/image reference updates and patch-level boundary hardening notes.
+If you're upgrading from `v5.1.1`, review the [changelog](CHANGELOG.md) for the full security advisory details.
 
 ---
 

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: qwed-core
-          image: docker.io/qwedai/qwed-verification:5.1.1
+          image: docker.io/qwedai/qwed-verification:5.1.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed"
-version = "5.1.1"
+version = "5.1.2"
 description = "The Deterministic Verification Protocol for AI - 11 verification engines for math, logic, code, SQL, facts, images, and more. Now with Agentic Security Guards."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qwed"
-version = "5.1.1"
+version = "5.1.2"
 edition = "2021"
 authors = ["QWED-AI"]
 description = "Rust SDK for QWED Verification Protocol"

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -11,7 +11,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qwed = "5.1.1"
+qwed = "5.1.2"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "description": "TypeScript SDK for QWED Verification Protocol",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -32,7 +32,7 @@ TenantDependency = Annotated[TenantContext, Depends(get_current_tenant)]
 SessionDependency = Annotated[Session, Depends(get_session)]
 AgentTokenHeader = Annotated[str, Header(...)]
 
-APP_VERSION = "5.1.1"
+APP_VERSION = "5.1.2"
 
 app = FastAPI(
     title="QWED API",


### PR DESCRIPTION
## v5.1.2 — Security Patch Release

**This is an emergency patch release.** Fixes a **High severity (CVSS 8.8) authenticated RCE vulnerability** (CWE-95) in SymPy's `parse_expr()` across all math verification paths.

### Security

- **CWE-95 mitigation**: Added `safe_parse_expr()` with denylist + stripped `__builtins__` + allow-listed math namespace + per-call global dict copy + post-parse validation. Replaced all 17 direct `parse_expr()` call sites.
- **Calculus symbol consistency**: Fixed `n` symbol mismatch causing incorrect `diff`/`integrate`/`limit` results.
- **Defense-in-depth**: AST depth limits, SymPy tree validation, relational rejection, `extra_symbols` validation.

### Included PRs

- `#197` fix(ts-sdk): lockfile restore
- `#198` ci: CodSpeed benchmarks
- `#199` fix(cache): fail-closed Redis backend
- `#200` fix(math): restrict SymPy expression parsing (CWE-95)

### Version Bumps

| Artifact | 5.1.1 → 5.1.2 |
|---|---|
| qwed (PyPI) | ✅ |
| @qwed-ai/sdk (NPM) | ✅ |
| qwed (Rust crate) | ✅ |
| API version header | ✅ |
| Docker image tag | ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Emergency security patch for a critical authentication-based vulnerability.
  * Added defense-in-depth hardening: safer expression parsing, consistent symbol handling, stricter validation limits, rejection of unsupported relational expressions, and fail-closed caching behavior.
  * Strengthened release notes to document the security improvements in detail.

* **Chores**
  * Bumped version to **5.1.2** across APIs, SDKs, Kubernetes deployment image tag, and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->