### PR TITLE
fix(math): require eigenvalue cardinality match before verification (Issue #130)

### DIFF
--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -482,6 +482,22 @@ class VerificationEngine:
                 eigenvals = list(mat.eigenvals().keys())
                 eigenvals_float = sorted([complex(v.evalf()).real for v in eigenvals])
                 expected_sorted = sorted(expected)
+                # Cardinality check: incomplete claims must not pass (Issue #130)
+                if len(eigenvals_float) != len(expected_sorted):
+                    return {
+                        "is_correct": False,
+                        "status": "CORRECTION_NEEDED",
+                        "error": (
+                            f"Incomplete eigenvalue claim: matrix has "
+                            f"{len(eigenvals_float)} eigenvalue(s) but "
+                            f"{len(expected_sorted)} claimed. All eigenvalues "
+                            f"must be specified for verification."
+                        ),
+                        "calculated_eigenvalues": eigenvals_float,
+                        "claimed_eigenvalues": list(expected),
+                        "calculated_count": len(eigenvals_float),
+                        "claimed_count": len(expected_sorted),
+                    }
                 is_correct = all(
                     abs(a - b) < 1e-6 
                     for a, b in zip(eigenvals_float, expected_sorted)
@@ -490,7 +506,7 @@ class VerificationEngine:
                     "is_correct": is_correct,
                     "status": "VERIFIED" if is_correct else "CORRECTION_NEEDED",
                     "calculated_eigenvalues": eigenvals_float,
-                    "claimed_eigenvalues": expected
+                    "claimed_eigenvalues": list(expected)
                 }
             else:
                 return {"is_correct": False, "status": "ERROR", "error": f"Unknown operation: {operation}"}

--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -479,19 +479,22 @@ class VerificationEngine:
                 
             elif operation == "eigenvalues":
                 mat = list(sympy_matrices.values())[0]
-                eigenvals = list(mat.eigenvals().keys())
+                # Expand by algebraic multiplicity so repeated roots are counted
+                eigen_multiset = mat.eigenvals()
+                eigenvals = [v for v, m in eigen_multiset.items() for _ in range(m)]
                 eigenvals_float = sorted([complex(v.evalf()).real for v in eigenvals])
                 expected_sorted = sorted(expected)
-                # Cardinality check: incomplete claims must not pass (Issue #130)
+                # Cardinality check: claim must match exact eigenvalue count (Issue #130)
                 if len(eigenvals_float) != len(expected_sorted):
                     return {
                         "is_correct": False,
                         "status": "CORRECTION_NEEDED",
                         "error": (
-                            f"Incomplete eigenvalue claim: matrix has "
-                            f"{len(eigenvals_float)} eigenvalue(s) but "
-                            f"{len(expected_sorted)} claimed. All eigenvalues "
-                            f"must be specified for verification."
+                            f"Eigenvalue cardinality mismatch: matrix has "
+                            f"{len(eigenvals_float)} eigenvalue(s) (counting "
+                            f"multiplicity) but {len(expected_sorted)} claimed. "
+                            f"All eigenvalues including repeated roots must be "
+                            f"specified for verification."
                         ),
                         "calculated_eigenvalues": eigenvals_float,
                         "claimed_eigenvalues": list(expected),

--- a/tests/test_math_engine_extended.py
+++ b/tests/test_math_engine_extended.py
@@ -304,7 +304,7 @@ class TestEigenvalueCompleteness:
         )
         assert result["is_correct"] is False
         assert result["status"] == "CORRECTION_NEEDED"
-        assert "Incomplete eigenvalue claim" in result["error"]
+        assert "cardinality mismatch" in result["error"]
         assert result["calculated_count"] == 2
         assert result["claimed_count"] == 1
 
@@ -346,6 +346,28 @@ class TestEigenvalueCompleteness:
             operation="eigenvalues",
             matrices={"A": [[5]]},
             expected=[5],
+        )
+        assert result["is_correct"] is True
+        assert result["status"] == "VERIFIED"
+
+    def test_repeated_eigenvalue_incomplete_rejected(self, engine):
+        """diag(2,2) has eigenvalue 2 with multiplicity 2 — claim [2] is incomplete."""
+        result = engine.verify_matrix_operation(
+            operation="eigenvalues",
+            matrices={"A": [[2, 0], [0, 2]]},
+            expected=[2],
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "CORRECTION_NEEDED"
+        assert result["calculated_count"] == 2
+        assert result["claimed_count"] == 1
+
+    def test_repeated_eigenvalue_complete_verified(self, engine):
+        """diag(2,2) with claim [2, 2] accounts for multiplicity — VERIFIED."""
+        result = engine.verify_matrix_operation(
+            operation="eigenvalues",
+            matrices={"A": [[2, 0], [0, 2]]},
+            expected=[2, 2],
         )
         assert result["is_correct"] is True
         assert result["status"] == "VERIFIED"

--- a/tests/test_math_engine_extended.py
+++ b/tests/test_math_engine_extended.py
@@ -286,3 +286,66 @@ class TestPercentageCalculations:
             operation="decrease"
         )
         assert result["is_correct"] is True
