### PR TITLE
fix(math): fail-closed on ambiguous mode — block multi-mode datasets (Issue #129)

### DIFF
--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -745,11 +745,11 @@ class VerificationEngine:
                         "error": (
                             f"Ambiguous mode: {len(modes)} values share the maximum "
                             f"frequency ({max_freq}). Cannot deterministically verify "
-                            f"a single mode. Modes: {sorted(modes)}"
+                            f"a single mode. Modes: {sorted(modes, key=str)}"
                         ),
                         "statistic": statistic,
                         "data_points": n,
-                        "ambiguous_modes": sorted(modes),
+                        "ambiguous_modes": sorted(modes, key=str),
                     }
                 calculated = modes[0]
             elif statistic == "variance":

--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -736,7 +736,22 @@ class VerificationEngine:
             elif statistic == "mode":
                 from collections import Counter
                 counter = Counter(data)
-                calculated = counter.most_common(1)[0][0]
+                max_freq = max(counter.values())
+                modes = [val for val, freq in counter.items() if freq == max_freq]
+                if len(modes) > 1:
+                    return {
+                        "is_correct": False,
+                        "status": "BLOCKED",
+                        "error": (
+                            f"Ambiguous mode: {len(modes)} values share the maximum "
+                            f"frequency ({max_freq}). Cannot deterministically verify "
+                            f"a single mode. Modes: {sorted(modes)}"
+                        ),
+                        "statistic": statistic,
+                        "data_points": n,
+                        "ambiguous_modes": sorted(modes),
+                    }
+                calculated = modes[0]
             elif statistic == "variance":
                 mean = sum(data) / n
                 calculated = sum((x - mean) ** 2 for x in data) / n

--- a/tests/test_math_engine_extended.py
+++ b/tests/test_math_engine_extended.py
@@ -182,6 +182,73 @@ class TestMathEngineEdgeCases:
         )
         assert result["status"] == "ERROR"
 
+    # =========================================================================
+    # Mode ambiguity fail-closed (Issue #129)
+    # =========================================================================
+
+    def test_mode_ambiguous_blocked(self, engine):
+        """Multi-mode dataset must return BLOCKED, not VERIFIED (Issue #129)."""
+        result = engine.verify_statistics(
+            data=[1, 1, 2, 2],
+            statistic="mode",
+            expected=1
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "BLOCKED"
+        assert "Ambiguous mode" in result["error"]
+        assert sorted(result["ambiguous_modes"]) == [1, 2]
+
+    def test_mode_ambiguous_blocked_other_claim(self, engine):
+        """Multi-mode dataset blocks regardless of which value is claimed."""
+        result = engine.verify_statistics(
+            data=[1, 1, 2, 2],
+            statistic="mode",
+            expected=2
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "BLOCKED"
+
+    def test_mode_unique_verified(self, engine):
+        """Unique mode matches claim -> VERIFIED."""
+        result = engine.verify_statistics(
+            data=[1, 1, 2],
+            statistic="mode",
+            expected=1
+        )
+        assert result["is_correct"] is True
+        assert result["status"] == "VERIFIED"
+
+    def test_mode_unique_correction_needed(self, engine):
+        """Unique mode does NOT match claim -> CORRECTION_NEEDED."""
+        result = engine.verify_statistics(
+            data=[1, 1, 2],
+            statistic="mode",
+            expected=2
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "CORRECTION_NEEDED"
+
+    def test_mode_all_equal_verified(self, engine):
+        """All-equal dataset has a unique deterministic mode."""
+        result = engine.verify_statistics(
+            data=[3, 3, 3],
+            statistic="mode",
+            expected=3
+        )
+        assert result["is_correct"] is True
+        assert result["status"] == "VERIFIED"
+
+    def test_mode_three_way_tie_blocked(self, engine):
+        """Three-way tie must also be BLOCKED."""
+        result = engine.verify_statistics(
+            data=[1, 2, 3, 1, 2, 3],
+            statistic="mode",
+            expected=1
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "BLOCKED"
+        assert sorted(result["ambiguous_modes"]) == [1, 2, 3]
+
 
 class TestPercentageCalculations:
     """Test percentage verification."""


### PR DESCRIPTION
Closes #129

## What changed

`verify_statistics(statistic="mode")` previously used `Counter(data).most_common(1)[0][0]` which heuristically picks one value when multiple values share the maximum frequency. This allows a caller to receive VERIFIED for an ambiguous input -- violating QWED's fail-closed principle.

**Fix:** Detect tied modes and return BLOCKED with a structured error including the list of ambiguous modes. Only a unique mode can produce VERIFIED.

## State transition

| Condition | Return |
|-----------|--------|
| Empty dataset | ERROR |
| Multiple values tie for max frequency | BLOCKED (ambiguous_modes list) |
| Unique mode matches claim | VERIFIED |
| Unique mode does NOT match claim | CORRECTION_NEEDED |

## Tests

6 new regression tests in `tests/test_math_engine_extended.py`:
- Two-way tie: BLOCKED
- Three-way tie: BLOCKED
- Unique mode matches: VERIFIED
- Unique mode doesn't match: CORRECTION_NEEDED
- All-equal dataset: VERIFIED
- Claim-independence (blocks regardless of which tied value is claimed)

Full suite: 27 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Mode calculations now detect ties instead of selecting an arbitrary value.
  - Ambiguous mode results are marked as **BLOCKED** with details about the tied values.
  - Unique modes continue to be verified or flagged for correction based on the submitted result.
  - Datasets where all values are identical are handled correctly.

- **Tests**
  - Added coverage for unique modes, tied modes, all-equal datasets, and incorrect claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->