### PR TITLE
feat(#234): migrate get_verification_budget to return DiagnosticResult

### DIFF
--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -13,7 +13,7 @@ import tempfile
 import os
 import sys
 
-from .diagnostics import DiagnosticResult
+from .diagnostics import AdvisoryCheck, DiagnosticResult
 
 
 class SymbolicVerifier:
@@ -825,54 +825,63 @@ class SymbolicVerifier:
         self, 
         code: str,
         max_paths: int = 1000
-    ) -> Dict[str, Any]:
-        """
-        Calculate verification budget - estimated paths to explore.
-        
-        Helps decide if verification is feasible or needs stricter bounds.
-        
-        Args:
-            code: Code to analyze
-            max_paths: Maximum paths before warning
-            
-        Returns:
-            Dict with path estimation and recommendations
-        """
+    ) -> "DiagnosticResult":
+        """Calculate verification budget — estimated paths to explore."""
         analysis = self.analyze_complexity(code)
-        
+
         if analysis.get("status") == "syntax_error":
-            return analysis
-        
-        # Estimate paths (simplified heuristic)
+            return DiagnosticResult.unverifiable(
+                agent_message="Cannot estimate verification budget: syntax error in code.",
+                developer_fields={
+                    "constraint_id": "symbolic_verifier.syntax_error",
+                    "parse_error": analysis.get("message"),
+                },
+            )
+
         loops = analysis.get("loops", [])
         recursions = analysis.get("recursions", [])
-        
-        # Rough estimation: paths = iterations^depth for nested loops
+
         default_iterations = 10
         estimated_paths = 1
-        
+
         for loop in loops:
             if loop.get("iterable_type") == "range":
                 estimated_paths *= default_iterations
             else:
-                estimated_paths *= default_iterations * 2  # Unknown iterables are worse
-        
-        # Add recursion factor
+                estimated_paths *= default_iterations * 2
+
         if recursions:
             estimated_paths *= 2 ** len(recursions)
-        
+
         feasible = estimated_paths <= max_paths
-        
-        return {
-            "estimated_paths": min(estimated_paths, 999999),  # Cap for display
-            "max_paths": max_paths,
-            "feasible": feasible,
-            "recommendation": analysis.get("recommendation", {}),
-            "message": (
-                "Verification feasible within budget" if feasible 
-                else f"Path explosion risk: {estimated_paths} paths. Use stricter bounds."
-            )
-        }
+        capped = min(estimated_paths, 999999)
+
+        message = (
+            "Verification feasible within budget" if feasible
+            else f"Path explosion risk: {estimated_paths} paths. Use stricter bounds."
+        )
+
+        advisory = AdvisoryCheck(
+            name="verification_budget",
+            constraint_id="symbolic_verifier.verification_budget",
+            details={
+                "estimated_paths": capped,
+                "max_paths": max_paths,
+                "feasible": feasible,
+            },
+        )
+
+        return DiagnosticResult.unverifiable(
+            agent_message=message,
+            developer_fields={
+                "constraint_id": "symbolic_verifier.verification_budget",
+                "estimated_paths": capped,
+                "max_paths": max_paths,
+                "feasible": feasible,
+                "recommendation": analysis.get("recommendation", {}),
+                "advisory_checks": [advisory.to_dict()],
+            },
+        )
 
 
 # Factory function for easy access

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -15,6 +15,8 @@ import sys
 
 from .diagnostics import AdvisoryCheck, DiagnosticResult
 
+CONSTRAINT_SYNTAX_ERROR = "symbolic_verifier.syntax_error"
+
 
 class SymbolicVerifier:
     """
@@ -90,7 +92,7 @@ class SymbolicVerifier:
             return DiagnosticResult.blocked(
                 agent_message="Symbolic verification blocked: the code could not be parsed.",
                 developer_fields={
-                    "constraint_id": "symbolic_verifier.syntax_error",
+                    "constraint_id": CONSTRAINT_SYNTAX_ERROR,
                     "parse_error": str(e),
                     "verification_mode": "symbolic",
                 },
@@ -717,7 +719,7 @@ class SymbolicVerifier:
             diagnostic = DiagnosticResult.blocked(
                 agent_message="Bounded verification blocked: the code could not be parsed.",
                 developer_fields={
-                    "constraint_id": "symbolic_verifier.syntax_error",
+                    "constraint_id": CONSTRAINT_SYNTAX_ERROR,
                     "parse_error": analysis.get("message"),
                 },
             )
@@ -830,11 +832,13 @@ class SymbolicVerifier:
         analysis = self.analyze_complexity(code)
 
         if analysis.get("status") == "syntax_error":
-            return DiagnosticResult.unverifiable(
+            return DiagnosticResult.blocked(
                 agent_message="Cannot estimate verification budget: syntax error in code.",
                 developer_fields={
-                    "constraint_id": "symbolic_verifier.syntax_error",
+                    "constraint_id": CONSTRAINT_SYNTAX_ERROR,
                     "parse_error": analysis.get("message"),
+                    "feasible": False,
+                    "advisory_checks": [],
                 },
             )
 

--- a/tests/test_symbolic_verifier.py
+++ b/tests/test_symbolic_verifier.py
@@ -647,7 +647,8 @@ def add(x, y):
     return x + y
 """
         result = self.verifier.get_verification_budget(code)
