### PR TITLE
fix: remove unused check_assertions parameter from verify_code

### DIFF
--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -60,13 +60,12 @@ class SymbolicVerifier:
         except ImportError:
             return False
     
-    def verify_code(self, code: str, check_assertions: bool = True) -> DiagnosticResult:
+    def verify_code(self, code: str) -> DiagnosticResult:
         """
         Verify Python code using symbolic execution.
 
         Args:
             code: Python code to verify
-            check_assertions: Whether to check assert statements
 
         Returns:
             DiagnosticResult describing the outcome. Note: this engine does not

--- a/tests/test_symbolic_verifier.py
+++ b/tests/test_symbolic_verifier.py
@@ -202,10 +202,9 @@ def add(x: int, y: int) -> int:
         ):
             with patch.object(self.verifier, "_crosshair_available", True):
                 result = self.verifier.verify_code(code)
+        assert result.status is DiagnosticStatus.UNVERIFIABLE
+        assert result.developer_fields["constraint_id"] == "symbolic_verifier.no_counterexample_found"
         assert result.developer_fields["functions_checked"] > 0
-        # This engine does not yet emit VERIFIED (issue #15) — a clean symbolic
-        # search surfaces as UNVERIFIABLE since a timeout-bounded search isn't
-        # a completeness proof.
         assert result.is_verified is False
         assert result.proof_ref is None
 

--- a/tests/test_symbolic_verifier.py
+++ b/tests/test_symbolic_verifier.py
@@ -183,14 +183,25 @@ def broken(
         assert result.status is DiagnosticStatus.BLOCKED
         assert result.developer_fields["constraint_id"] == "symbolic_verifier.syntax_error"
 
-    @pytest.mark.skipif(not _crosshair_available, reason="CrossHair not installed")
     def test_verify_simple_function(self):
         """Test verification of simple typed function."""
         code = """
 def add(x: int, y: int) -> int:
     return x + y
 """
-        result = self.verifier.verify_code(code)
+        with patch.object(
+            self.verifier,
+            "_verify_function",
+            return_value={
+                "verified": True,
+                "function": "add",
+                "skipped": False,
+                "unverifiable": False,
+                "issues": []
+            }
+        ):
+            with patch.object(self.verifier, "_crosshair_available", True):
+                result = self.verifier.verify_code(code)
         assert result.developer_fields["functions_checked"] > 0
         # This engine does not yet emit VERIFIED (issue #15) — a clean symbolic
         # search surfaces as UNVERIFIABLE since a timeout-bounded search isn't


### PR DESCRIPTION
 SonarCloud flagged this after PR #212 merge — parameter was declared but never used or passed by any caller.

----
## Summary by Gitar

- **Test improvements:**
    - Mock `_verify_function` in `test_verify_simple_function` to ensure deterministic execution without relying on external dependencies.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the code verification interface by removing the optional assertion-checking parameter.
  * Verification now uses a consistent, streamlined input format.

* **Tests**
  * Improved verification coverage with deterministic test conditions.
  * Tests now validate verification results more reliably across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->