### PR TITLE
fix(math): require IRR convergence proof before VERIFIED (Issue #131)

### DIFF
--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -631,6 +631,15 @@ class VerificationEngine:
             if not cash_flows or len(cash_flows) < 2:
                 return {"is_correct": False, "status": "ERROR", "error": "Need at least 2 cash flows"}
 
+            # All-zero cash flows: IRR is mathematically undefined
+            if all(cf == 0 for cf in cash_flows):
+                return {
+                    "is_correct": False,
+                    "status": "BLOCKED",
+                    "error": "IRR is undefined: all cash flows are zero. Any rate satisfies NPV=0.",
+                    "cash_flows": cash_flows,
+                }
+
             # Descartes' rule of signs: count sign changes, skipping zeros
             sign_changes = 0
             last_sign = 0

--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -623,13 +623,41 @@ class VerificationEngine:
         """
         Verify Internal Rate of Return calculation.
         
-        IRR is the rate where NPV = 0
+        IRR is the rate where NPV = 0.
+        Fail-closed: non-convergence, derivative stall, and ambiguous
+        (multi-root) cash flow patterns are blocked, not verified.
         """
         try:
+            if not cash_flows or len(cash_flows) < 2:
+                return {"is_correct": False, "status": "ERROR", "error": "Need at least 2 cash flows"}
+
+            # Descartes' rule of signs: count sign changes to detect multi-root ambiguity
+            sign_changes = 0
+            for i in range(1, len(cash_flows)):
+                if (cash_flows[i - 1] < 0 and cash_flows[i] > 0) or \
+                   (cash_flows[i - 1] > 0 and cash_flows[i] < 0):
+                    sign_changes += 1
+
+            if sign_changes > 1:
+                return {
+                    "is_correct": False,
+                    "status": "BLOCKED",
+                    "error": (
+                        f"Ambiguous IRR: {sign_changes} sign changes in cash flows "
+                        f"implies up to {sign_changes} possible roots. Cannot "
+                        f"deterministically verify a unique IRR."
+                    ),
+                    "sign_changes": sign_changes,
+                    "cash_flows": cash_flows,
+                }
+
             # Newton-Raphson method to find IRR
             r = Decimal("0.1")  # Initial guess
-            
-            for _ in range(100):  # Max iterations
+            converged = False
+            convergence_threshold = Decimal("0.0001")
+            max_iterations = 100
+
+            for iteration in range(max_iterations):
                 npv = Decimal("0")
                 npv_derivative = Decimal("0")
                 
@@ -639,12 +667,40 @@ class VerificationEngine:
                     if t > 0:
                         npv_derivative -= t * cf_dec / ((1 + r) ** (t + 1))
                 
-                if abs(npv) < Decimal("0.0001"):
+                if abs(npv) < convergence_threshold:
+                    converged = True
                     break
-                    
-                if npv_derivative != 0:
-                    r = r - npv / npv_derivative
-            
+
+                if npv_derivative == 0:
+                    # Derivative stall: Newton's method cannot proceed
+                    return {
+                        "is_correct": False,
+                        "status": "BLOCKED",
+                        "error": (
+                            f"IRR verification failed: derivative is zero at "
+                            f"iteration {iteration + 1} (r={float(r):.6f}). "
+                            f"Newton-Raphson cannot converge from this path."
+                        ),
+                        "iterations_used": iteration + 1,
+                        "cash_flows": cash_flows,
+                    }
+
+                r = r - npv / npv_derivative
+
+            if not converged:
+                return {
+                    "is_correct": False,
+                    "status": "BLOCKED",
+                    "error": (
+                        f"IRR verification failed: Newton-Raphson did not converge "
+                        f"within {max_iterations} iterations. Final NPV residual: "
+                        f"{float(abs(npv)):.8f}."
+                    ),
+                    "iterations_used": max_iterations,
+                    "final_residual": float(abs(npv)),
+                    "cash_flows": cash_flows,
+                }
+
             irr = float(r)
             is_correct = abs(irr - expected) <= tolerance
             
@@ -653,6 +709,8 @@ class VerificationEngine:
                 "status": "VERIFIED" if is_correct else "CORRECTION_NEEDED",
                 "calculated_irr": irr,
                 "claimed_irr": expected,
+                "converged": True,
+                "iterations_used": iteration + 1,
                 "cash_flows": cash_flows
             }
             

--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -631,12 +631,18 @@ class VerificationEngine:
             if not cash_flows or len(cash_flows) < 2:
                 return {"is_correct": False, "status": "ERROR", "error": "Need at least 2 cash flows"}
 
