### PR TITLE
docs: archive stale docs — roadmap.md, ARCHITECTURE.md (historical), update DEPLOYMENT.md version refs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,6 @@
-# System Architecture
+# System Architecture — Historical Archive
+
+> ⚠️ **This document is a historical archive.** Current architecture diagrams and engine documentation live in the [mintlify docs](https://qweldocs.mintlify.app) and the curriculum [`ARCHITECTURE.md`](../ARCHITECTURE.md). The information below reflects an earlier (v2-v3 era) design with only 4 engines and no security guards.
 
 ## Overview
 QWED is a **Neurosymbolic Verification Engine** that combines the flexibility of Large Language Models (LLMs) with the determinism of symbolic execution engines (SymPy, Z3, SQLGlot, etc.).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 # System Architecture — Historical Archive
 
-> ⚠️ **This document is a historical archive.** Current architecture diagrams and engine documentation live in the [mintlify docs](https://qweldocs.mintlify.app) and the curriculum [`ARCHITECTURE.md`](../ARCHITECTURE.md). The information below reflects an earlier (v2-v3 era) design with only 4 engines and no security guards.
+> ⚠️ **This document is a historical archive.** Current architecture diagrams and documentation live at [docs.qwedai.com](https://docs.qwedai.com). The information below reflects an earlier (v2-v3 era) design with only 4 engines and no security guards.
 
 ## Overview
-QWED is a **Neurosymbolic Verification Engine** that combines the flexibility of Large Language Models (LLMs) with the determinism of symbolic execution engines (SymPy, Z3, SQLGlot, etc.).
+QWED is a **deterministic verification layer for AI systems**. It verifies AI outputs using mathematics, symbolic reasoning, and formal methods (Z3, SMT, SymPy), creating an auditable trust boundary for agentic AI. Not generation. Verification.
 
 ## High-Level Design
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -19,11 +19,11 @@ The easiest way to run QWED locally or on a single server is using Docker Compos
 
 ### Dockerfile
 
-A `Dockerfile` is provided in the root directory. It builds the QWED core service based on `python:3.11-slim`.
+A `Dockerfile` is provided in the root directory. It builds the QWED core service based on `python:3.13-slim-bookworm`.
 
 ```bash
 # Build the image manually
-docker build -t qwed-core:2.0.0 .
+docker build -t qweda/qwed-verification:5.2.0 .
 ```
 
 ### Docker Compose
@@ -226,7 +226,7 @@ Before going to production, ensure the following:
 **Error:** `SecureCodeExecutor initialization failed`
 **Solution:**
 1. Check Docker is running: `docker ps`
-2. Check `python:3.10-slim` image exists: `docker pull python:3.10-slim` (The executor uses this image).
+2. Check `python:3.13-slim-bookworm` image exists: `docker pull python:3.13-slim-bookworm` (The executor uses this image).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # QWED Roadmap — Historical Archive
 
-> ⚠️ **This document is a historical archive.** The QWED roadmap has moved to [mintlify docs](https://qweldocs.mintlify.app). The information below is preserved for reference only and may not reflect the current (v5.2.0+) ecosystem.
+> ⚠️ **This document is a historical archive.** The QWED roadmap has moved to [docs.qwedai.com](https://docs.qwedai.com). The information below is preserved for reference only and may not reflect the current (v5.2.0+) ecosystem.
 
 **Vision:** The First Open Source Neurosymbolic AI Guardrail
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,6 @@
-# QWED Roadmap
+# QWED Roadmap — Historical Archive
+
+> ⚠️ **This document is a historical archive.** The QWED roadmap has moved to [mintlify docs](https://qweldocs.mintlify.app). The information below is preserved for reference only and may not reflect the current (v5.2.0+) ecosystem.
 
 **Vision:** The First Open Source Neurosymbolic AI Guardrail
 


### PR DESCRIPTION
Part of qwed-learning#9 — version and ecosystem synchronization.

### Changes

- **docs/roadmap.md** — Added historical archive banner (superseded by mintlify docs)
- **docs/ARCHITECTURE.md** — Added historical archive banner (v2-v3 era, only 4 engines)
- **docs/DEPLOYMENT.md** — Updated stale references:
  - `python:3.11-slim` → `python:3.13-slim-bookworm`
  - `qwed-core:2.0.0` → `qweda/qwed-verification:5.2.0`
  - `python:3.10-slim` → `python:3.13-slim-bookworm`