### PR TITLE
feat(#235): migrate verify_safety_properties to return DiagnosticResult

### DIFF
--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -463,6 +463,7 @@ class SymbolicVerifier:
         return DiagnosticResult.unverifiable(
             agent_message=f"Safety check: {len(issues)} issues found" if issues else "Safety check: no issues detected",
             developer_fields={
+                "constraint_id": "symbolic_verifier.safety_properties",
                 "verification_mode": "symbolic",
                 "is_safe": safe,
                 "properties_checked": list(dict.fromkeys(properties_checked)),

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -387,76 +387,82 @@ class SymbolicVerifier:
                 "description": str(e)
             }]
     
-    def verify_safety_properties(self, code: str) -> Dict[str, Any]:
-        """
-        Verify common safety properties in code:
-        - Division by zero
-        - Index out of bounds
-        - None dereference
-        - Integer overflow (where detectable)
-        
-        Args:
-            code: Python code to check
-            
-        Returns:
-            Dict with safety analysis results
-        """
+    def verify_safety_properties(self, code: str) -> "DiagnosticResult":
+        """Verify common safety properties: division by zero, index bounds, etc."""
         properties_checked = []
         issues = []
-        
+
         try:
             tree = ast.parse(code)
         except SyntaxError as e:
-            return {
-                "is_safe": False,
-                "status": "syntax_error",
-                "message": str(e)
-            }
-        
-        # Check for division operations
+            return DiagnosticResult.blocked(
+                agent_message="Safety check blocked: the code could not be parsed.",
+                developer_fields={
+                    "constraint_id": CONSTRAINT_SYNTAX_ERROR,
+                    "is_safe": False,
+                    "issues": [],
+                    "warnings": 0,
+                    "errors": 0,
+                    "advisory_checks": [],
+                },
+            )
+
         for node in ast.walk(tree):
             if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Div, ast.FloorDiv, ast.Mod)):
                 properties_checked.append("division_safety")
-                # Check if divisor could be zero (heuristic)
                 if isinstance(node.right, ast.Constant) and node.right.value == 0:
                     issues.append({
                         "type": "division_by_zero",
                         "line": node.lineno,
-                        "description": "Division by literal zero detected"
+                        "description": "Division by literal zero detected",
                     })
                 elif isinstance(node.right, ast.Name):
                     issues.append({
                         "type": "potential_division_by_zero",
                         "line": node.lineno,
                         "variable": node.right.id,
-                        "description": f"Division by variable '{node.right.id}' - could be zero"
+                        "description": f"Division by variable '{node.right.id}' - could be zero",
                     })
-        
-        # Check for index operations
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Subscript):
                 properties_checked.append("index_safety")
-                # Flag potential index issues
                 if isinstance(node.slice, ast.Name):
                     issues.append({
                         "type": "potential_index_error",
                         "line": node.lineno,
-                        "description": "Index access with variable index - bounds not verified"
+                        "description": "Index access with variable index - bounds not verified",
                     })
-        
-        # Check for None comparisons that might indicate unhandled None
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
                 properties_checked.append("call_safety")
-        
-        return {
-            "is_safe": len([i for i in issues if "potential" not in i["type"]]) == 0,
-            "status": "analyzed",
-            "properties_checked": list(set(properties_checked)),
-            "issues": issues,
-            "warnings": len([i for i in issues if "potential" in i["type"]]),
-            "errors": len([i for i in issues if "potential" not in i["type"]])
-        }
+
+        safe = len([i for i in issues if "potential" not in i["type"]]) == 0
+        warnings = len([i for i in issues if "potential" in i["type"]])
+        errors = len([i for i in issues if "potential" not in i["type"]])
+
+        advisory = AdvisoryCheck(
+            name="safety_properties",
+            constraint_id="symbolic_verifier.safety_properties",
+            details={
+                "is_safe": safe,
+                "warnings": warnings,
+                "errors": errors,
+            },
+        )
+
+        return DiagnosticResult.unverifiable(
+            agent_message=f"Safety check: {len(issues)} issues found" if issues else "Safety check: no issues detected",
+            developer_fields={
+                "is_safe": safe,
+                "properties_checked": list(set(properties_checked)),
+                "issues": issues,
+                "warnings": warnings,
+                "errors": errors,
+                "advisory_checks": [advisory.to_dict()],
+            },
+        )
     
     def verify_function_contract(
         self, 

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -387,6 +387,37 @@ class SymbolicVerifier:
                 "description": str(e)
             }]
     