+
+
+class TestEigenvalueCompleteness:
+    """Eigenvalue verification must require complete claims (Issue #130)."""
+
+    @pytest.fixture
+    def engine(self):
+        return VerificationEngine()
+
+    def test_incomplete_eigenvalue_claim_rejected(self, engine):
+        """Claiming [2] for a matrix with eigenvalues [2, 3] must NOT verify."""
+        result = engine.verify_matrix_operation(
+            operation="eigenvalues",
+            matrices={"A": [[2, 0], [0, 3]]},
+            expected=[2],
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "CORRECTION_NEEDED"
+        assert "Incomplete eigenvalue claim" in result["error"]
+        assert result["calculated_count"] == 2
+        assert result["claimed_count"] == 1
+
+    def test_complete_eigenvalue_claim_verified(self, engine):
+        """Claiming [2, 3] for a matrix with eigenvalues [2, 3] must verify."""
+        result = engine.verify_matrix_operation(
+            operation="eigenvalues",
+            matrices={"A": [[2, 0], [0, 3]]},
+            expected=[2, 3],
+        )
+        assert result["is_correct"] is True
+        assert result["status"] == "VERIFIED"
+
+    def test_complete_eigenvalue_wrong_values(self, engine):
+        """Claiming [2, 4] for eigenvalues [2, 3] -> CORRECTION_NEEDED."""
+        result = engine.verify_matrix_operation(
+            operation="eigenvalues",
+            matrices={"A": [[2, 0], [0, 3]]},
+            expected=[2, 4],
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "CORRECTION_NEEDED"
+
+    def test_overcomplete_eigenvalue_claim_rejected(self, engine):
+        """Claiming MORE eigenvalues than exist must also fail."""
+        result = engine.verify_matrix_operation(
+            operation="eigenvalues",
+            matrices={"A": [[2, 0], [0, 3]]},
+            expected=[2, 3, 5],
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "CORRECTION_NEEDED"
+        assert result["calculated_count"] == 2
+        assert result["claimed_count"] == 3
+
+    def test_single_eigenvalue_verified(self, engine):
+        """1x1 matrix with single eigenvalue — complete claim verifies."""
+        result = engine.verify_matrix_operation(
+            operation="eigenvalues",
+            matrices={"A": [[5]]},
+            expected=[5],
+        )
+        assert result["is_correct"] is True
+        assert result["status"] == "VERIFIED"


### PR DESCRIPTION
Closes #130

## What changed

`verify_matrix_operation(operation="eigenvalues")` used `zip(eigenvals_float, expected_sorted)` which truncates comparison to the shorter list. An incomplete claim like `[2]` for a matrix with eigenvalues `[2, 3]` would pass as VERIFIED because zip only compares the first pair.

**Fix:** Add explicit cardinality check before value comparison. If the claimed list length differs from the calculated eigenvalue count, return CORRECTION_NEEDED with a structured error. Partial agreement is not proof.

## Behavior

| Condition | Return |
|-----------|--------|
| Claimed count != calculated count | CORRECTION_NEEDED (incomplete claim) |
| Counts match, all values match | VERIFIED |
| Counts match, values differ | CORRECTION_NEEDED |

## Tests

5 new regression tests in `tests/test_math_engine_extended.py`:
- Incomplete claim [2] for eigenvalues [2, 3]: CORRECTION_NEEDED
- Complete claim [2, 3]: VERIFIED
- Wrong values [2, 4]: CORRECTION_NEEDED
- Overcomplete claim [2, 3, 5]: CORRECTION_NEEDED
- Single-eigenvalue 1x1 matrix: VERIFIED

Full suite: 32 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eigenvalue verification now rejects incomplete or overcomplete claims.
  * Incorrect eigenvalue lists provide clearer correction guidance, including calculated and claimed counts.
  * Verified results consistently return claimed eigenvalues as a list.

* **Tests**
  * Added coverage for complete, incomplete, incorrect, overcomplete, and single-eigenvalue claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->