-            # Descartes' rule of signs: count sign changes to detect multi-root ambiguity
+            # Descartes' rule of signs: count sign changes, skipping zeros
             sign_changes = 0
-            for i in range(1, len(cash_flows)):
-                if (cash_flows[i - 1] < 0 and cash_flows[i] > 0) or \
-                   (cash_flows[i - 1] > 0 and cash_flows[i] < 0):
-                    sign_changes += 1
+            last_sign = 0
+            for cf in cash_flows:
+                if cf > 0:
+                    if last_sign < 0:
+                        sign_changes += 1
+                    last_sign = 1
+                elif cf < 0:
+                    if last_sign > 0:
+                        sign_changes += 1
+                    last_sign = -1
 
             if sign_changes > 1:
                 return {

--- a/src/qwed_new/core/verifier.py
+++ b/src/qwed_new/core/verifier.py
@@ -614,6 +614,59 @@ class VerificationEngine:
         except Exception as e:
             return {"is_correct": False, "status": "ERROR", "error": str(e)}
     
+    @staticmethod
+    def _count_sign_changes(cash_flows: List[float]) -> int:
+        """Count sign changes in cash flows, skipping zeros (Descartes' rule)."""
+        sign_changes = 0
+        last_sign = 0
+        for cf in cash_flows:
+            if cf > 0:
+                if last_sign < 0:
+                    sign_changes += 1
+                last_sign = 1
+            elif cf < 0:
+                if last_sign > 0:
+                    sign_changes += 1
+                last_sign = -1
+        return sign_changes
+
+    @staticmethod
+    def _find_irr_newton(cash_flows: List[float]) -> Dict[str, Any]:
+        """Run Newton-Raphson to find IRR. Returns result dict with convergence info."""
+        r = Decimal("0.1")
+        convergence_threshold = Decimal("0.0001")
+        max_iterations = 100
+
+        for iteration in range(max_iterations):
+            npv = Decimal("0")
+            npv_derivative = Decimal("0")
+
+            for t, cf in enumerate(cash_flows):
+                cf_dec = Decimal(str(cf))
+                npv += cf_dec / ((1 + r) ** t)
+                if t > 0:
+                    npv_derivative -= t * cf_dec / ((1 + r) ** (t + 1))
+
+            if abs(npv) < convergence_threshold:
+                return {"converged": True, "irr": float(r), "iterations": iteration + 1}
+
+            if npv_derivative == 0:
+                return {
+                    "converged": False,
+                    "reason": "derivative_stall",
+                    "iterations": iteration + 1,
+                    "r": float(r),
+                }
+
+            r = r - npv / npv_derivative
+
+        return {
+            "converged": False,
+            "reason": "max_iterations",
+            "iterations": max_iterations,
+            "residual": float(abs(npv)),
+        }
+
     def verify_irr(
         self,
         cash_flows: List[float],
@@ -640,18 +693,17 @@ class VerificationEngine:
                     "cash_flows": cash_flows,
                 }
 
-            # Descartes' rule of signs: count sign changes, skipping zeros
-            sign_changes = 0
-            last_sign = 0
-            for cf in cash_flows:
-                if cf > 0:
-                    if last_sign < 0:
-                        sign_changes += 1
-                    last_sign = 1
-                elif cf < 0:
-                    if last_sign > 0:
-                        sign_changes += 1
-                    last_sign = -1
+            # Descartes' rule of signs: detect multi-root or no-root ambiguity
+            sign_changes = self._count_sign_changes(cash_flows)
+
+            if sign_changes == 0:
+                return {
+                    "is_correct": False,
+                    "status": "BLOCKED",
+                    "error": "No real IRR exists: all cash flows have the same sign (zero sign changes).",
+                    "sign_changes": 0,
+                    "cash_flows": cash_flows,
+                }
 
             if sign_changes > 1:
                 return {
@@ -666,57 +718,31 @@ class VerificationEngine:
                     "cash_flows": cash_flows,
                 }
 
-            # Newton-Raphson method to find IRR
-            r = Decimal("0.1")  # Initial guess
-            converged = False
-            convergence_threshold = Decimal("0.0001")
-            max_iterations = 100
+            # Newton-Raphson to find IRR
+            newton_result = self._find_irr_newton(cash_flows)
 
-            for iteration in range(max_iterations):
-                npv = Decimal("0")
-                npv_derivative = Decimal("0")
-                
-                for t, cf in enumerate(cash_flows):
-                    cf_dec = Decimal(str(cf))
-                    npv += cf_dec / ((1 + r) ** t)
-                    if t > 0:
-                        npv_derivative -= t * cf_dec / ((1 + r) ** (t + 1))
-                
-                if abs(npv) < convergence_threshold:
-                    converged = True
-                    break
-
-                if npv_derivative == 0:
-                    # Derivative stall: Newton's method cannot proceed
-                    return {
-                        "is_correct": False,
-                        "status": "BLOCKED",
-                        "error": (
-                            f"IRR verification failed: derivative is zero at "
-                            f"iteration {iteration + 1} (r={float(r):.6f}). "
-                            f"Newton-Raphson cannot converge from this path."
-                        ),
-                        "iterations_used": iteration + 1,
-                        "cash_flows": cash_flows,
-                    }
-
-                r = r - npv / npv_derivative
-
-            if not converged:
+            if not newton_result["converged"]:
+                if newton_result["reason"] == "derivative_stall":
+                    error_msg = (
+                        f"IRR verification failed: derivative is zero at "
+                        f"iteration {newton_result['iterations']} (r={newton_result['r']:.6f}). "
+                        f"Newton-Raphson cannot converge from this path."
+                    )
+                else:
+                    error_msg = (
+                        f"IRR verification failed: Newton-Raphson did not converge "
+                        f"within {newton_result['iterations']} iterations. Final NPV residual: "
+                        f"{newton_result['residual']:.8f}."
+                    )
                 return {
                     "is_correct": False,
                     "status": "BLOCKED",
-                    "error": (
-                        f"IRR verification failed: Newton-Raphson did not converge "
-                        f"within {max_iterations} iterations. Final NPV residual: "
-                        f"{float(abs(npv)):.8f}."
-                    ),
-                    "iterations_used": max_iterations,
-                    "final_residual": float(abs(npv)),
+                    "error": error_msg,
+                    "iterations_used": newton_result["iterations"],
                     "cash_flows": cash_flows,
                 }
 
-            irr = float(r)
+            irr = newton_result["irr"]
             is_correct = abs(irr - expected) <= tolerance
             
             return {
@@ -725,7 +751,7 @@ class VerificationEngine:
                 "calculated_irr": irr,
                 "claimed_irr": expected,
                 "converged": True,
-                "iterations_used": iteration + 1,
+                "iterations_used": newton_result["iterations"],
                 "cash_flows": cash_flows
             }
             

--- a/tests/test_math_engine_extended.py
+++ b/tests/test_math_engine_extended.py
@@ -371,3 +371,67 @@ class TestEigenvalueCompleteness:
         )
         assert result["is_correct"] is True
         assert result["status"] == "VERIFIED"