+    def _check_division_safety(self, node, issues, properties_checked):
+        """Check a node for division-by-zero hazards."""
+        if not isinstance(node, ast.BinOp) or not isinstance(node.op, (ast.Div, ast.FloorDiv, ast.Mod)):
+            return
+        properties_checked.append("division_safety")
+        if isinstance(node.right, ast.Constant) and node.right.value == 0:
+            issues.append({
+                "type": "division_by_zero",
+                "line": node.lineno,
+                "description": "Division by literal zero detected",
+            })
+        elif isinstance(node.right, ast.Name):
+            issues.append({
+                "type": "potential_division_by_zero",
+                "line": node.lineno,
+                "variable": node.right.id,
+                "description": f"Division by variable '{node.right.id}' - could be zero",
+            })
+
+    def _check_subscript_safety(self, node, issues, properties_checked):
+        """Check a node for index-out-of-bounds hazards."""
+        if not isinstance(node, ast.Subscript):
+            return
+        properties_checked.append("index_safety")
+        if isinstance(node.slice, ast.Name):
+            issues.append({
+                "type": "potential_index_error",
+                "line": node.lineno,
+                "description": "Index access with variable index - bounds not verified",
+            })
+
     def verify_safety_properties(self, code: str) -> "DiagnosticResult":
         """Verify common safety properties: division by zero, index bounds, etc."""
         properties_checked = []
@@ -399,6 +430,8 @@ class SymbolicVerifier:
                 agent_message="Safety check blocked: the code could not be parsed.",
                 developer_fields={
                     "constraint_id": CONSTRAINT_SYNTAX_ERROR,
+                    "parse_error": str(e),
+                    "verification_mode": "symbolic",
                     "is_safe": False,
                     "issues": [],
                     "warnings": 0,
@@ -408,33 +441,8 @@ class SymbolicVerifier:
             )
 
         for node in ast.walk(tree):
-            if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Div, ast.FloorDiv, ast.Mod)):
-                properties_checked.append("division_safety")
-                if isinstance(node.right, ast.Constant) and node.right.value == 0:
-                    issues.append({
-                        "type": "division_by_zero",
-                        "line": node.lineno,
-                        "description": "Division by literal zero detected",
-                    })
-                elif isinstance(node.right, ast.Name):
-                    issues.append({
-                        "type": "potential_division_by_zero",
-                        "line": node.lineno,
-                        "variable": node.right.id,
-                        "description": f"Division by variable '{node.right.id}' - could be zero",
-                    })
-
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Subscript):
-                properties_checked.append("index_safety")
-                if isinstance(node.slice, ast.Name):
-                    issues.append({
-                        "type": "potential_index_error",
-                        "line": node.lineno,
-                        "description": "Index access with variable index - bounds not verified",
-                    })
-
-        for node in ast.walk(tree):
+            self._check_division_safety(node, issues, properties_checked)
+            self._check_subscript_safety(node, issues, properties_checked)
             if isinstance(node, ast.Call):
                 properties_checked.append("call_safety")
 
