### PR TITLE
Potential fix for code scanning alert no. 515: Log Injection

### DIFF
--- a/src/qwed_new/core/output_sanitizer.py
+++ b/src/qwed_new/core/output_sanitizer.py
@@ -50,6 +50,13 @@ class OutputSanitizer:
         # Sanitization event counter
         self.sanitization_count = 0
     
+    def _sanitize_for_log(self, value: Any) -> str:
+        """Return a log-safe string to prevent log injection/forgery."""
+        text = str(value)
+        text = text.replace("\r", "\\r").replace("\n", "\\n")
+        text = re.sub(r"[\x00-\x1f\x7f]", "", text)
+        return text
+
     def sanitize_output(
         self, 
         result: Dict[str, Any], 
@@ -78,8 +85,9 @@ class OutputSanitizer:
                 sanitized_value = self._strip_dangerous_content(value)
                 if sanitized_value != value:
                     changes_made = True
+                    safe_key = self._sanitize_for_log(key)
                     logger.warning(
-                        f"Sanitized output field '{key}' for org {organization_id}: "
+                        f"Sanitized output field '{safe_key}' for org {organization_id}: "
                         f"removed {len(value) - len(sanitized_value)} dangerous chars"
                     )
                 sanitized_result[key] = sanitized_value


### PR DESCRIPTION
Potential fix for [https://github.com/QWED-AI/qwed-verification/security/code-scanning/515](https://github.com/QWED-AI/qwed-verification/security/code-scanning/515)

General fix: ensure any untrusted data interpolated into logs is log-safe by removing/escaping CR/LF (and ideally other control chars) before logging.

Best minimal fix (without changing functionality): in `src/qwed_new/core/output_sanitizer.py`, sanitize `key` into a log-safe representation right before `logger.warning(...)`, and log the sanitized version instead of raw `key`. This preserves behavior while preventing newline/control-character log forging. A small helper method keeps the fix reusable and clear.

Changes needed:
- Add a private helper method in `OutputSanitizer`, e.g. `_sanitize_for_log(...)`, that:
  - coerces input to string,
  - replaces `\r` and `\n` with escaped literals (`\\r`, `\\n`),
  - strips other non-printable control characters.
- Update the warning block in `sanitize_output` to use `safe_key = self._sanitize_for_log(key)` in the formatted message.

No other files are required to fix this specific CodeQL alert location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
