### PR TITLE
feat: add verification_mode to SymbolicVerifier DiagnosticResults (#237)

### DIFF
--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -771,7 +771,7 @@ class SymbolicVerifier:
         """Serialize a DiagnosticResult into verify_bounded's dict shape, uniformly across all branches."""
         result = diagnostic.to_dict()
         result["is_verified"] = diagnostic.is_verified
-        result["verification_mode"] = "bounded_symbolic"
+        result["developer_fields"]["verification_mode"] = "bounded_symbolic"
         result["bounded"] = bounded
         result["bounds_applied"] = bounds_applied
         result["complexity_analysis"] = complexity_analysis

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -77,7 +77,10 @@ class SymbolicVerifier:
         if not self._crosshair_available:
             return DiagnosticResult.blocked(
                 agent_message="Symbolic verification is unavailable: the CrossHair engine is not installed.",
-                developer_fields={"constraint_id": "symbolic_verifier.crosshair_not_available"},
+                developer_fields={
+                    "constraint_id": "symbolic_verifier.crosshair_not_available",
+                    "verification_mode": "symbolic",
+                },
             )
 
         # Parse code to extract functions
@@ -89,6 +92,7 @@ class SymbolicVerifier:
                 developer_fields={
                     "constraint_id": "symbolic_verifier.syntax_error",
                     "parse_error": str(e),
+                    "verification_mode": "symbolic",
                 },
             )
 
@@ -101,6 +105,7 @@ class SymbolicVerifier:
                 developer_fields={
                     "constraint_id": "symbolic_verifier.no_verifiable_functions",
                     "functions_discovered": 0,
+                    "verification_mode": "symbolic",
                 },
             )
 
@@ -110,6 +115,7 @@ class SymbolicVerifier:
     def _diagnostic_from_summary(self, summary: Dict[str, Any]) -> DiagnosticResult:
         """Map aggregated per-function counts to a DiagnosticResult (fail-closed)."""
         developer_fields = {
+            "verification_mode": "symbolic",
             "functions_discovered": summary["functions_discovered"],
             "functions_checked": summary["checked_count"],
             "functions_verified": summary["verified_count"],
@@ -765,6 +771,7 @@ class SymbolicVerifier:
         """Serialize a DiagnosticResult into verify_bounded's dict shape, uniformly across all branches."""
         result = diagnostic.to_dict()
         result["is_verified"] = diagnostic.is_verified
+        result["verification_mode"] = "bounded_symbolic"
         result["bounded"] = bounded
         result["bounds_applied"] = bounds_applied
         result["complexity_analysis"] = complexity_analysis


### PR DESCRIPTION
## Summary

Adds `verification_mode` to every `DiagnosticResult` produced by `SymbolicVerifier`, so downstream consumers can distinguish symbolic results from heuristic/fallback results. Closes #237.

## Changes

`src/qwed_new/core/symbolic_verifier.py` — 8 insertions, 1 deletion:

### verify_code (3 direct return paths)
- `crosshair_not_available` → `developer_fields["verification_mode"] = "symbolic"`
- `syntax_error` → `developer_fields["verification_mode"] = "symbolic"`
- `no_verifiable_functions` → `developer_fields["verification_mode"] = "symbolic"`

### _diagnostic_from_summary (6 paths via shared dict)
All paths (all_verified, counterexample, timeout, no_typed_functions, incomplete_coverage, verification_error) now include `"verification_mode": "symbolic"` in the shared `developer_fields` dict.

### verify_bounded via _bounded_result (2 paths)
`_bounded_result()` now adds `"verification_mode": "bounded_symbolic"` to the result dict for syntax_error and bounds_transform_error paths.

## verification_mode values

| Method | verification_mode |
|--------|-------------------|
| verify_code | `symbolic` |
| verify_function_contract | `symbolic` (delegates to verify_code) |
| verify_bounded | `bounded_symbolic` |

## Non-goals (not in scope)

- Advisory methods (analyze_complexity, get_verification_budget, verify_safety_properties) — still return dict, migrated in #233/#234/#235
- verify_bounded full DiagnosticResult — tracked in #236
- proof_ref retention / search_exhaustive — separate design discussion

## Tests

All 58 existing symbolic verifier tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Verification results now clearly indicate whether they came from symbolic verification or bounded symbolic analysis.
  * Verification mode information is consistently included across blocked, failed, and completed verification outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->