### PR TITLE
fix: use PBKDF2 instead of raw SHA-256 for key rotation hashing

### DIFF
--- a/src/qwed_new/core/key_rotation.py
+++ b/src/qwed_new/core/key_rotation.py
@@ -9,7 +9,6 @@ Features:
 """
 
 import secrets
-import hashlib
 import logging
 from datetime import datetime, timedelta
 from typing import Optional, Tuple
@@ -19,6 +18,7 @@ from qwed_new.core.models import ApiKey
 from qwed_new.core.database import engine
 from sqlmodel import Session
 from qwed_new.core.alerting import alert_manager
+from qwed_new.auth.security import hash_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +44,8 @@ class KeyManager:
         # Generate secure random key
         raw_key = f"qwed_live_{secrets.token_urlsafe(32)}"
         
-        # Hash for storage
-        key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+        # Hash for storage (using PBKDF2 to match auth/security.py)
+        key_hash = hash_api_key(raw_key)
         key_preview = f"{raw_key[:10]}...{raw_key[-4:]}"
         
         expires_at = datetime.utcnow() + timedelta(days=expires_in_days)

--- a/tests/test_key_rotation.py
+++ b/tests/test_key_rotation.py
@@ -1,7 +1,6 @@
 """Tests for key_rotation.py — Key lifecycle management (Issue #224)."""
 
 from unittest.mock import patch, MagicMock
-import pytest
 from qwed_new.core.key_rotation import KeyManager
 
 

--- a/tests/test_key_rotation.py
+++ b/tests/test_key_rotation.py
@@ -1,0 +1,22 @@
+"""Tests for key_rotation.py — Key lifecycle management (Issue #224)."""
+
+from unittest.mock import patch, MagicMock
+import pytest
+from qwed_new.core.key_rotation import KeyManager
+
+
+class TestKeyManager:
+    """KeyManager.create_key must use hash_api_key (PBKDF2, not raw SHA-256)."""
+
+    @patch("qwed_new.core.key_rotation.Session")
+    @patch("qwed_new.core.key_rotation.hash_api_key")
+    def test_create_key_uses_hash_api_key(self, mock_hash, mock_session):
+        mock_session.return_value.__enter__.return_value = MagicMock()
+        mock_hash.return_value = "ab" * 32  # 64-char hex
+
+        key_manager = KeyManager()
+        api_key, raw = key_manager.create_key(organization_id=1)
+
+        mock_hash.assert_called_once()
+        assert mock_hash.call_args[0][0].startswith("qwed_live_")
+        assert api_key.key_hash == "ab" * 32


### PR DESCRIPTION
## Summary

Fixes #224.\n\nKeyManager.create_key() was using \hashlib.sha256()\ to hash API keys before storage, while every verification path (main.py, tenant_context.py, auth/middleware.py) uses PBKDF2-HMAC-SHA256 via \hash_api_key()\ from auth/security.py.\n\nThis meant a key created through rotation could never authenticate — the SHA-256 hash stored by rotation would never match the PBKDF2 hash expected by the auth layer.\n\n## Change\n\n\src/qwed_new/core/key_rotation.py\:\n- Replaced \import hashlib\ with \rom qwed_new.auth.security import hash_api_key\\n- Changed \hashlib.sha256(raw_key.encode()).hexdigest()\ → \hash_api_key(raw_key)\\n\n## Verification\n\n- \hash_api_key()\ is deterministic — same input always produces the same 64-char hex output\n- All four consumers now use the same function: key_rotation.py (creation), main.py (verification), tenant_context.py (verification), auth/middleware.py (verification)\n- No circular import (verified: import succeeds with QWED_JWT_SECRET_KEY set)\n- Removed unused \hashlib\ import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * API keys created during rotation now use the application’s standardized secure hashing process.
  * Key rotation and expiring-key alerts continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->