+
+
+class TestIRRConvergenceProof:
+    """IRR verification must prove convergence (Issue #131)."""
+
+    @pytest.fixture
+    def engine(self):
+        return VerificationEngine()
+
+    def test_multi_sign_change_blocked(self, engine):
+        """Multiple sign changes -> ambiguous IRR -> BLOCKED."""
+        result = engine.verify_irr(
+            cash_flows=[-100, 230, -132],
+            expected=0.1,
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "BLOCKED"
+        assert "Ambiguous IRR" in result["error"]
+        assert result["sign_changes"] == 2
+
+    def test_simple_irr_converges_verified(self, engine):
+        """Standard cash flow with single sign change converges and verifies."""
+        result = engine.verify_irr(
+            cash_flows=[-1000, 300, 400, 400, 300],
+            expected=0.149,
+            tolerance=0.001,
+        )
+        assert result["is_correct"] is True
+        assert result["status"] == "VERIFIED"
+        assert result["converged"] is True
+
+    def test_simple_irr_wrong_claim(self, engine):
+        """Converged IRR that doesn't match claim -> CORRECTION_NEEDED."""
+        result = engine.verify_irr(
+            cash_flows=[-1000, 300, 400, 400, 300],
+            expected=0.50,
+            tolerance=0.001,
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "CORRECTION_NEEDED"
+        assert result["converged"] is True
+
+    def test_zero_cash_flow_irr(self, engine):
+        """Cash flow [-100, 0, 0, 100] — single sign change, should converge."""
+        result = engine.verify_irr(
+            cash_flows=[-100, 0, 0, 100],
+            expected=0.0,
+            tolerance=0.01,
+        )
+        # IRR of [-100, 0, 0, 100] is 0% (100/100 = 1, (1+r)^3 = 1, r=0)
+        assert result["status"] in ("VERIFIED", "BLOCKED")
+        # If it converges, it should verify at 0%
+        if result["status"] == "VERIFIED":
+            assert result["is_correct"] is True
+
+    def test_empty_cash_flows_error(self, engine):
+        """Empty cash flows -> ERROR."""
+        result = engine.verify_irr(cash_flows=[], expected=0.1)
+        assert result["status"] == "ERROR"
+
+    def test_single_cash_flow_error(self, engine):
+        """Single cash flow -> ERROR (need at least 2)."""
+        result = engine.verify_irr(cash_flows=[-100], expected=0.1)
+        assert result["status"] == "ERROR"

--- a/tests/test_math_engine_extended.py
+++ b/tests/test_math_engine_extended.py
@@ -452,3 +452,11 @@ class TestIRRConvergenceProof:
         assert result["is_correct"] is False
         assert result["status"] == "BLOCKED"
         assert "undefined" in result["error"]
+
+    def test_same_sign_cash_flows_blocked(self, engine):
+        """All positive cash flows: no real IRR exists -> BLOCKED."""
+        result = engine.verify_irr(cash_flows=[100, 200, 300], expected=0.1)
+        assert result["is_correct"] is False
+        assert result["status"] == "BLOCKED"
+        assert "same sign" in result["error"]
+        assert result["sign_changes"] == 0

--- a/tests/test_math_engine_extended.py
+++ b/tests/test_math_engine_extended.py
@@ -445,3 +445,10 @@ class TestIRRConvergenceProof:
         """Single cash flow -> ERROR (need at least 2)."""
         result = engine.verify_irr(cash_flows=[-100], expected=0.1)
         assert result["status"] == "ERROR"
+
+    def test_all_zero_cash_flows_blocked(self, engine):
+        """All-zero cash flows: IRR is undefined -> BLOCKED."""
+        result = engine.verify_irr(cash_flows=[0, 0, 0], expected=0.1)
+        assert result["is_correct"] is False
+        assert result["status"] == "BLOCKED"
+        assert "undefined" in result["error"]

--- a/tests/test_math_engine_extended.py
+++ b/tests/test_math_engine_extended.py
@@ -391,6 +391,16 @@ class TestIRRConvergenceProof:
         assert "Ambiguous IRR" in result["error"]
         assert result["sign_changes"] == 2
 
+    def test_zero_hidden_sign_change_blocked(self, engine):
+        """Zeros between sign changes must not hide multi-root ambiguity."""
+        result = engine.verify_irr(
+            cash_flows=[-100, 0, 230, -132],
+            expected=0.1,
+        )
+        assert result["is_correct"] is False
+        assert result["status"] == "BLOCKED"
+        assert result["sign_changes"] == 2
+
     def test_simple_irr_converges_verified(self, engine):
         """Standard cash flow with single sign change converges and verifies."""
         result = engine.verify_irr(


### PR DESCRIPTION
Closes #131

## What changed

`verify_irr()` ran Newton-Raphson and always converted the final iterate into a result, even if convergence was never established. Three fail-open paths:

1. **Non-convergence:** Loop exhausts 100 iterations without NPV below threshold, still returns VERIFIED with stale iterate
2. **Derivative stall:** `npv_derivative == 0` skips update silently, leaving `r` unchanged
3. **Multi-root ambiguity:** Cash flows with multiple sign changes can have multiple valid IRRs (Descartes' rule), making any single answer non-deterministic

## Fix

- Track convergence explicitly with `converged` flag; return BLOCKED if not converged within max iterations
- Return BLOCKED on derivative stall (Newton cannot proceed)
- Return BLOCKED on >1 sign change (ambiguous, multi-root IRR)
- Successful results include `converged: True` and `iterations_used` for auditability

## Behavior

| Condition | Return |
|-----------|--------|
| Multiple sign changes (multi-root) | BLOCKED (ambiguous) |
| Derivative zero mid-iteration | BLOCKED (stall) |
| No convergence in 100 iterations | BLOCKED (non-convergent) |
| Converged, matches claim | VERIFIED |
| Converged, doesn't match claim | CORRECTION_NEEDED |

## Tests

6 new regression tests in `tests/test_math_engine_extended.py`:
- Multi-sign-change [-100, 230, -132]: BLOCKED
- Standard cash flow converges: VERIFIED
- Wrong claim after convergence: CORRECTION_NEEDED
- Zero-intermediate cash flow [-100, 0, 0, 100]: handled
- Empty cash flows: ERROR
- Single cash flow: ERROR

Full suite: 40 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IRR verification now fails closed for undefined/ambiguous cases (e.g., all-zero cash flows, insufficient cash flows, and multi sign-change scenarios).
  * Newton-Raphson stopping behavior is more deterministic, with explicit handling when convergence can’t be reached or the derivative becomes zero.
  * Results now include convergence status and iteration count, improving correctness for claimed IRR checks.
* **Tests**
  * Added extended IRR convergence coverage, including edge cases for zero values and multi-root ambiguity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->