-        assert result["feasible"] == True
+        assert result.developer_fields["feasible"]
+        assert result.status == DiagnosticStatus.UNVERIFIABLE
     
     def test_complex_code_path_explosion(self):
         """Test that complex code triggers path explosion warning."""
@@ -661,8 +662,8 @@ def explosion(items):
                         print(a, b, c, d, e)
 """
         result = self.verifier.get_verification_budget(code, max_paths=100)
-        assert result["feasible"] == False
-        assert "path explosion" in result["message"].lower() or result["estimated_paths"] > 100
+        assert result.developer_fields["feasible"] is False
+        assert "path explosion" in result.agent_message.lower() or result.developer_fields["estimated_paths"] > 100
 
 
 if __name__ == "__main__":

--- a/tests/test_symbolic_verifier.py
+++ b/tests/test_symbolic_verifier.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from qwed_new.core.symbolic_verifier import SymbolicVerifier, create_symbolic_verifier
+from qwed_new.core.symbolic_verifier import CONSTRAINT_SYNTAX_ERROR, SymbolicVerifier, create_symbolic_verifier
 from qwed_new.core.diagnostics import DiagnosticStatus
 
 
@@ -647,9 +647,9 @@ def add(x, y):
     return x + y
 """
         result = self.verifier.get_verification_budget(code)
-        assert result.developer_fields["feasible"]
+        assert result.advisory_checks[0].details["feasible"]
         assert result.status == DiagnosticStatus.UNVERIFIABLE
-    
+
     def test_complex_code_path_explosion(self):
         """Test that complex code triggers path explosion warning."""
         code = """
@@ -662,8 +662,18 @@ def explosion(items):
                         print(a, b, c, d, e)
 """
         result = self.verifier.get_verification_budget(code, max_paths=100)
+        assert result.advisory_checks[0].details["feasible"] is False
+        assert "path explosion" in result.agent_message.lower()
+
+    def test_get_verification_budget_syntax_error(self):
+        """Test budget estimation returns BLOCKED on syntax error."""
+        code = """
+def broken(
+"""
+        result = self.verifier.get_verification_budget(code)
+        assert result.status == DiagnosticStatus.BLOCKED
         assert result.developer_fields["feasible"] is False
-        assert "path explosion" in result.agent_message.lower() or result.developer_fields["estimated_paths"] > 100
+        assert result.constraint_id == CONSTRAINT_SYNTAX_ERROR
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Migrates `SymbolicVerifier.get_verification_budget()` from returning `Dict[str, Any]` to returning `DiagnosticResult`, continuing the SymbolicVerifier DiagnosticResult migration (Phase 2, tracker #238).

Closes #234

## Changes

- **`get_verification_budget()`** (`symbolic_verifier.py:824`) — now returns `DiagnosticResult` with status `UNVERIFIABLE`. Budget metadata (`estimated_paths`, `max_paths`, `feasible`, `recommendation`) lives in `developer_fields`. An `AdvisoryCheck` is included for downstream gate consumption. The human-readable message becomes `agent_message`.
- **Syntax error path** — also returns `DiagnosticResult` instead of the raw `analyze_complexity` dict.
- **Import** — added `AdvisoryCheck` to imports from `diagnostics`.
- **Test updates** — `test_symbolic_verifier.py` uses `.developer_fields[...]`, `.agent_message`, `.status` instead of dict access.

## Verification

- Both budget-specific tests pass
- Full test suite: 1427 passed, 102 skipped, 0 failures
- No production callers of `get_verification_budget()` outside tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification-budget checks now return structured diagnostic results, including advisory-check details, feasibility, and capped estimated-path information.
  * Enhanced status reporting with clearer end-user messaging and developer-facing metadata.

* **Bug Fixes**
  * Syntax errors are reported consistently as blocked diagnostics, including a standardized constraint identifier and infeasibility indicator.
  * Improved handling and messaging for path exploration exceeding the configured budget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->