### PR TITLE
feat(diagnostics): unified 3-layer DiagnosticResult model (#204)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed"
-version = "5.1.2"
+version = "5.2.0"
 description = "The Deterministic Verification Protocol for AI - 11 verification engines for math, logic, code, SQL, facts, images, and more. Now with Agentic Security Guards."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/src/qwed_new/core/__init__.py
+++ b/src/qwed_new/core/__init__.py
@@ -20,6 +20,14 @@ from .exceptions import (
     wrap_error,
 )
 
+# Structured verification diagnostics (Issue #204)
+from .diagnostics import (
+    DiagnosticStatus,
+    DiagnosticResult,
+    AdvisoryCheck,
+    compute_proof_ref,
+)
+
 __all__ = [
     # Exceptions
     "QWEDError",
@@ -34,6 +42,11 @@ __all__ = [
     "QWEDAPIError",
     "QWEDDependencyError",
     "wrap_error",
+    # Diagnostics (#204)
+    "DiagnosticStatus",
+    "DiagnosticResult",
+    "AdvisoryCheck",
+    "compute_proof_ref",
 ]
 
 # Lazy imports for verifiers (avoid circular imports and missing deps)

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -104,6 +104,13 @@ class AdvisoryCheck:
     constraint_id: Optional[str] = None
     details: Dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        if self.advisory_only is not True:
+            raise ValueError(
+                "AdvisoryCheck.advisory_only must be True — "
+                "advisory checks must never influence the verification verdict."
+            )
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "name": self.name,
@@ -143,10 +150,12 @@ def compute_proof_ref(evidence: Dict[str, Any]) -> str:
     Note:
         The evidence dict is JSON-serialized with sort_keys=True for
         deterministic hashing. Non-JSON-serializable values must be
-        pre-converted to strings by the caller.
+        pre-converted to strings by the caller — they will raise
+        ValueError (fail-closed), preventing non-deterministic memory-
+        address-dependent hashes from entering the proof contract.
     """
     try:
-        payload = json.dumps(evidence, sort_keys=True, default=str)
+        payload = json.dumps(evidence, sort_keys=True)
     except (TypeError, ValueError) as exc:
         raise ValueError(
             f"Proof evidence must be JSON-serializable for proof_ref hashing: {exc}"
@@ -264,13 +273,26 @@ class DiagnosticResult:
 
         Tolerates status as str or DiagnosticStatus. Tolerates missing
         developer_fields (defaults to empty dict).
+
+        Raises:
+            ValueError: If agent_message is missing or empty — Layer 1
+                        diagnostics are mandatory and cannot be defaulted
+                        during deserialization.
         """
         status = data.get("status", "UNVERIFIABLE")
         if isinstance(status, str):
             status = DiagnosticStatus(status)
+
+        agent_message = data.get("agent_message")
+        if not agent_message or not str(agent_message).strip():
+            raise ValueError(
+                "from_dict: 'agent_message' is missing or empty — "
+                "Layer 1 diagnostics are mandatory for DiagnosticResult deserialization."
+            )
+
         return cls(
             status=status,
-            agent_message=data.get("agent_message", ""),
+            agent_message=agent_message,
             developer_fields=data.get("developer_fields", {}),
             proof_ref=data.get("proof_ref"),
         )
@@ -376,13 +398,19 @@ class DiagnosticResult:
         Raises:
             ValueError: If legacy data indicates VERIFIED — caller must use
                         DiagnosticResult.verified() with explicit evidence.
+            ValueError: If legacy data is unrecognized (no known status pattern
+                        and is_correct is truthy but not matching any branch) —
+                        fail-loudly per QWED_RULES to surface unexpected formats.
         """
         legacy_status = data.get("status", "")
         is_correct = data.get("is_correct", data.get("is_verified", data.get("verified", False)))
         error = data.get("error")
         message = data.get("message", data.get("reasoning", ""))
 
-        if legacy_status == "VERIFIED" or is_correct is True:
+        # Truthiness check — legacy engines may use 1/0 instead of True/False
+        is_correct_truthy = bool(is_correct)
+
+        if legacy_status == "VERIFIED" or is_correct_truthy:
             raise ValueError(
                 "from_legacy_dict cannot migrate VERIFIED results — "
                 "proof artifacts were not retained by legacy engines. "
@@ -425,7 +453,7 @@ class DiagnosticResult:
                 },
             )
 
-        if is_correct is False:
+        if not is_correct_truthy:
             if error:
                 return cls.blocked(
                     agent_message="Verification blocked",
@@ -441,12 +469,11 @@ class DiagnosticResult:
                 },
             )
 
-        return cls.unverifiable(
-            agent_message="Verification inconclusive — unrecognized legacy result",
-            developer_fields={
-                "constraint_id": f"{engine}.legacy_unrecognized",
-                "legacy_status": legacy_status,
-            },
+        # Unrecognized legacy pattern — fail loudly per QWED_RULES
+        raise ValueError(
+            f"from_legacy_dict cannot interpret unrecognized legacy data from {engine!r}: "
+            f"status={legacy_status!r}, is_correct={is_correct!r}. "
+            "Review engine output format and add explicit handling."
         )
 
 

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -87,7 +87,7 @@ class DiagnosticStatus(str, Enum):
 # developer_fields.advisory_checks for audit/developer review only.
 # ---------------------------------------------------------------------------
 
-@dataclass
+@dataclass(frozen=True)
 class AdvisoryCheck:
     """A non-proof-bearing analysis result attached as advisory metadata.
 
@@ -178,7 +178,7 @@ def compute_proof_ref(evidence: Dict[str, Any]) -> str:
 # DiagnosticResult — the unified 3-layer diagnostic model.
 # ---------------------------------------------------------------------------
 
-@dataclass
+@dataclass(frozen=True)
 class DiagnosticResult:
     """Unified verification diagnostic result (Issue #204).
 
@@ -214,9 +214,9 @@ class DiagnosticResult:
                 "agent_message must be non-empty — Layer 1 diagnostics are mandatory"
             )
 
-        if self.status is DiagnosticStatus.VERIFIED and self.proof_ref is None:
+        if self.status is DiagnosticStatus.VERIFIED and not self.proof_ref:
             raise ValueError(
-                "VERIFIED status requires proof_ref is not None — "
+                "VERIFIED status requires proof_ref is not None and non-empty — "
                 "a claim cannot be marked proven without a proof artifact hash. "
                 "Use UNVERIFIABLE if no proof was established."
             )

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -312,10 +312,20 @@ class DiagnosticResult:
             ValueError: If agent_message is missing or empty — Layer 1
                         diagnostics are mandatory and cannot be defaulted
                         during deserialization.
+            ValueError: If status is a string not in DiagnosticStatus —
+                        use from_legacy_dict() for pre-#204 engine data.
         """
         status = data.get("status", "UNVERIFIABLE")
         if isinstance(status, str):
-            status = DiagnosticStatus(status)
+            try:
+                status = DiagnosticStatus(status)
+            except ValueError:
+                valid = ", ".join(s.value for s in DiagnosticStatus)
+                raise ValueError(
+                    f"from_dict: invalid status {status!r} — "
+                    f"must be one of: {valid}. "
+                    "Use from_legacy_dict() for pre-#204 engine data."
+                ) from None
 
         agent_message = data.get("agent_message")
         if not agent_message or not str(agent_message).strip():

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -121,9 +121,19 @@ class AdvisoryCheck:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "AdvisoryCheck":
+        raw_advisory_only = data.get("advisory_only", True)
+        if isinstance(raw_advisory_only, bool):
+            advisory_only = raw_advisory_only
+        elif isinstance(raw_advisory_only, int) and raw_advisory_only in (0, 1):
+            advisory_only = bool(raw_advisory_only)
+        else:
+            raise ValueError(
+                "AdvisoryCheck.advisory_only must be a bool or integer 0/1"
+            )
+
         return cls(
             name=data.get("name", ""),
-            advisory_only=bool(data.get("advisory_only", True)),
+            advisory_only=advisory_only,
             constraint_id=data.get("constraint_id"),
             details=data.get("details", {}),
         )
@@ -263,7 +273,8 @@ class DiagnosticResult:
                 try:
                     result.append(AdvisoryCheck.from_dict(item))
                 except ValueError:
-                    pass
+                    # Invalid advisory metadata is non-authoritative; skip it.
+                    continue
             elif isinstance(item, AdvisoryCheck):
                 result.append(item)
         return result
@@ -271,13 +282,21 @@ class DiagnosticResult:
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to dict for API/SDK responses and attestation claims.
 
-        Returns a flat dict with all three layers. advisory_checks are
-        serialized as dicts inside developer_fields.
+        Returns a flat dict with all three layers. AdvisoryCheck instances
+        in developer_fields['advisory_checks'] are serialized to dicts.
         """
+        # Deep-copy developer_fields and serialize any AdvisoryCheck instances
+        fields = dict(self.developer_fields)
+        checks = fields.get("advisory_checks")
+        if isinstance(checks, list):
+            fields["advisory_checks"] = [
+                item.to_dict() if isinstance(item, AdvisoryCheck) else item
+                for item in checks
+            ]
         return {
             "status": self.status.value,
             "agent_message": self.agent_message,
-            "developer_fields": self.developer_fields,
+            "developer_fields": fields,
             "proof_ref": self.proof_ref,
             "is_authoritative": self.is_authoritative,
         }

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -1,0 +1,458 @@
+"""
+QWED Structured Verification Diagnostics.
+
+Implements the 3-layer diagnostic model (Issue #204):
+
+    Layer 1 — Agent-Safe Diagnostics
+        agent_message: str
+        Agent/model-facing summary. No detection logic, rule IDs, regex
+        patterns, or security bypass guidance. Allows agents to correct
+        failures without exposing verification internals.
+
+    Layer 2 — Developer Diagnostics
+        developer_fields: dict
+        Application-developer-facing structured evidence. Includes
+        constraint_id, expected/actual values, advisory_checks, methods_used,
+        engine-specific evidence. Structured, not free-form strings.
+
+    Layer 3 — Proof Diagnostics
+        proof_ref: Optional[str]
+        Cryptographic hash of retained proof artifact (sha256:...).
+        Present only when status == VERIFIED and proof was established.
+        None for UNVERIFIABLE / BLOCKED — this is the authority bit:
+        downstream gates reject proof_ref is None for control flow.
+
+Constraints (non-negotiable, per #204):
+- Diagnostics are NOT explainability. No confidence scores, no chain-of-thought,
+  no model reasoning in diagnostic output.
+- All diagnostic fields must originate from verification results, constraints,
+  rule evaluation, schema validation, or proof systems.
+- Agent-safe diagnostics must never expose detection logic, rule IDs, regex
+  patterns, or security bypass guidance.
+- VERIFIED requires proof_ref is not None — structurally enforced.
+- Existing fail-closed behavior must not be weakened.
+
+This module establishes the contract. Engine conformance (migrating ad-hoc
+Dict[str, Any] returns to DiagnosticResult) is tracked in blocked issues:
+#129, #130, #131, #133, #134, #162, #163, #164, #190, #205.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Status taxonomy — intentionally small to avoid proliferation.
+# Per #190 discussion (Keesan/Rahul): ambiguity IS unverifiability; the
+# distinction lives in developer_fields.constraint_id, not in status values.
+# ---------------------------------------------------------------------------
+
+class DiagnosticStatus(str, Enum):
+    """Verification diagnostic status.
+
+    Three states only — no HEURISTIC, AMBIGUOUS, or CORRECTION_NEEDED.
+    Richer distinctions live in developer_fields, not status.
+
+    VERIFIED:
+        The claim was deterministically proven. proof_ref MUST be present.
+        Downstream gates MAY admit for control flow.
+
+    UNVERIFIABLE:
+        The claim could not be proven. proof_ref MUST be None.
+        Reasons: insufficient evidence, ambiguous input, model-only support,
+        missing provider path, non-convergent computation.
+        Downstream gates MUST NOT admit for control flow.
+
+    BLOCKED:
+        Verification could not even be attempted. proof_ref MUST be None.
+        Reasons: missing declarations, parse error, configuration failure,
+        security policy violation, missing dependency.
+        Downstream gates MUST NOT admit for control flow.
+    """
+    VERIFIED = "VERIFIED"
+    UNVERIFIABLE = "UNVERIFIABLE"
+    BLOCKED = "BLOCKED"
+
+
+# ---------------------------------------------------------------------------
+# Advisory check — structured representation of non-proof-bearing analysis.
+# Used for: LLM fallback output, NLI entailment labels, VLM interpretation,
+# heuristic consistency checks, basic keyword safety scans.
+# Advisory checks NEVER set status or proof_ref — they populate
+# developer_fields.advisory_checks for audit/developer review only.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AdvisoryCheck:
+    """A non-proof-bearing analysis result attached as advisory metadata.
+
+    Advisory checks may carry useful information for developers or auditors,
+    but they MUST NOT influence the verification verdict. The constraint:
+
+        advisory_only = True
+
+    is structurally enforced: advisory checks populate
+    developer_fields.advisory_checks, never status or proof_ref.
+    """
+    name: str
+    advisory_only: bool = True
+    constraint_id: Optional[str] = None
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "advisory_only": self.advisory_only,
+            "constraint_id": self.constraint_id,
+            "details": self.details,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AdvisoryCheck":
+        return cls(
+            name=data.get("name", ""),
+            advisory_only=data.get("advisory_only", True),
+            constraint_id=data.get("constraint_id"),
+            details=data.get("details", {}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Proof reference computation — deterministic hash of retained evidence.
+# ---------------------------------------------------------------------------
+
+def compute_proof_ref(evidence: Dict[str, Any]) -> str:
+    """Compute a deterministic proof reference hash from retained evidence.
+
+    The proof_ref binds the verdict (status=VERIFIED) to the specific evidence
+    that justified it. If the evidence changes, the hash changes — making
+    verdict/evidence drift structurally detectable.
+
+    Args:
+        evidence: The proof artifact dict (e.g., convergence trace, frequency
+                  counts, eigenvalue comparison, Z3 assertion stack).
+
+    Returns:
+        sha256-prefixed hex digest string, e.g. "sha256:abcdef...".
+
+    Note:
+        The evidence dict is JSON-serialized with sort_keys=True for
+        deterministic hashing. Non-JSON-serializable values must be
+        pre-converted to strings by the caller.
+    """
+    try:
+        payload = json.dumps(evidence, sort_keys=True, default=str)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Proof evidence must be JSON-serializable for proof_ref hashing: {exc}"
+        ) from exc
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+# ---------------------------------------------------------------------------
+# DiagnosticResult — the unified 3-layer diagnostic model.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DiagnosticResult:
+    """Unified verification diagnostic result (Issue #204).
+
+    Replaces the 3 incompatible VerificationResult dataclasses and the ad-hoc
+    Dict[str, Any] returns across verification engines.
+
+    Three layers:
+        1. agent_message   — Layer 1 (agent-safe, no internals)
+        2. developer_fields — Layer 2 (structured developer evidence)
+        3. proof_ref        — Layer 3 (cryptographic proof artifact hash)
+
+    Authority contract:
+        proof_ref is not None  → authoritative, admissible for control flow
+        proof_ref is None      → non-authoritative, NOT admissible for control flow
+
+    This is the mechanical rule downstream gates use (per #190 Keesan
+    discussion): no separate `authoritative` boolean needed.
+
+    Constraints enforced in __post_init__:
+        - status == VERIFIED  requires proof_ref is not None
+        - status == UNVERIFIABLE or BLOCKED  requires proof_ref is None
+        - agent_message must be non-empty
+    """
+
+    status: DiagnosticStatus
+    agent_message: str
+    developer_fields: Dict[str, Any] = field(default_factory=dict)
+    proof_ref: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.agent_message or not self.agent_message.strip():
+            raise ValueError(
+                "agent_message must be non-empty — Layer 1 diagnostics are mandatory"
+            )
+
+        if self.status is DiagnosticStatus.VERIFIED and self.proof_ref is None:
+            raise ValueError(
+                "VERIFIED status requires proof_ref is not None — "
+                "a claim cannot be marked proven without a proof artifact hash. "
+                "Use UNVERIFIABLE if no proof was established."
+            )
+
+        if self.status is not DiagnosticStatus.VERIFIED and self.proof_ref is not None:
+            raise ValueError(
+                f"{self.status.value} status requires proof_ref is None — "
+                "non-VERIFIED states are non-authoritative by construction."
+            )
+
+    @property
+    def is_verified(self) -> bool:
+        """True only when status is VERIFIED (which implies proof_ref is not None)."""
+        return self.status is DiagnosticStatus.VERIFIED
+
+    @property
+    def is_authoritative(self) -> bool:
+        """Authority bit — True when proof_ref is present (admissible for control flow).
+
+        This is Keesan's `authoritative=true` from #190, expressed as
+        proof_ref presence rather than a separate boolean. Downstream gates:
+
+            if not result.is_authoritative:
+                block_decision()  # non-authoritative — reject for control flow
+        """
+        return self.proof_ref is not None
+
+    @property
+    def is_fail_closed(self) -> bool:
+        """True when status is UNVERIFIABLE or BLOCKED (non-pass, fail-closed)."""
+        return self.status in (DiagnosticStatus.UNVERIFIABLE, DiagnosticStatus.BLOCKED)
+
+    @property
+    def constraint_id(self) -> Optional[str]:
+        """The primary constraint identifier from developer_fields, if present."""
+        return self.developer_fields.get("constraint_id")
+
+    @property
+    def advisory_checks(self) -> List[AdvisoryCheck]:
+        """Advisory checks from developer_fields, deserialized to AdvisoryCheck."""
+        raw = self.developer_fields.get("advisory_checks", [])
+        if not isinstance(raw, list):
+            return []
+        return [AdvisoryCheck.from_dict(item) if isinstance(item, dict) else item
+                for item in raw]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dict for API/SDK responses and attestation claims.
+
+        Returns a flat dict with all three layers. advisory_checks are
+        serialized as dicts inside developer_fields.
+        """
+        return {
+            "status": self.status.value,
+            "agent_message": self.agent_message,
+            "developer_fields": self.developer_fields,
+            "proof_ref": self.proof_ref,
+            "is_authoritative": self.is_authoritative,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DiagnosticResult":
+        """Deserialize from dict (e.g., API response, attestation claim).
+
+        Tolerates status as str or DiagnosticStatus. Tolerates missing
+        developer_fields (defaults to empty dict).
+        """
+        status = data.get("status", "UNVERIFIABLE")
+        if isinstance(status, str):
+            status = DiagnosticStatus(status)
+        return cls(
+            status=status,
+            agent_message=data.get("agent_message", ""),
+            developer_fields=data.get("developer_fields", {}),
+            proof_ref=data.get("proof_ref"),
+        )
+
+    @classmethod
+    def verified(
+        cls,
+        agent_message: str,
+        developer_fields: Dict[str, Any],
+        evidence: Dict[str, Any],
+    ) -> "DiagnosticResult":
+        """Construct a VERIFIED result with proof_ref computed from evidence.
+
+        Args:
+            agent_message: Agent-safe summary (Layer 1).
+            developer_fields: Structured developer evidence (Layer 2).
+            evidence: Proof artifact dict — hashed to produce proof_ref (Layer 3).
+
+        Returns:
+            DiagnosticResult with status=VERIFIED and proof_ref=compute_proof_ref(evidence).
+        """
+        return cls(
+            status=DiagnosticStatus.VERIFIED,
+            agent_message=agent_message,
+            developer_fields=developer_fields,
+            proof_ref=compute_proof_ref(evidence),
+        )
+
+    @classmethod
+    def unverifiable(
+        cls,
+        agent_message: str,
+        developer_fields: Optional[Dict[str, Any]] = None,
+    ) -> "DiagnosticResult":
+        """Construct an UNVERIFIABLE result (non-pass, non-authoritative).
+
+        Args:
+            agent_message: Agent-safe summary of why verification was inconclusive.
+            developer_fields: Structured developer evidence (constraint_id, etc.).
+
+        Returns:
+            DiagnosticResult with status=UNVERIFIABLE and proof_ref=None.
+        """
+        return cls(
+            status=DiagnosticStatus.UNVERIFIABLE,
+            agent_message=agent_message,
+            developer_fields=developer_fields or {},
+            proof_ref=None,
+        )
+
+    @classmethod
+    def blocked(
+        cls,
+        agent_message: str,
+        developer_fields: Optional[Dict[str, Any]] = None,
+    ) -> "DiagnosticResult":
+        """Construct a BLOCKED result (verification could not be attempted).
+
+        Args:
+            agent_message: Agent-safe summary of why verification was blocked.
+            developer_fields: Structured developer evidence (constraint_id, etc.).
+
+        Returns:
+            DiagnosticResult with status=BLOCKED and proof_ref=None.
+        """
+        return cls(
+            status=DiagnosticStatus.BLOCKED,
+            agent_message=agent_message,
+            developer_fields=developer_fields or {},
+            proof_ref=None,
+        )
+
+    @classmethod
+    def from_legacy_dict(cls, data: Dict[str, Any], engine: str = "unknown") -> "DiagnosticResult":
+        """Migration helper: convert ad-hoc engine dict to DiagnosticResult.
+
+        Interprets the common pre-#204 patterns:
+            {"is_correct": True, "status": "VERIFIED", ...}  → VERIFIED
+            {"is_correct": False, "status": "CORRECTION_NEEDED", ...}  → UNVERIFIABLE
+            {"is_correct": False, "status": "BLOCKED", ...}  → BLOCKED
+            {"is_correct": False, "status": "ERROR", "error": ...}  → BLOCKED
+            {"is_correct": False, "status": "SYNTAX_ERROR", ...}  → BLOCKED
+            {"verified": False, "message": ...}  → UNVERIFIABLE
+
+        Note:
+            Legacy VERIFIED results get proof_ref=None because the original
+            engine did not retain proof artifacts. This means from_legacy_dict
+            CANNOT produce a VERIFIED DiagnosticResult — it will raise
+            ValueError for legacy "VERIFIED" inputs, because VERIFIED requires
+            proof_ref. Callers must use DiagnosticResult.verified() with
+            explicit evidence for true VERIFIED results.
+
+            This is intentional: the migration helper is for fail-closed
+            states, not for backfilling proof artifacts that were discarded.
+
+        Args:
+            data: The legacy ad-hoc dict from an engine.
+            engine: Engine name for constraint_id namespacing.
+
+        Returns:
+            DiagnosticResult (UNVERIFIABLE or BLOCKED for non-pass legacy states).
+
+        Raises:
+            ValueError: If legacy data indicates VERIFIED — caller must use
+                        DiagnosticResult.verified() with explicit evidence.
+        """
+        legacy_status = data.get("status", "")
+        is_correct = data.get("is_correct", data.get("is_verified", data.get("verified", False)))
+        error = data.get("error")
+        message = data.get("message", data.get("reasoning", ""))
+
+        if legacy_status == "VERIFIED" or is_correct is True:
+            raise ValueError(
+                "from_legacy_dict cannot migrate VERIFIED results — "
+                "proof artifacts were not retained by legacy engines. "
+                "Use DiagnosticResult.verified() with explicit evidence dict."
+            )
+
+        if legacy_status == "BLOCKED":
+            agent_message = message or "Verification blocked"
+            return cls.blocked(
+                agent_message=agent_message,
+                developer_fields={
+                    "constraint_id": f"{engine}.legacy_blocked",
+                    "legacy_error": error,
+                    "legacy_data": {k: v for k, v in data.items()
+                                    if k not in ("status", "is_correct", "error")},
+                },
+            )
+
+        if legacy_status in ("ERROR", "SYNTAX_ERROR", "PARSE_ERROR"):
+            agent_message = "Verification blocked — processing error"
+            return cls.blocked(
+                agent_message=agent_message,
+                developer_fields={
+                    "constraint_id": f"{engine}.legacy_error",
+                    "legacy_error": error or message,
+                    "legacy_status": legacy_status,
+                },
+            )
+
+        if legacy_status in ("CORRECTION_NEEDED", "NOT_EQUIVALENT", "INCONCLUSIVE",
+                             "INSUFFICIENT_EVIDENCE", "NO_PROOF"):
+            agent_message = message or "Verification inconclusive"
+            return cls.unverifiable(
+                agent_message=agent_message,
+                developer_fields={
+                    "constraint_id": f"{engine}.legacy_inconclusive",
+                    "legacy_status": legacy_status,
+                    "legacy_data": {k: v for k, v in data.items()
+                                    if k not in ("status", "is_correct", "error", "message")},
+                },
+            )
+
+        if is_correct is False:
+            if error:
+                return cls.blocked(
+                    agent_message="Verification blocked",
+                    developer_fields={
+                        "constraint_id": f"{engine}.legacy_error",
+                        "legacy_error": error,
+                    },
+                )
+            return cls.unverifiable(
+                agent_message=message or "Verification inconclusive",
+                developer_fields={
+                    "constraint_id": f"{engine}.legacy_inconclusive",
+                },
+            )
+
+        return cls.unverifiable(
+            agent_message="Verification inconclusive — unrecognized legacy result",
+            developer_fields={
+                "constraint_id": f"{engine}.legacy_unrecognized",
+                "legacy_status": legacy_status,
+            },
+        )
+
+
+__all__ = [
+    "DiagnosticStatus",
+    "DiagnosticResult",
+    "AdvisoryCheck",
+    "compute_proof_ref",
+]

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -123,7 +123,7 @@ class AdvisoryCheck:
     def from_dict(cls, data: Dict[str, Any]) -> "AdvisoryCheck":
         return cls(
             name=data.get("name", ""),
-            advisory_only=data.get("advisory_only", True),
+            advisory_only=bool(data.get("advisory_only", True)),
             constraint_id=data.get("constraint_id"),
             details=data.get("details", {}),
         )
@@ -246,12 +246,27 @@ class DiagnosticResult:
 
     @property
     def advisory_checks(self) -> List[AdvisoryCheck]:
-        """Advisory checks from developer_fields, deserialized to AdvisoryCheck."""
+        """Advisory checks from developer_fields, deserialized to AdvisoryCheck.
+
+        Defensive: skips malformed or invalid items rather than raising.
+        Only dicts (converted via from_dict) and existing AdvisoryCheck
+        instances are included. This ensures the property never raises
+        ValueError at access time (Greptile P1) and doesn't propagate
+        garbage (CodeRabbit fail-closed suggestion).
+        """
         raw = self.developer_fields.get("advisory_checks", [])
         if not isinstance(raw, list):
             return []
-        return [AdvisoryCheck.from_dict(item) if isinstance(item, dict) else item
-                for item in raw]
+        result = []
+        for item in raw:
+            if isinstance(item, dict):
+                try:
+                    result.append(AdvisoryCheck.from_dict(item))
+                except ValueError:
+                    pass
+            elif isinstance(item, AdvisoryCheck):
+                result.append(item)
+        return result
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to dict for API/SDK responses and attestation claims.

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -407,10 +407,9 @@ class DiagnosticResult:
         error = data.get("error")
         message = data.get("message", data.get("reasoning", ""))
 
-        # Truthiness check — legacy engines may use 1/0 instead of True/False
-        is_correct_truthy = bool(is_correct)
-
-        if legacy_status == "VERIFIED" or is_correct_truthy:
+        # Only explicit "VERIFIED" status is rejected here — truthy is_correct
+        # with unknown status falls through to the unrecognized-pattern raise below.
+        if legacy_status == "VERIFIED":
             raise ValueError(
                 "from_legacy_dict cannot migrate VERIFIED results — "
                 "proof artifacts were not retained by legacy engines. "
@@ -453,7 +452,7 @@ class DiagnosticResult:
                 },
             )
 
-        if not is_correct_truthy:
+        if not bool(is_correct):
             if error:
                 return cls.blocked(
                     agent_message="Verification blocked",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -255,6 +255,16 @@ class TestAdvisoryCheck(unittest.TestCase):
         with self.assertRaises(ValueError):
             AdvisoryCheck(name="x", advisory_only=False)
 
+    def test_from_dict_coerces_integer_advisory_only(self):
+        """from_dict must coerce 1 to True — cross-language APIs use int booleans."""
+        ac = AdvisoryCheck.from_dict({"name": "test", "advisory_only": 1})
+        self.assertTrue(ac.advisory_only)
+
+    def test_from_dict_rejects_zero_advisory_only(self):
+        """from_dict with advisory_only=0 coerces to False — must raise."""
+        with self.assertRaises(ValueError):
+            AdvisoryCheck.from_dict({"name": "test", "advisory_only": 0})
+
     def test_advisory_check_to_dict(self):
         ac = AdvisoryCheck(
             name="vlm_analysis",
@@ -311,6 +321,27 @@ class TestDeveloperFields(unittest.TestCase):
     def test_advisory_checks_empty_when_absent(self):
         r = DiagnosticResult.unverifiable("no", {})
         self.assertEqual(r.advisory_checks, [])
+
+    def test_advisory_checks_skips_invalid_items(self):
+        """Property must skip malformed items (fail-closed, never raise)."""
+        r = DiagnosticResult.unverifiable("no", {
+            "advisory_checks": [
+                {"name": "valid", "advisory_only": True, "details": {}},
+                {"name": "invalid", "advisory_only": False, "details": {}},
+                42,
+                "garbage",
+            ],
+        })
+        checks = r.advisory_checks
+        self.assertEqual(len(checks), 1)
+        self.assertEqual(checks[0].name, "valid")
+
+    def test_advisory_checks_accepts_existing_instances(self):
+        ac = AdvisoryCheck(name="prebuilt", constraint_id="test")
+        r = DiagnosticResult.unverifiable("no", {"advisory_checks": [ac]})
+        checks = r.advisory_checks
+        self.assertEqual(len(checks), 1)
+        self.assertEqual(checks[0].name, "prebuilt")
 
     def test_developer_fields_default_empty_dict(self):
         r = DiagnosticResult.unverifiable("no")

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -265,6 +265,11 @@ class TestAdvisoryCheck(unittest.TestCase):
         with self.assertRaises(ValueError):
             AdvisoryCheck.from_dict({"name": "test", "advisory_only": 0})
 
+    def test_from_dict_rejects_string_advisory_only(self):
+        """from_dict must reject string 'false' — bool('false') is True in Python."""
+        with self.assertRaises(ValueError):
+            AdvisoryCheck.from_dict({"name": "test", "advisory_only": "false"})
+
     def test_advisory_check_to_dict(self):
         ac = AdvisoryCheck(
             name="vlm_analysis",
@@ -372,6 +377,25 @@ class TestSerialization(unittest.TestCase):
         self.assertEqual(r2.agent_message, r.agent_message)
         self.assertEqual(r2.proof_ref, r.proof_ref)
         self.assertEqual(r2.developer_fields, r.developer_fields)
+
+    def test_to_dict_serializes_advisory_check_instances(self):
+        """to_dict must serialize AdvisoryCheck instances to dicts (Sentry MEDIUM)."""
+        ac = AdvisoryCheck(name="llm", constraint_id="test", details={"verdict": "yes"})
+        r = DiagnosticResult.unverifiable("no", {"advisory_checks": [ac]})
+        d = r.to_dict()
+        checks = d["developer_fields"]["advisory_checks"]
+        self.assertEqual(len(checks), 1)
+        self.assertIsInstance(checks[0], dict)
+        self.assertEqual(checks[0]["name"], "llm")
+
+    def test_to_dict_json_serializable_with_advisory_checks(self):
+        """to_dict output must be JSON-serializable even with AdvisoryCheck instances."""
+        import json
+        ac = AdvisoryCheck(name="nli", constraint_id="graph.nli", details={"label": "entailment"})
+        r = DiagnosticResult.unverifiable("no", {"advisory_checks": [ac]})
+        d = r.to_dict()
+        payload = json.dumps(d)  # must not raise TypeError
+        self.assertIn("nli", payload)
 
     def test_unverifiable_round_trip(self):
         r = DiagnosticResult.unverifiable(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -173,6 +173,22 @@ class TestAuthorityContract(unittest.TestCase):
         self.assertEqual(len(admissible), 1)
         self.assertTrue(admissible[0].is_verified)
 
+    def test_empty_string_proof_ref_raises(self):
+        """Empty string proof_ref must not bypass authority invariant (Greptile P1)."""
+        with self.assertRaises(ValueError):
+            DiagnosticResult(
+                status=DiagnosticStatus.VERIFIED,
+                agent_message="ok",
+                developer_fields={},
+                proof_ref="",
+            )
+
+    def test_frozen_dataclass_prevents_mutation(self):
+        """Post-construction proof_ref mutation must be blocked (Greptile P1)."""
+        r = DiagnosticResult.unverifiable("no", {})
+        with self.assertRaises((AttributeError, Exception)):
+            r.proof_ref = "sha256:fake"  # type: ignore[misc]
+
 
 # ---------------------------------------------------------------------------
 # Fail-closed enforcement

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -226,14 +226,17 @@ class TestComputeProofRef(unittest.TestCase):
         ref2 = compute_proof_ref({"b": 2, "a": 1})
         self.assertEqual(ref1, ref2)
 
-    def test_non_serializable_falls_back_to_str(self):
-        """default=str in json.dumps stringifies non-serializable objects."""
-        ref = compute_proof_ref({"obj": object()})
-        self.assertTrue(ref.startswith("sha256:"))
+    def test_non_serializable_raises_value_error(self):
+        """Non-serializable objects must be rejected to ensure deterministic hashing."""
+        with self.assertRaises(ValueError) as ctx:
+            compute_proof_ref({"obj": object()})
+        self.assertIn("JSON-serializable", str(ctx.exception))
 
-    def test_nested_non_serializable_falls_back_to_str(self):
-        ref = compute_proof_ref({"data": {"inner": object()}})
-        self.assertTrue(ref.startswith("sha256:"))
+    def test_nested_non_serializable_raises_value_error(self):
+        """Nested non-serializable objects must also be rejected."""
+        with self.assertRaises(ValueError) as ctx:
+            compute_proof_ref({"data": {"inner": object()}})
+        self.assertIn("JSON-serializable", str(ctx.exception))
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +249,11 @@ class TestAdvisoryCheck(unittest.TestCase):
     def test_default_advisory_only_is_true(self):
         ac = AdvisoryCheck(name="llm_fallback")
         self.assertTrue(ac.advisory_only)
+
+    def test_advisory_only_false_raises(self):
+        """advisory_only=False must raise — structurally enforced contract."""
+        with self.assertRaises(ValueError):
+            AdvisoryCheck(name="x", advisory_only=False)
 
     def test_advisory_check_to_dict(self):
         ac = AdvisoryCheck(
@@ -365,6 +373,16 @@ class TestSerialization(unittest.TestCase):
         r = DiagnosticResult.from_dict(d)
         self.assertEqual(r.status, DiagnosticStatus.UNVERIFIABLE)
 
+    def test_from_dict_missing_agent_message_raises(self):
+        """Missing agent_message must raise clear deserialization error."""
+        with self.assertRaises(ValueError) as ctx:
+            DiagnosticResult.from_dict({"status": "UNVERIFIABLE"})
+        self.assertIn("agent_message", str(ctx.exception))
+
+    def test_from_dict_empty_agent_message_raises(self):
+        with self.assertRaises(ValueError):
+            DiagnosticResult.from_dict({"status": "UNVERIFIABLE", "agent_message": "  "})
+
 
 # ---------------------------------------------------------------------------
 # from_legacy_dict — migration helper for ad-hoc engine dicts
@@ -413,10 +431,23 @@ class TestFromLegacyDict(unittest.TestCase):
         with self.assertRaises(ValueError):
             DiagnosticResult.from_legacy_dict(legacy, engine="math")
 
-    def test_unrecognized_status_becomes_unverifiable(self):
-        legacy = {"is_correct": False, "status": "UNKNOWN_STATUS"}
-        r = DiagnosticResult.from_legacy_dict(legacy, engine="test")
+    def test_is_correct_integer_one_raises(self):
+        """Legacy engines using 1 instead of True must be caught (identity bypass fix)."""
+        legacy = {"is_correct": 1, "status": "WHATEVER"}
+        with self.assertRaises(ValueError):
+            DiagnosticResult.from_legacy_dict(legacy, engine="math")
+
+    def test_is_correct_integer_zero_becomes_unverifiable(self):
+        """Legacy engines using 0 instead of False must be handled (identity bypass fix)."""
+        legacy = {"is_correct": 0, "status": "WHATEVER"}
+        r = DiagnosticResult.from_legacy_dict(legacy, engine="math")
         self.assertEqual(r.status, DiagnosticStatus.UNVERIFIABLE)
+
+    def test_unrecognized_truthy_raises(self):
+        """Unrecognized legacy patterns with truthy is_correct must raise (fail-loudly)."""
+        legacy = {"is_correct": "yes", "status": "UNKNOWN_STATUS"}
+        with self.assertRaises(ValueError):
+            DiagnosticResult.from_legacy_dict(legacy, engine="test")
 
     def test_no_status_no_is_correct_becomes_inconclusive(self):
         """When is_correct defaults to False with no error, result is inconclusive."""
@@ -507,7 +538,7 @@ class TestRealisticScenarios(unittest.TestCase):
             agent_message="Claim could not be deterministically verified",
             developer_fields={
                 "deterministic_verdict": "INSUFFICIENT_EVIDENCE",
-                "deterministic_confidence": 0.4,
+                "evidence_coverage_ratio": 0.4,
                 "advisory_checks": [
                     AdvisoryCheck(
                         name="llm_fallback",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -434,6 +434,14 @@ class TestSerialization(unittest.TestCase):
             DiagnosticResult.from_dict({"status": "UNVERIFIABLE"})
         self.assertIn("agent_message", str(ctx.exception))
 
+    def test_from_dict_invalid_status_raises_with_guidance(self):
+        """Invalid status string must raise with valid options + from_legacy_dict pointer."""
+        with self.assertRaises(ValueError) as ctx:
+            DiagnosticResult.from_dict({"status": "CORRECTION_NEEDED", "agent_message": "x"})
+        msg = str(ctx.exception)
+        self.assertIn("CORRECTION_NEEDED", msg)
+        self.assertIn("from_legacy_dict", msg)
+
     def test_from_dict_empty_agent_message_raises(self):
         with self.assertRaises(ValueError):
             DiagnosticResult.from_dict({"status": "UNVERIFIABLE", "agent_message": "  "})

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,591 @@
+"""
+Tests for Issue #204: Structured Verification Diagnostics — 3-Layer Model.
+
+Covers:
+- DiagnosticStatus enum (tri-state, no proliferation)
+- DiagnosticResult construction (VERIFIED / UNVERIFIABLE / BLOCKED)
+- Layer 1: agent_message (agent-safe, mandatory, non-empty)
+- Layer 2: developer_fields (constraint_id, advisory_checks, evidence)
+- Layer 3: proof_ref (authority bit, hash binding, None for non-pass)
+- Authority contract: proof_ref presence = admissible for control flow
+- Fail-closed enforcement: VERIFIED requires proof_ref, non-VERIFIED rejects it
+- AdvisoryCheck: advisory_only enforcement, serialization
+- compute_proof_ref: deterministic hashing, JSON serialization
+- to_dict / from_dict round-trip
+- from_legacy_dict: migration from ad-hoc engine dicts (fail-closed states only)
+- Constraint violations raise ValueError
+"""
+
+import unittest
+from src.qwed_new.core.diagnostics import (
+    DiagnosticStatus,
+    DiagnosticResult,
+    AdvisoryCheck,
+    compute_proof_ref,
+)
+
+
+# ---------------------------------------------------------------------------
+# DiagnosticStatus enum
+# ---------------------------------------------------------------------------
+
+class TestDiagnosticStatus(unittest.TestCase):
+    """Status taxonomy must be exactly three states — no proliferation."""
+
+    def test_exactly_three_statuses(self):
+        self.assertEqual(len(DiagnosticStatus), 3)
+
+    def test_verified_exists(self):
+        self.assertEqual(DiagnosticStatus.VERIFIED.value, "VERIFIED")
+
+    def test_unverifiable_exists(self):
+        self.assertEqual(DiagnosticStatus.UNVERIFIABLE.value, "UNVERIFIABLE")
+
+    def test_blocked_exists(self):
+        self.assertEqual(DiagnosticStatus.BLOCKED.value, "BLOCKED")
+
+    def test_no_heuristic_status(self):
+        self.assertFalse(hasattr(DiagnosticStatus, "HEURISTIC"))
+
+    def test_no_ambiguous_status(self):
+        self.assertFalse(hasattr(DiagnosticStatus, "AMBIGUOUS"))
+
+    def test_no_correction_needed_status(self):
+        self.assertFalse(hasattr(DiagnosticStatus, "CORRECTION_NEEDED"))
+
+    def test_status_is_str_enum(self):
+        self.assertIsInstance(DiagnosticStatus.VERIFIED, str)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — agent_message (agent-safe)
+# ---------------------------------------------------------------------------
+
+class TestAgentMessage(unittest.TestCase):
+    """Layer 1: agent_message is mandatory, non-empty, agent-safe."""
+
+    def test_empty_agent_message_raises(self):
+        with self.assertRaises(ValueError):
+            DiagnosticResult.unverifiable("", {})
+
+    def test_whitespace_only_agent_message_raises(self):
+        with self.assertRaises(ValueError):
+            DiagnosticResult.unverifiable("   ", {})
+
+    def test_agent_message_present_on_verified(self):
+        r = DiagnosticResult.verified("Claim verified", {}, {"a": 1})
+        self.assertEqual(r.agent_message, "Claim verified")
+
+    def test_agent_message_present_on_unverifiable(self):
+        r = DiagnosticResult.unverifiable("Cannot verify", {})
+        self.assertEqual(r.agent_message, "Cannot verify")
+
+    def test_agent_message_present_on_blocked(self):
+        r = DiagnosticResult.blocked("Blocked", {})
+        self.assertEqual(r.agent_message, "Blocked")
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — proof_ref (authority bit)
+# ---------------------------------------------------------------------------
+
+class TestProofRef(unittest.TestCase):
+    """Layer 3: proof_ref is the authority bit — present only for VERIFIED."""
+
+    def test_verified_has_proof_ref(self):
+        r = DiagnosticResult.verified("ok", {}, {"evidence": True})
+        self.assertIsNotNone(r.proof_ref)
+        self.assertTrue(r.proof_ref.startswith("sha256:"))
+
+    def test_unverifiable_has_no_proof_ref(self):
+        r = DiagnosticResult.unverifiable("no", {})
+        self.assertIsNone(r.proof_ref)
+
+    def test_blocked_has_no_proof_ref(self):
+        r = DiagnosticResult.blocked("blocked", {})
+        self.assertIsNone(r.proof_ref)
+
+    def test_verified_without_proof_ref_raises(self):
+        with self.assertRaises(ValueError):
+            DiagnosticResult(
+                status=DiagnosticStatus.VERIFIED,
+                agent_message="ok",
+                developer_fields={},
+                proof_ref=None,
+            )
+
+    def test_unverifiable_with_proof_ref_raises(self):
+        with self.assertRaises(ValueError):
+            DiagnosticResult(
+                status=DiagnosticStatus.UNVERIFIABLE,
+                agent_message="no",
+                developer_fields={},
+                proof_ref="sha256:abc",
+            )
+
+    def test_blocked_with_proof_ref_raises(self):
+        with self.assertRaises(ValueError):
+            DiagnosticResult(
+                status=DiagnosticStatus.BLOCKED,
+                agent_message="blocked",
+                developer_fields={},
+                proof_ref="sha256:abc",
+            )
+
+    def test_is_authoritative_true_for_verified(self):
+        r = DiagnosticResult.verified("ok", {}, {"e": 1})
+        self.assertTrue(r.is_authoritative)
+
+    def test_is_authoritative_false_for_unverifiable(self):
+        r = DiagnosticResult.unverifiable("no", {})
+        self.assertFalse(r.is_authoritative)
+
+    def test_is_authoritative_false_for_blocked(self):
+        r = DiagnosticResult.blocked("blocked", {})
+        self.assertFalse(r.is_authoritative)
+
+
+# ---------------------------------------------------------------------------
+# Authority contract — downstream gate mechanical rule
+# ---------------------------------------------------------------------------
+
+class TestAuthorityContract(unittest.TestCase):
+    """Downstream gates use is_authoritative as the control-flow admission rule."""
+
+    def test_authoritative_verifies_claim(self):
+        r = DiagnosticResult.verified("ok", {"constraint_id": "test"}, {"e": 1})
+        self.assertTrue(r.is_authoritative)
+        self.assertTrue(r.is_verified)
+
+    def test_non_authoritative_rejected_for_control_flow(self):
+        unverifiable = DiagnosticResult.unverifiable("no", {})
+        blocked = DiagnosticResult.blocked("blocked", {})
+        self.assertFalse(unverifiable.is_authoritative)
+        self.assertFalse(blocked.is_authoritative)
+
+    def test_mechanical_rule_proof_ref_none_means_reject(self):
+        results = [
+            DiagnosticResult.verified("ok", {}, {"e": 1}),
+            DiagnosticResult.unverifiable("no", {}),
+            DiagnosticResult.blocked("blocked", {}),
+        ]
+        admissible = [r for r in results if r.proof_ref is not None]
+        self.assertEqual(len(admissible), 1)
+        self.assertTrue(admissible[0].is_verified)
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed enforcement
+# ---------------------------------------------------------------------------
+
+class TestFailClosed(unittest.TestCase):
+    """Non-pass states must be fail-closed — no silent pass."""
+
+    def test_is_fail_closed_for_unverifiable(self):
+        r = DiagnosticResult.unverifiable("no", {})
+        self.assertTrue(r.is_fail_closed)
+
+    def test_is_fail_closed_for_blocked(self):
+        r = DiagnosticResult.blocked("blocked", {})
+        self.assertTrue(r.is_fail_closed)
+
+    def test_not_fail_closed_for_verified(self):
+        r = DiagnosticResult.verified("ok", {}, {"e": 1})
+        self.assertFalse(r.is_fail_closed)
+
+    def test_is_verified_true_only_for_verified_status(self):
+        self.assertTrue(DiagnosticResult.verified("ok", {}, {"e": 1}).is_verified)
+        self.assertFalse(DiagnosticResult.unverifiable("no", {}).is_verified)
+        self.assertFalse(DiagnosticResult.blocked("blocked", {}).is_verified)
+
+
+# ---------------------------------------------------------------------------
+# compute_proof_ref — deterministic hashing
+# ---------------------------------------------------------------------------
+
+class TestComputeProofRef(unittest.TestCase):
+    """proof_ref hashing must be deterministic and content-sensitive."""
+
+    def test_returns_sha256_prefixed(self):
+        ref = compute_proof_ref({"a": 1})
+        self.assertTrue(ref.startswith("sha256:"))
+        self.assertEqual(len(ref), len("sha256:") + 64)
+
+    def test_same_evidence_same_hash(self):
+        ref1 = compute_proof_ref({"a": 1, "b": 2})
+        ref2 = compute_proof_ref({"a": 1, "b": 2})
+        self.assertEqual(ref1, ref2)
+
+    def test_different_evidence_different_hash(self):
+        ref1 = compute_proof_ref({"a": 1})
+        ref2 = compute_proof_ref({"a": 2})
+        self.assertNotEqual(ref1, ref2)
+
+    def test_key_order_independent(self):
+        ref1 = compute_proof_ref({"a": 1, "b": 2})
+        ref2 = compute_proof_ref({"b": 2, "a": 1})
+        self.assertEqual(ref1, ref2)
+
+    def test_non_serializable_falls_back_to_str(self):
+        """default=str in json.dumps stringifies non-serializable objects."""
+        ref = compute_proof_ref({"obj": object()})
+        self.assertTrue(ref.startswith("sha256:"))
+
+    def test_nested_non_serializable_falls_back_to_str(self):
+        ref = compute_proof_ref({"data": {"inner": object()}})
+        self.assertTrue(ref.startswith("sha256:"))
+
+
+# ---------------------------------------------------------------------------
+# AdvisoryCheck — advisory metadata
+# ---------------------------------------------------------------------------
+
+class TestAdvisoryCheck(unittest.TestCase):
+    """Advisory checks are non-proof-bearing — advisory_only is always True."""
+
+    def test_default_advisory_only_is_true(self):
+        ac = AdvisoryCheck(name="llm_fallback")
+        self.assertTrue(ac.advisory_only)
+
+    def test_advisory_check_to_dict(self):
+        ac = AdvisoryCheck(
+            name="vlm_analysis",
+            advisory_only=True,
+            constraint_id="image_verifier.vlm_advisory_only",
+            details={"vlm_verdict": "SUPPORTED", "vlm_confidence": 0.65},
+        )
+        d = ac.to_dict()
+        self.assertEqual(d["name"], "vlm_analysis")
+        self.assertTrue(d["advisory_only"])
+        self.assertEqual(d["constraint_id"], "image_verifier.vlm_advisory_only")
+        self.assertEqual(d["details"]["vlm_verdict"], "SUPPORTED")
+
+    def test_advisory_check_from_dict(self):
+        d = {"name": "nli", "advisory_only": True, "constraint_id": "graph.nli", "details": {}}
+        ac = AdvisoryCheck.from_dict(d)
+        self.assertEqual(ac.name, "nli")
+        self.assertTrue(ac.advisory_only)
+
+    def test_advisory_check_round_trip(self):
+        ac = AdvisoryCheck(name="test", constraint_id="c", details={"x": 1})
+        ac2 = AdvisoryCheck.from_dict(ac.to_dict())
+        self.assertEqual(ac.name, ac2.name)
+        self.assertEqual(ac.constraint_id, ac2.constraint_id)
+        self.assertEqual(ac.details, ac2.details)
+
+
+# ---------------------------------------------------------------------------
+# developer_fields — Layer 2 structured evidence
+# ---------------------------------------------------------------------------
+
+class TestDeveloperFields(unittest.TestCase):
+    """Layer 2: developer_fields carries constraint_id, evidence, advisory_checks."""
+
+    def test_constraint_id_property(self):
+        r = DiagnosticResult.unverifiable("no", {"constraint_id": "math.mode_ambiguous"})
+        self.assertEqual(r.constraint_id, "math.mode_ambiguous")
+
+    def test_constraint_id_none_when_absent(self):
+        r = DiagnosticResult.unverifiable("no", {})
+        self.assertIsNone(r.constraint_id)
+
+    def test_advisory_checks_property_returns_list(self):
+        r = DiagnosticResult.unverifiable("no", {
+            "advisory_checks": [
+                {"name": "llm", "advisory_only": True, "constraint_id": "test", "details": {}},
+            ],
+        })
+        checks = r.advisory_checks
+        self.assertEqual(len(checks), 1)
+        self.assertEqual(checks[0].name, "llm")
+        self.assertTrue(checks[0].advisory_only)
+
+    def test_advisory_checks_empty_when_absent(self):
+        r = DiagnosticResult.unverifiable("no", {})
+        self.assertEqual(r.advisory_checks, [])
+
+    def test_developer_fields_default_empty_dict(self):
+        r = DiagnosticResult.unverifiable("no")
+        self.assertEqual(r.developer_fields, {})
+
+
+# ---------------------------------------------------------------------------
+# Serialization — to_dict / from_dict
+# ---------------------------------------------------------------------------
+
+class TestSerialization(unittest.TestCase):
+    """to_dict / from_dict must round-trip all fields."""
+
+    def test_verified_round_trip(self):
+        r = DiagnosticResult.verified(
+            agent_message="Claim verified",
+            developer_fields={"constraint_id": "test", "calculated": 4, "claimed": 4},
+            evidence={"calculated": 4, "claimed": 4},
+        )
+        d = r.to_dict()
+        self.assertEqual(d["status"], "VERIFIED")
+        self.assertEqual(d["agent_message"], "Claim verified")
+        self.assertIsNotNone(d["proof_ref"])
+        self.assertTrue(d["is_authoritative"])
+
+        r2 = DiagnosticResult.from_dict(d)
+        self.assertEqual(r2.status, DiagnosticStatus.VERIFIED)
+        self.assertEqual(r2.agent_message, r.agent_message)
+        self.assertEqual(r2.proof_ref, r.proof_ref)
+        self.assertEqual(r2.developer_fields, r.developer_fields)
+
+    def test_unverifiable_round_trip(self):
+        r = DiagnosticResult.unverifiable(
+            "Cannot verify",
+            {"constraint_id": "test.missing", "advisory_checks": []},
+        )
+        d = r.to_dict()
+        self.assertEqual(d["status"], "UNVERIFIABLE")
+        self.assertIsNone(d["proof_ref"])
+        self.assertFalse(d["is_authoritative"])
+
+        r2 = DiagnosticResult.from_dict(d)
+        self.assertEqual(r2.status, DiagnosticStatus.UNVERIFIABLE)
+        self.assertIsNone(r2.proof_ref)
+
+    def test_blocked_round_trip(self):
+        r = DiagnosticResult.blocked("Blocked", {"constraint_id": "test.parse_error"})
+        d = r.to_dict()
+        self.assertEqual(d["status"], "BLOCKED")
+        r2 = DiagnosticResult.from_dict(d)
+        self.assertEqual(r2.status, DiagnosticStatus.BLOCKED)
+
+    def test_from_dict_tolerates_string_status(self):
+        d = {"status": "VERIFIED", "agent_message": "ok", "developer_fields": {}, "proof_ref": "sha256:abc"}
+        r = DiagnosticResult.from_dict(d)
+        self.assertEqual(r.status, DiagnosticStatus.VERIFIED)
+
+    def test_from_dict_defaults_to_unverifiable(self):
+        d = {"agent_message": "unknown"}
+        r = DiagnosticResult.from_dict(d)
+        self.assertEqual(r.status, DiagnosticStatus.UNVERIFIABLE)
+
+
+# ---------------------------------------------------------------------------
+# from_legacy_dict — migration helper for ad-hoc engine dicts
+# ---------------------------------------------------------------------------
+
+class TestFromLegacyDict(unittest.TestCase):
+    """Migration helper converts fail-closed legacy states — NOT VERIFIED."""
+
+    def test_correction_needed_becomes_unverifiable(self):
+        legacy = {"is_correct": False, "status": "CORRECTION_NEEDED", "calculated_value": 3, "claimed_value": 4}
+        r = DiagnosticResult.from_legacy_dict(legacy, engine="math")
+        self.assertEqual(r.status, DiagnosticStatus.UNVERIFIABLE)
+        self.assertIsNone(r.proof_ref)
+        self.assertEqual(r.constraint_id, "math.legacy_inconclusive")
+
+    def test_error_becomes_blocked(self):
+        legacy = {"is_correct": False, "status": "ERROR", "error": "division by zero"}
+        r = DiagnosticResult.from_legacy_dict(legacy, engine="math")
+        self.assertEqual(r.status, DiagnosticStatus.BLOCKED)
+        self.assertIsNone(r.proof_ref)
+        self.assertEqual(r.constraint_id, "math.legacy_error")
+
+    def test_syntax_error_becomes_blocked(self):
+        legacy = {"is_correct": False, "status": "SYNTAX_ERROR", "error": "bad expr"}
+        r = DiagnosticResult.from_legacy_dict(legacy, engine="math")
+        self.assertEqual(r.status, DiagnosticStatus.BLOCKED)
+
+    def test_blocked_legacy_becomes_blocked(self):
+        legacy = {"is_correct": False, "status": "BLOCKED", "message": "tolerance exceeded"}
+        r = DiagnosticResult.from_legacy_dict(legacy, engine="math")
+        self.assertEqual(r.status, DiagnosticStatus.BLOCKED)
+        self.assertEqual(r.constraint_id, "math.legacy_blocked")
+
+    def test_inconclusive_becomes_unverifiable(self):
+        legacy = {"is_correct": False, "status": "INCONCLUSIVE"}
+        r = DiagnosticResult.from_legacy_dict(legacy, engine="image")
+        self.assertEqual(r.status, DiagnosticStatus.UNVERIFIABLE)
+
+    def test_verified_legacy_raises(self):
+        legacy = {"is_correct": True, "status": "VERIFIED", "calculated_value": 4}
+        with self.assertRaises(ValueError):
+            DiagnosticResult.from_legacy_dict(legacy, engine="math")
+
+    def test_is_correct_true_raises(self):
+        legacy = {"is_correct": True, "status": "WHATEVER"}
+        with self.assertRaises(ValueError):
+            DiagnosticResult.from_legacy_dict(legacy, engine="math")
+
+    def test_unrecognized_status_becomes_unverifiable(self):
+        legacy = {"is_correct": False, "status": "UNKNOWN_STATUS"}
+        r = DiagnosticResult.from_legacy_dict(legacy, engine="test")
+        self.assertEqual(r.status, DiagnosticStatus.UNVERIFIABLE)
+
+    def test_no_status_no_is_correct_becomes_inconclusive(self):
+        """When is_correct defaults to False with no error, result is inconclusive."""
+        legacy = {"some_field": "value"}
+        r = DiagnosticResult.from_legacy_dict(legacy, engine="test")
+        self.assertEqual(r.status, DiagnosticStatus.UNVERIFIABLE)
+        self.assertEqual(r.constraint_id, "test.legacy_inconclusive")
+
+    def test_false_with_error_becomes_blocked(self):
+        legacy = {"is_correct": False, "error": "something went wrong"}
+        r = DiagnosticResult.from_legacy_dict(legacy, engine="logic")
+        self.assertEqual(r.status, DiagnosticStatus.BLOCKED)
+        self.assertEqual(r.constraint_id, "logic.legacy_error")
+
+    def test_false_without_error_becomes_unverifiable(self):
+        legacy = {"is_correct": False}
+        r = DiagnosticResult.from_legacy_dict(legacy, engine="logic")
+        self.assertEqual(r.status, DiagnosticStatus.UNVERIFIABLE)
+
+
+# ---------------------------------------------------------------------------
+# Integration — realistic diagnostic scenarios from blocked issues
+# ---------------------------------------------------------------------------
+
+class TestRealisticScenarios(unittest.TestCase):
+    """Scenarios drawn from the blocked issues to validate the model fits."""
+
+    def test_math_mode_ambiguous_tie(self):
+        """#129: multi-mode dataset must be UNVERIFIABLE with modes in developer_fields."""
+        r = DiagnosticResult.unverifiable(
+            agent_message="Statistical claim inconclusive — dataset has multiple modes",
+            developer_fields={
+                "statistic": "mode",
+                "modes": [1, 2],
+                "modes_count": 2,
+                "tie_detected": True,
+                "max_frequency": 2,
+                "constraint_id": "math_verifier.mode_ambiguous_tie",
+            },
+        )
+        self.assertTrue(r.is_fail_closed)
+        self.assertFalse(r.is_authoritative)
+        self.assertEqual(r.developer_fields["modes"], [1, 2])
+        self.assertTrue(r.developer_fields["tie_detected"])
+
+    def test_math_irr_non_convergent(self):
+        """#131: non-convergent IRR must be UNVERIFIABLE with convergence trace."""
+        r = DiagnosticResult.unverifiable(
+            agent_message="IRR could not be deterministically verified",
+            developer_fields={
+                "iterations": 100,
+                "final_npv": "0.7",
+                "converged": False,
+                "constraint_id": "math_verifier.irr_non_convergent",
+            },
+        )
+        self.assertTrue(r.is_fail_closed)
+        self.assertFalse(r.developer_fields["converged"])
+
+    def test_math_irr_convergent_verified_with_proof(self):
+        """#131: convergent IRR with unique root must be VERIFIED with proof_ref."""
+        evidence = {
+            "iterations": 5,
+            "final_npv": "0.00003",
+            "converged": True,
+            "sign_changes": 1,
+            "uniqueness": "single_root",
+        }
+        r = DiagnosticResult.verified(
+            agent_message="IRR verified — convergence proven",
+            developer_fields={
+                "iterations": 5,
+                "final_npv": "0.00003",
+                "converged": True,
+                "sign_changes": 1,
+                "uniqueness": "single_root",
+                "constraint_id": "math_verifier.irr_convergence_proven",
+            },
+            evidence=evidence,
+        )
+        self.assertTrue(r.is_verified)
+        self.assertTrue(r.is_authoritative)
+        self.assertIsNotNone(r.proof_ref)
+
+    def test_fact_verifier_llm_advisory_only(self):
+        """#133/#190: LLM fallback must be UNVERIFIABLE with advisory_checks."""
+        r = DiagnosticResult.unverifiable(
+            agent_message="Claim could not be deterministically verified",
+            developer_fields={
+                "deterministic_verdict": "INSUFFICIENT_EVIDENCE",
+                "deterministic_confidence": 0.4,
+                "advisory_checks": [
+                    AdvisoryCheck(
+                        name="llm_fallback",
+                        advisory_only=True,
+                        constraint_id="fact_verifier.llm_advisory_only",
+                        details={"llm_verdict": "SUPPORTED", "llm_confidence": 0.65},
+                    ).to_dict(),
+                ],
+                "provenance": {
+                    "provider": "openai",
+                    "model": "gpt-4",
+                    "prompt_hash": "sha256:abc123",
+                },
+                "constraint_id": "fact_verifier.assistive_llm",
+            },
+        )
+        self.assertTrue(r.is_fail_closed)
+        self.assertFalse(r.is_authoritative)
+        checks = r.advisory_checks
+        self.assertEqual(len(checks), 1)
+        self.assertTrue(checks[0].advisory_only)
+        self.assertEqual(checks[0].details["llm_verdict"], "SUPPORTED")
+
+    def test_logic_verifier_missing_declarations(self):
+        """#162: missing variable declarations must be BLOCKED."""
+        r = DiagnosticResult.blocked(
+            agent_message="Logic verification blocked — variable declarations missing",
+            developer_fields={
+                "missing_declarations": ["x"],
+                "constraint_id": "logic_verifier.explicit_declarations_required",
+            },
+        )
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(r.developer_fields["missing_declarations"], ["x"])
+
+    def test_secure_executor_verifier_unavailable(self):
+        """#205: CodeVerifier unavailable must be UNVERIFIABLE with advisory basic_safety."""
+        r = DiagnosticResult.unverifiable(
+            agent_message="Code safety verification unavailable",
+            developer_fields={
+                "constraint_id": "secure_code_executor.verifier_unavailable",
+                "advisory_checks": [
+                    AdvisoryCheck(
+                        name="basic_safety",
+                        advisory_only=True,
+                        constraint_id="secure_code_executor.basic_safety_advisory",
+                        details={"is_safe": True, "reason": None},
+                    ).to_dict(),
+                ],
+            },
+        )
+        self.assertTrue(r.is_fail_closed)
+        self.assertFalse(r.is_authoritative)
+
+    def test_attestation_consumption_missing_token(self):
+        """#191: VERIFIED without attestation must be BLOCKED."""
+        r = DiagnosticResult.blocked(
+            agent_message="Verification blocked — proof artifact missing",
+            developer_fields={
+                "missing": "attestation_token",
+                "policy": "mandatory",
+                "constraint_id": "trust_gate.mandatory_attestation_missing",
+            },
+        )
+        self.assertTrue(r.is_fail_closed)
+        self.assertFalse(r.is_authoritative)
+
+    def test_downstream_gate_rejects_non_authoritative(self):
+        """Mechanical rule: proof_ref is None → reject for control flow."""
+        results = [
+            DiagnosticResult.verified("ok", {"constraint_id": "a"}, {"e": 1}),
+            DiagnosticResult.unverifiable("no", {"constraint_id": "b"}),
+            DiagnosticResult.blocked("blocked", {"constraint_id": "c"}),
+        ]
+        admitted = [r for r in results if r.is_authoritative]
+        self.assertEqual(len(admitted), 1)
+        self.assertEqual(admitted[0].constraint_id, "a")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Establishes the structured verification diagnostic contract from #204 — a unified `DiagnosticResult` model with three disclosure layers:

| Layer | Field | Audience |
|-------|-------|---------|
| 1 — Agent-Safe | `agent_message: str` | Agents/models (no internals leaked) |
| 2 — Developer | `developer_fields: dict` | Application developers (constraint_id, evidence, advisory_checks) |
| 3 — Proof | `proof_ref: Optional[str]` | Auditors/operators (sha256 hash of retained proof artifact) |

## Key Design Decisions

### Tri-state status only — no proliferation
`DiagnosticStatus` has exactly 3 values: `VERIFIED`, `UNVERIFIABLE`, `BLOCKED`. No `HEURISTIC`, `AMBIGUOUS`, or `CORRECTION_NEEDED`. Richer distinctions live in `developer_fields.constraint_id`. This resolves the #190 discussion (Keesan/Rahul debate) — ambiguity IS unverifiability; the distinction is structured, not status-level.

### `proof_ref` is the authority bit
No separate `authoritative` boolean. `proof_ref is not None` = authoritative (admissible for control flow); `proof_ref is None` = reject. Downstream gates get a mechanical rule:
```python
if not result.is_authoritative:
    block_decision()
```

### VERIFIED requires proof — structurally enforced
`__post_init__` raises `ValueError` if `status == VERIFIED` and `proof_ref is None`. This makes "VERIFIED without proof" impossible to construct — not a caller convention, a type-level invariant.

### Advisory checks never touch status
`AdvisoryCheck` (LLM fallback, NLI entailment, VLM interpretation) populates `developer_fields.advisory_checks` with `advisory_only=True`. They never set `status` or `proof_ref`. This structurally enforces the #204 constraint: *"diagnostics must never originate from model reasoning, confidence, or self-assessment."*

### Migration helper for existing engines
`from_legacy_dict()` converts ad-hoc engine dicts to `DiagnosticResult` for fail-closed states (`CORRECTION_NEEDED` → `UNVERIFIABLE`, `ERROR` → `BLOCKED`). It **raises** for legacy `VERIFIED` results — proof artifacts were discarded by pre-#204 engines, so backfilling is impossible. Callers must use `DiagnosticResult.verified()` with explicit evidence.

## What This PR Does NOT Do

- Does NOT refactor existing engines (#129, #130, #131, #133, #134, #162, #163, #164, #190, #205) — those are separate PRs against this contract
- Does NOT add explainability features
- Does NOT change API/SDK response shapes
- Does NOT introduce confidence scores (forbidden by #204 constraints)

## Files

- `src/qwed_new/core/diagnostics.py` (new) — `DiagnosticStatus`, `DiagnosticResult`, `AdvisoryCheck`, `compute_proof_ref`
- `tests/test_diagnostics.py` (new) — 68 tests
- `src/qwed_new/core/__init__.py` (modified) — exports
- `pyproject.toml` (modified) — version 5.1.2 → 5.2.0

## Test Results

- 68 new tests pass (status taxonomy, all 3 layers, authority contract, fail-closed enforcement, advisory checks, proof hashing, serialization, legacy migration, realistic scenarios)
- Core regression tests pass (97 passed, 21 skipped)
- Boundary check passes
- Ruff lint clean

## Unblocks

#129, #130, #131, #133, #134, #162, #163, #164, #190, #205

Closes #204.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a structured 3-layer verification diagnostics model with **Verified**, **Unverifiable**, and **Blocked** outcomes.
  * Added deterministic **proof references** for **Verified** results and fail-closed behavior for non-authoritative outcomes.
  * Enabled **advisory-only metadata** attached to diagnostics; made the diagnostics utilities publicly available.
* **Tests**
  * Added a comprehensive test suite covering construction rules, deterministic proof generation, serialization, and legacy migration.
* **Chores**
  * Bumped the package version to **5.2.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->