@@ -455,8 +463,9 @@ class SymbolicVerifier:
         return DiagnosticResult.unverifiable(
             agent_message=f"Safety check: {len(issues)} issues found" if issues else "Safety check: no issues detected",
             developer_fields={
+                "verification_mode": "symbolic",
                 "is_safe": safe,
-                "properties_checked": list(set(properties_checked)),
+                "properties_checked": list(dict.fromkeys(properties_checked)),
                 "issues": issues,
                 "warnings": warnings,
                 "errors": errors,

--- a/tests/test_symbolic_verifier.py
+++ b/tests/test_symbolic_verifier.py
@@ -51,9 +51,10 @@ def divide(x):
     return x / 0
 """
         result = self.verifier.verify_safety_properties(code)
-        assert not result["is_safe"]
-        assert any("division_by_zero" in str(i) for i in result["issues"])
-    
+        assert result.status == DiagnosticStatus.UNVERIFIABLE
+        assert not result.developer_fields["is_safe"]
+        assert any("division_by_zero" in str(i) for i in result.developer_fields["issues"])
+
     def test_detect_potential_division_by_variable(self):
         """Test detection of potential division by zero with variable."""
         code = """
@@ -61,10 +62,10 @@ def divide(x: int, y: int) -> float:
     return x / y
 """
         result = self.verifier.verify_safety_properties(code)
-        # Should flag as potential issue
-        assert len(result["issues"]) > 0
-        assert any("potential_division_by_zero" in str(i["type"]) for i in result["issues"])
-    
+        assert result.status == DiagnosticStatus.UNVERIFIABLE
+        assert len(result.developer_fields["issues"]) > 0
+        assert any("potential_division_by_zero" in str(i["type"]) for i in result.developer_fields["issues"])
+
     def test_safe_code(self):
         """Test that safe code passes."""
         code = """
@@ -72,9 +73,9 @@ def add(x: int, y: int) -> int:
     return x + y
 """
         result = self.verifier.verify_safety_properties(code)
-        # No division, should be clean
-        assert result["errors"] == 0
-    
+        assert result.status == DiagnosticStatus.UNVERIFIABLE
+        assert result.developer_fields["errors"] == 0
+
     def test_syntax_error_handling(self):
         """Test handling of syntax errors."""
         code = """
@@ -82,8 +83,8 @@ def broken(
     return x + 
 """
         result = self.verifier.verify_safety_properties(code)
-        assert not result["is_safe"]
-        assert result["status"] == "syntax_error"
+        assert result.status == DiagnosticStatus.BLOCKED
+        assert not result.developer_fields["is_safe"]
 
 
 class TestFunctionExtraction:

--- a/tests/test_symbolic_verifier.py
+++ b/tests/test_symbolic_verifier.py
@@ -52,6 +52,9 @@ def divide(x):
 """
         result = self.verifier.verify_safety_properties(code)
         assert result.status == DiagnosticStatus.UNVERIFIABLE
+        assert result.developer_fields["verification_mode"] == "symbolic"
+        assert len(result.advisory_checks) == 1
+        assert result.advisory_checks[0].advisory_only is True
         assert not result.developer_fields["is_safe"]
         assert any("division_by_zero" in str(i) for i in result.developer_fields["issues"])
 
@@ -84,6 +87,8 @@ def broken(
 """
         result = self.verifier.verify_safety_properties(code)
         assert result.status == DiagnosticStatus.BLOCKED
+        assert result.developer_fields["verification_mode"] == "symbolic"
+        assert "parse_error" in result.developer_fields
         assert not result.developer_fields["is_safe"]
 
 


### PR DESCRIPTION
## Summary

Migrates `SymbolicVerifier.verify_safety_properties()` from returning `Dict[str, Any]` to returning `DiagnosticResult`. This is the final issue in the SymbolicVerifier DiagnosticResult migration — closes #238 (Phase 2 tracker).

## Changes

- **`verify_safety_properties()`** (`symbolic_verifier.py:390`) — now returns `DiagnosticResult`. Syntax errors return `BLOCKED`, analysis results return `UNVERIFIABLE` with safety data (`is_safe`, `issues`, etc.) in `developer_fields` and an `AdvisoryCheck`.
- **Test updates** — `TestSafetyPropertyChecks` uses `.status`, `.developer_fields[...]` instead of dict access.

## Verification

- All 4 safety property tests pass
- Full test suite: 1428 passed, 102 skipped, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Safety verification results now provide consistent structured diagnostic statuses.
  * Syntax errors are clearly reported as blocked checks with safety details.
  * Potential division-by-zero and index-related risks now include clearer issue classifications and counts.
* **Tests**
  * Updated safety verification coverage to validate the structured diagnostic response format and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->