### PR TITLE
fix: enforce mandatory proof artifact for VERIFIED attestations (issuance + consumption)

### DIFF
--- a/src/qwed_new/core/__init__.py
+++ b/src/qwed_new/core/__init__.py
@@ -20,12 +20,13 @@ from .exceptions import (
     wrap_error,
 )
 
-# Structured verification diagnostics (Issue #204)
+# Structured verification diagnostics (Issue #204, #191)
 from .diagnostics import (
     DiagnosticStatus,
     DiagnosticResult,
     AdvisoryCheck,
     compute_proof_ref,
+    enforce_trust_decision,
 )
 
 __all__ = [
@@ -42,11 +43,12 @@ __all__ = [
     "QWEDAPIError",
     "QWEDDependencyError",
     "wrap_error",
-    # Diagnostics (#204)
+    # Diagnostics (#204, #191)
     "DiagnosticStatus",
     "DiagnosticResult",
     "AdvisoryCheck",
     "compute_proof_ref",
+    "enforce_trust_decision",
 ]
 
 # Lazy imports for verifiers (avoid circular imports and missing deps)

--- a/src/qwed_new/core/attestation.py
+++ b/src/qwed_new/core/attestation.py
@@ -495,7 +495,7 @@ def create_verification_attestation(
             error="cryptography/PyJWT package not installed",
         )
 
-    if verified and proof_data is None:
+    if verified and not proof_data:
         logger.warning(
             "attestation.blocked query_hash=%s reason=VERIFIED_WITHOUT_PROOF",
             hashlib.sha256(query.encode()).hexdigest()[:16],

--- a/src/qwed_new/core/attestation.py
+++ b/src/qwed_new/core/attestation.py
@@ -495,6 +495,18 @@ def create_verification_attestation(
             error="cryptography/PyJWT package not installed",
         )
 
+    if verified and proof_data is None:
+        logger.warning(
+            "attestation.blocked query_hash=%s reason=VERIFIED_WITHOUT_PROOF",
+            hashlib.sha256(query.encode()).hexdigest()[:16],
+        )
+        return AttestationResult(
+            status=AttestationStatus.BLOCKED,
+            token=None,
+            error_code="VERIFIED_WITHOUT_PROOF",
+            error="VERIFIED status requires proof_data — cannot sign attestation without proof artifact",
+        )
+
     try:
         service = get_attestation_service()
         result = VerificationResult(

--- a/src/qwed_new/core/control_plane.py
+++ b/src/qwed_new/core/control_plane.py
@@ -17,6 +17,7 @@ from qwed_new.core.schemas import MathVerificationTask
 from qwed_new.core.observability import metrics_collector
 from qwed_new.core.security import EnhancedSecurityGateway, redact_pii
 from qwed_new.core.output_sanitizer import OutputSanitizer
+from qwed_new.core.diagnostics import DiagnosticResult, enforce_trust_decision
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,25 @@ class ControlPlane:
             response_status = self._determine_math_response_status(verification_result)
             trust_boundary = self._build_math_trust_boundary(provider, verification_result)
             trust_boundary["overall_status"] = response_status
+
+            # 4.5 Trust Boundary Enforcement (Issue #191)
+            # Convert legacy dict to DiagnosticResult for enforcement.
+            # Advisory mode (require_attestation=False) until engines are
+            # fully migrated to DiagnosticResult.
+            try:
+                dr = DiagnosticResult.from_legacy_dict(verification_result, engine="math")
+                enforced = enforce_trust_decision(
+                    dr,
+                    require_attestation=False,
+                    query=query,
+                )
+                trust_boundary["trust_enforced"] = enforced.status.value
+                trust_boundary["attestation_policy"] = "advisory"
+            except ValueError:
+                # Legacy VERIFIED results without proof_ref cannot be
+                # represented as DiagnosticResult. Skip enforcement.
+                trust_boundary["trust_enforced"] = "not_applicable"
+                trust_boundary["attestation_policy"] = "advisory"
             
             # 5. Response Construction
             response = {

--- a/src/qwed_new/core/control_plane.py
+++ b/src/qwed_new/core/control_plane.py
@@ -5,6 +5,7 @@ This module orchestrates the entire request lifecycle:
 Request -> Policy Check -> Routing -> Translation -> Verification -> Response
 """
 
+import hashlib
 import time
 import logging
 from typing import Dict, Any, Optional
@@ -145,9 +146,15 @@ class ControlPlane:
                 )
                 trust_boundary["trust_enforced"] = enforced.status.value
                 trust_boundary["attestation_policy"] = "advisory"
-            except ValueError:
+            except ValueError as exc:
                 # Legacy VERIFIED results without proof_ref cannot be
-                # represented as DiagnosticResult. Skip enforcement.
+                # represented as DiagnosticResult (from_legacy_dict raises).
+                # Log the specific reason and mark enforcement as skipped.
+                logger.warning(
+                    "trust_boundary.enforcement_skipped query_hash=%s reason=from_legacy_dict error=%s",
+                    hashlib.sha256(query.encode()).hexdigest()[:16] if query else "unknown",
+                    exc,
+                )
                 trust_boundary["trust_enforced"] = "not_applicable"
                 trust_boundary["attestation_policy"] = "advisory"
             

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -567,7 +567,7 @@ def enforce_trust_decision(
 
     Audit event:
         Every block decision is logged at WARNING level with structured
-        fields: action, token_present, policy, reason, constraint_id.
+        fields: constraint_id, reason, policy, and error where applicable.
     """
     policy = "mandatory" if require_attestation else "optional"
 
@@ -642,11 +642,29 @@ def enforce_trust_decision(
         )
 
     # Validate token claims against the result (bind token to this specific result)
-    qwed_claims = (token_claims or {}).get("qwed", {})
+    raw_qwed = (token_claims or {}).get("qwed")
+    qwed_claims = raw_qwed if isinstance(raw_qwed, dict) else None
+    raw_result_claims = qwed_claims.get("result") if qwed_claims else None
+    result_claims = raw_result_claims if isinstance(raw_result_claims, dict) else None
+    if result_claims is None:
+        logger.warning(
+            "trust_gate.blocked constraint_id=%s reason=claims_missing_or_malformed policy=%s",
+            result.constraint_id or "unknown",
+            policy,
+        )
+        return DiagnosticResult.blocked(
+            agent_message="Verification blocked — attestation claims missing or malformed",
+            developer_fields={
+                "constraint_id": "trust_gate.claims_missing",
+                "policy": policy,
+                "verdict_status": result.status.value,
+                "verdict_proof_ref": result.proof_ref,
+            },
+        )
 
     # Status must match
-    token_status = qwed_claims.get("result", {}).get("status")
-    if token_status and token_status != result.status.value:
+    token_status = result_claims.get("status")
+    if token_status != result.status.value:
         logger.warning(
             "trust_gate.blocked constraint_id=%s reason=claims_status_mismatch "
             "token_status=%s result_status=%s policy=%s",
@@ -669,7 +687,7 @@ def enforce_trust_decision(
     if query is not None:
         expected_query_hash = _compute_query_hash(query)
         token_query_hash = qwed_claims.get("query_hash")
-        if token_query_hash and token_query_hash != expected_query_hash:
+        if token_query_hash != expected_query_hash:
             logger.warning(
                 "trust_gate.blocked constraint_id=%s reason=claims_query_mismatch policy=%s",
                 result.constraint_id or "unknown",
@@ -685,9 +703,9 @@ def enforce_trust_decision(
                 },
             )
 
-    # Proof hash must match the result's proof_ref (both non-null)
+    # Proof hash must match the result's proof_ref
     token_proof_hash = qwed_claims.get("proof_hash")
-    if token_proof_hash and result.proof_ref and token_proof_hash != result.proof_ref:
+    if token_proof_hash != result.proof_ref:
         logger.warning(
             "trust_gate.blocked constraint_id=%s reason=claims_proof_mismatch policy=%s",
             result.constraint_id or "unknown",

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -529,12 +529,18 @@ class DiagnosticResult:
 # without required attestation artifact.
 # ---------------------------------------------------------------------------
 
+def _compute_query_hash(query: str) -> str:
+    """Compute a query hash in the same format as AttestationService._hash_content."""
+    return f"sha256:{hashlib.sha256(query.encode('utf-8')).hexdigest()}"
+
+
 def enforce_trust_decision(
     result: DiagnosticResult,
     *,
     attestation_token: Optional[str] = None,
     require_attestation: bool = True,
     trusted_issuers: Optional[List[str]] = None,
+    query: Optional[str] = None,
 ) -> DiagnosticResult:
     """Enforce trust-boundary gate: VERIFIED without required attestation → BLOCKED.
 
@@ -550,11 +556,14 @@ def enforce_trust_decision(
             attestation token is blocked. If False, attestation is advisory.
         trusted_issuers: Optional list of trusted issuer DIDs for token
             verification. Defaults to None (uses AttestationService default).
+        query: Original query string for query_hash binding validation.
+            If provided, the attestation token's qwed.query_hash claim must
+            match sha256(query). Without it, query binding is not checked.
 
     Returns:
         The original DiagnosticResult if all policy checks pass, or a BLOCKED
-        DiagnosticResult with fail-closed semantics if attestation is missing
-        or invalid.
+        DiagnosticResult with fail-closed semantics if attestation is missing,
+        invalid, or claims do not match the result.
 
     Audit event:
         Every block decision is logged at WARNING level with structured
@@ -569,7 +578,6 @@ def enforce_trust_decision(
     # No attestation token provided
     if not attestation_token:
         if not require_attestation:
-            # Optional policy + no token → pass through (advisory)
             return result
         logger.warning(
             "trust_gate.blocked constraint_id=%s reason=missing_attestation_token policy=%s",
@@ -592,7 +600,7 @@ def enforce_trust_decision(
         from .attestation import get_attestation_service
 
         service = get_attestation_service()
-        is_valid, _claims, error = service.verify_attestation(
+        is_valid, token_claims, error = service.verify_attestation(
             attestation_token,
             trusted_issuers=trusted_issuers,
         )
@@ -633,7 +641,69 @@ def enforce_trust_decision(
             },
         )
 
-    # Attestation valid — pass through
+    # Validate token claims against the result (bind token to this specific result)
+    qwed_claims = (token_claims or {}).get("qwed", {})
+
+    # Status must match
+    token_status = qwed_claims.get("result", {}).get("status")
+    if token_status and token_status != result.status.value:
+        logger.warning(
+            "trust_gate.blocked constraint_id=%s reason=claims_status_mismatch "
+            "token_status=%s result_status=%s policy=%s",
+            result.constraint_id or "unknown",
+            token_status,
+            result.status.value,
+            policy,
+        )
+        return DiagnosticResult.blocked(
+            agent_message="Verification blocked — attestation claims do not match result status",
+            developer_fields={
+                "constraint_id": "trust_gate.claims_status_mismatch",
+                "token_status": token_status,
+                "result_status": result.status.value,
+                "policy": policy,
+            },
+        )
+
+    # Query hash must match if query was provided
+    if query is not None:
+        expected_query_hash = _compute_query_hash(query)
+        token_query_hash = qwed_claims.get("query_hash")
+        if token_query_hash and token_query_hash != expected_query_hash:
+            logger.warning(
+                "trust_gate.blocked constraint_id=%s reason=claims_query_mismatch policy=%s",
+                result.constraint_id or "unknown",
+                policy,
+            )
+            return DiagnosticResult.blocked(
+                agent_message="Verification blocked — attestation query hash does not match",
+                developer_fields={
+                    "constraint_id": "trust_gate.claims_query_mismatch",
+                    "expected_query_hash": expected_query_hash,
+                    "token_query_hash": token_query_hash,
+                    "policy": policy,
+                },
+            )
+
+    # Proof hash must match the result's proof_ref (both non-null)
+    token_proof_hash = qwed_claims.get("proof_hash")
+    if token_proof_hash and result.proof_ref and token_proof_hash != result.proof_ref:
+        logger.warning(
+            "trust_gate.blocked constraint_id=%s reason=claims_proof_mismatch policy=%s",
+            result.constraint_id or "unknown",
+            policy,
+        )
+        return DiagnosticResult.blocked(
+            agent_message="Verification blocked — attestation proof hash does not match result",
+            developer_fields={
+                "constraint_id": "trust_gate.claims_proof_mismatch",
+                "token_proof_hash": token_proof_hash,
+                "result_proof_ref": result.proof_ref,
+                "policy": policy,
+            },
+        )
+
+    # Attestation valid and claims bound — pass through
     return result
 
 

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -44,7 +44,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ class AdvisoryCheck:
 # Proof reference computation — deterministic hash of retained evidence.
 # ---------------------------------------------------------------------------
 
-def compute_proof_ref(evidence: Union[Dict[str, Any], str]) -> str:
+def compute_proof_ref(evidence: Dict[str, Any] | str) -> str:
     """Compute a deterministic proof reference hash from retained evidence.
 
     The proof_ref binds the verdict (status=VERIFIED) to the specific evidence

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -560,6 +560,8 @@ def enforce_trust_decision(
         Every block decision is logged at WARNING level with structured
         fields: action, token_present, policy, reason, constraint_id.
     """
+    policy = "mandatory" if require_attestation else "optional"
+
     # Fail-closed states pass through — no attestation needed
     if result.is_fail_closed:
         return result
@@ -570,15 +572,16 @@ def enforce_trust_decision(
             # Optional policy + no token → pass through (advisory)
             return result
         logger.warning(
-            "trust_gate.blocked constraint_id=%s reason=missing_attestation_token policy=mandatory",
+            "trust_gate.blocked constraint_id=%s reason=missing_attestation_token policy=%s",
             result.constraint_id or "unknown",
+            policy,
         )
         return DiagnosticResult.blocked(
             agent_message="Verification blocked — proof artifact missing",
             developer_fields={
                 "constraint_id": "trust_gate.mandatory_attestation_missing",
                 "missing": "attestation_token",
-                "policy": "mandatory",
+                "policy": policy,
                 "verdict_status": result.status.value,
                 "verdict_proof_ref": result.proof_ref,
             },
@@ -589,23 +592,24 @@ def enforce_trust_decision(
         from .attestation import get_attestation_service
 
         service = get_attestation_service()
-        is_valid, claims, error = service.verify_attestation(
+        is_valid, _claims, error = service.verify_attestation(
             attestation_token,
             trusted_issuers=trusted_issuers,
         )
     except Exception as exc:
         logger.warning(
             "trust_gate.blocked constraint_id=%s reason=attestation_verification_failed "
-            "error=%s",
+            "error=%s policy=%s",
             result.constraint_id or "unknown",
             exc,
+            policy,
         )
         return DiagnosticResult.blocked(
             agent_message="Verification blocked — proof artifact verification failed",
             developer_fields={
                 "constraint_id": "trust_gate.attestation_verification_error",
                 "error": str(exc),
-                "policy": "mandatory",
+                "policy": policy,
                 "verdict_status": result.status.value,
                 "verdict_proof_ref": result.proof_ref,
             },
@@ -613,16 +617,17 @@ def enforce_trust_decision(
 
     if not is_valid:
         logger.warning(
-            "trust_gate.blocked constraint_id=%s reason=invalid_attestation_token error=%s",
+            "trust_gate.blocked constraint_id=%s reason=invalid_attestation_token error=%s policy=%s",
             result.constraint_id or "unknown",
             error,
+            policy,
         )
         return DiagnosticResult.blocked(
             agent_message="Verification blocked — proof artifact invalid",
             developer_fields={
                 "constraint_id": "trust_gate.invalid_attestation_token",
                 "validation_error": error,
-                "policy": "mandatory",
+                "policy": policy,
                 "verdict_status": result.status.value,
                 "verdict_proof_ref": result.proof_ref,
             },

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -44,7 +44,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ class AdvisoryCheck:
 # Proof reference computation — deterministic hash of retained evidence.
 # ---------------------------------------------------------------------------
 
-def compute_proof_ref(evidence: Dict[str, Any]) -> str:
+def compute_proof_ref(evidence: Union[Dict[str, Any], str]) -> str:
     """Compute a deterministic proof reference hash from retained evidence.
 
     The proof_ref binds the verdict (status=VERIFIED) to the specific evidence
@@ -155,24 +155,32 @@ def compute_proof_ref(evidence: Dict[str, Any]) -> str:
 
     Args:
         evidence: The proof artifact dict (e.g., convergence trace, frequency
-                  counts, eigenvalue comparison, Z3 assertion stack).
+                  counts, eigenvalue comparison, Z3 assertion stack) or a
+                  pre-serialized string. When a string is passed, it is hashed
+                  directly — this ensures callers can pass the same
+                  ``json.dumps(evidence_dict, sort_keys=True)`` that the
+                  attestation issuer used as ``proof_data``, guaranteeing the
+                  resulting hash matches the attestation token's ``proof_hash``.
 
     Returns:
         sha256-prefixed hex digest string, e.g. "sha256:abcdef...".
 
     Note:
-        The evidence dict is JSON-serialized with sort_keys=True for
+        When a dict is passed, it is JSON-serialized with sort_keys=True for
         deterministic hashing. Non-JSON-serializable values must be
         pre-converted to strings by the caller — they will raise
         ValueError (fail-closed), preventing non-deterministic memory-
         address-dependent hashes from entering the proof contract.
     """
-    try:
-        payload = json.dumps(evidence, sort_keys=True)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(
-            f"Proof evidence must be JSON-serializable for proof_ref hashing: {exc}"
-        ) from exc
+    if isinstance(evidence, str):
+        payload = evidence
+    else:
+        try:
+            payload = json.dumps(evidence, sort_keys=True)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Proof evidence must be JSON-serializable for proof_ref hashing: {exc}"
+            ) from exc
     digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
     return f"sha256:{digest}"
 
@@ -350,6 +358,7 @@ class DiagnosticResult:
         agent_message: str,
         developer_fields: Dict[str, Any],
         evidence: Dict[str, Any],
+        proof_data: Optional[str] = None,
     ) -> "DiagnosticResult":
         """Construct a VERIFIED result with proof_ref computed from evidence.
 
@@ -357,6 +366,12 @@ class DiagnosticResult:
             agent_message: Agent-safe summary (Layer 1).
             developer_fields: Structured developer evidence (Layer 2).
             evidence: Proof artifact dict — hashed to produce proof_ref (Layer 3).
+            proof_data: Optional pre-serialized proof string. When provided,
+                ``proof_ref`` is computed directly from this string (via
+                :func:`compute_proof_ref`) instead of from *evidence*. This
+                ensures the hash matches the attestation token's ``proof_hash``
+                when the same string is passed as ``proof_data`` to
+                :func:`create_verification_attestation`.
 
         Returns:
             DiagnosticResult with status=VERIFIED and proof_ref=compute_proof_ref(evidence).
@@ -365,7 +380,7 @@ class DiagnosticResult:
             status=DiagnosticStatus.VERIFIED,
             agent_message=agent_message,
             developer_fields=developer_fields,
-            proof_ref=compute_proof_ref(evidence),
+            proof_ref=compute_proof_ref(proof_data if proof_data is not None else evidence),
         )
 
     @classmethod
@@ -534,68 +549,13 @@ def _compute_query_hash(query: str) -> str:
     return f"sha256:{hashlib.sha256(query.encode('utf-8')).hexdigest()}"
 
 
-def enforce_trust_decision(
+def _verify_attestation_token(
+    attestation_token: str,
+    trusted_issuers: Optional[List[str]],
     result: DiagnosticResult,
-    *,
-    attestation_token: Optional[str] = None,
-    require_attestation: bool = True,
-    trusted_issuers: Optional[List[str]] = None,
-    query: Optional[str] = None,
-) -> DiagnosticResult:
-    """Enforce trust-boundary gate: VERIFIED without required attestation → BLOCKED.
-
-    This is the single enforcement point for consumption-side attestation
-    validation. Every release gate / trust boundary MUST route verification
-    results through this function before making admission decisions.
-
-    Args:
-        result: The verification DiagnosticResult from the engine.
-        attestation_token: The JWT attestation token (from
-            attestation.create_verification_attestation). May be None.
-        require_attestation: If True (default), VERIFIED without a valid
-            attestation token is blocked. If False, attestation is advisory.
-        trusted_issuers: Optional list of trusted issuer DIDs for token
-            verification. Defaults to None (uses AttestationService default).
-        query: Original query string for query_hash binding validation.
-            If provided, the attestation token's qwed.query_hash claim must
-            match sha256(query). Without it, query binding is not checked.
-
-    Returns:
-        The original DiagnosticResult if all policy checks pass, or a BLOCKED
-        DiagnosticResult with fail-closed semantics if attestation is missing,
-        invalid, or claims do not match the result.
-
-    Audit event:
-        Every block decision is logged at WARNING level with structured
-        fields: constraint_id, reason, policy, and error where applicable.
-    """
-    policy = "mandatory" if require_attestation else "optional"
-
-    # Fail-closed states pass through — no attestation needed
-    if result.is_fail_closed:
-        return result
-
-    # No attestation token provided
-    if not attestation_token:
-        if not require_attestation:
-            return result
-        logger.warning(
-            "trust_gate.blocked constraint_id=%s reason=missing_attestation_token policy=%s",
-            result.constraint_id or "unknown",
-            policy,
-        )
-        return DiagnosticResult.blocked(
-            agent_message="Verification blocked — proof artifact missing",
-            developer_fields={
-                "constraint_id": "trust_gate.mandatory_attestation_missing",
-                "missing": "attestation_token",
-                "policy": policy,
-                "verdict_status": result.status.value,
-                "verdict_proof_ref": result.proof_ref,
-            },
-        )
-
-    # Verify the attestation token
+    policy: str,
+) -> Optional[Tuple[bool, Dict[str, Any], Optional[str]]]:
+    """Verify the attestation token, returning (is_valid, claims, error) or a blocked result."""
     try:
         from .attestation import get_attestation_service
 
@@ -641,7 +601,16 @@ def enforce_trust_decision(
             },
         )
 
-    # Validate token claims against the result (bind token to this specific result)
+    return is_valid, token_claims, error
+
+
+def _validate_attestation_claims(
+    result: DiagnosticResult,
+    token_claims: Dict[str, Any],
+    query: Optional[str],
+    policy: str,
+) -> Optional[DiagnosticResult]:
+    """Validate token claims against result. Returns a blocked result or None."""
     raw_qwed = (token_claims or {}).get("qwed")
     qwed_claims = raw_qwed if isinstance(raw_qwed, dict) else None
     raw_result_claims = qwed_claims.get("result") if qwed_claims else None
@@ -662,7 +631,6 @@ def enforce_trust_decision(
             },
         )
 
-    # Status must match
     token_status = result_claims.get("status")
     if token_status != result.status.value:
         logger.warning(
@@ -683,7 +651,6 @@ def enforce_trust_decision(
             },
         )
 
-    # Query hash must match if query was provided
     if query is not None:
         expected_query_hash = _compute_query_hash(query)
         token_query_hash = qwed_claims.get("query_hash")
@@ -703,7 +670,6 @@ def enforce_trust_decision(
                 },
             )
 
-    # Proof hash must match the result's proof_ref
     token_proof_hash = qwed_claims.get("proof_hash")
     if token_proof_hash != result.proof_ref:
         logger.warning(
@@ -721,7 +687,77 @@ def enforce_trust_decision(
             },
         )
 
-    # Attestation valid and claims bound — pass through
+    return None
+
+
+def enforce_trust_decision(
+    result: DiagnosticResult,
+    *,
+    attestation_token: Optional[str] = None,
+    require_attestation: bool = True,
+    trusted_issuers: Optional[List[str]] = None,
+    query: Optional[str] = None,
+) -> DiagnosticResult:
+    """Enforce trust-boundary gate: VERIFIED without required attestation → BLOCKED.
+
+    This is the single enforcement point for consumption-side attestation
+    validation. Every release gate / trust boundary MUST route verification
+    results through this function before making admission decisions.
+
+    Args:
+        result: The verification DiagnosticResult from the engine.
+        attestation_token: The JWT attestation token (from
+            attestation.create_verification_attestation). May be None.
+        require_attestation: If True (default), VERIFIED without a valid
+            attestation token is blocked. If False, attestation is advisory.
+        trusted_issuers: Optional list of trusted issuer DIDs for token
+            verification. Defaults to None (uses AttestationService default).
+        query: Original query string for query_hash binding validation.
+            If provided, the attestation token's qwed.query_hash claim must
+            match sha256(query). Without it, query binding is not checked.
+
+    Returns:
+        The original DiagnosticResult if all policy checks pass, or a BLOCKED
+        DiagnosticResult with fail-closed semantics if attestation is missing,
+        invalid, or claims do not match the result.
+
+    Audit event:
+        Every block decision is logged at WARNING level with structured
+        fields: constraint_id, reason, policy, and error where applicable.
+    """
+    policy = "mandatory" if require_attestation else "optional"
+
+    if result.is_fail_closed:
+        return result
+
+    if not attestation_token:
+        if not require_attestation:
+            return result
+        logger.warning(
+            "trust_gate.blocked constraint_id=%s reason=missing_attestation_token policy=%s",
+            result.constraint_id or "unknown",
+            policy,
+        )
+        return DiagnosticResult.blocked(
+            agent_message="Verification blocked — proof artifact missing",
+            developer_fields={
+                "constraint_id": "trust_gate.mandatory_attestation_missing",
+                "missing": "attestation_token",
+                "policy": policy,
+                "verdict_status": result.status.value,
+                "verdict_proof_ref": result.proof_ref,
+            },
+        )
+
+    verification = _verify_attestation_token(attestation_token, trusted_issuers, result, policy)
+    if isinstance(verification, DiagnosticResult):
+        return verification
+    _is_valid, token_claims, _error = verification
+
+    validation = _validate_attestation_claims(result, token_claims, query, policy)
+    if validation is not None:
+        return validation
+
     return result
 
 

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -41,9 +41,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -520,9 +523,119 @@ class DiagnosticResult:
         )
 
 
+# ---------------------------------------------------------------------------
+# Trust boundary enforcement — consumption-side attestation validation.
+# Issue #191: No trust-boundary path can return/consume effective VERIFIED
+# without required attestation artifact.
+# ---------------------------------------------------------------------------
+
+def enforce_trust_decision(
+    result: DiagnosticResult,
+    *,
+    attestation_token: Optional[str] = None,
+    require_attestation: bool = True,
+    trusted_issuers: Optional[List[str]] = None,
+) -> DiagnosticResult:
+    """Enforce trust-boundary gate: VERIFIED without required attestation → BLOCKED.
+
+    This is the single enforcement point for consumption-side attestation
+    validation. Every release gate / trust boundary MUST route verification
+    results through this function before making admission decisions.
+
+    Args:
+        result: The verification DiagnosticResult from the engine.
+        attestation_token: The JWT attestation token (from
+            attestation.create_verification_attestation). May be None.
+        require_attestation: If True (default), VERIFIED without a valid
+            attestation token is blocked. If False, attestation is advisory.
+        trusted_issuers: Optional list of trusted issuer DIDs for token
+            verification. Defaults to None (uses AttestationService default).
+
+    Returns:
+        The original DiagnosticResult if all policy checks pass, or a BLOCKED
+        DiagnosticResult with fail-closed semantics if attestation is missing
+        or invalid.
+
+    Audit event:
+        Every block decision is logged at WARNING level with structured
+        fields: action, token_present, policy, reason, constraint_id.
+    """
+    # Fail-closed states pass through — no attestation needed
+    if result.is_fail_closed:
+        return result
+
+    # No attestation token provided
+    if not attestation_token:
+        if not require_attestation:
+            # Optional policy + no token → pass through (advisory)
+            return result
+        logger.warning(
+            "trust_gate.blocked constraint_id=%s reason=missing_attestation_token policy=mandatory",
+            result.constraint_id or "unknown",
+        )
+        return DiagnosticResult.blocked(
+            agent_message="Verification blocked — proof artifact missing",
+            developer_fields={
+                "constraint_id": "trust_gate.mandatory_attestation_missing",
+                "missing": "attestation_token",
+                "policy": "mandatory",
+                "verdict_status": result.status.value,
+                "verdict_proof_ref": result.proof_ref,
+            },
+        )
+
+    # Verify the attestation token
+    try:
+        from .attestation import get_attestation_service
+
+        service = get_attestation_service()
+        is_valid, claims, error = service.verify_attestation(
+            attestation_token,
+            trusted_issuers=trusted_issuers,
+        )
+    except Exception as exc:
+        logger.warning(
+            "trust_gate.blocked constraint_id=%s reason=attestation_verification_failed "
+            "error=%s",
+            result.constraint_id or "unknown",
+            exc,
+        )
+        return DiagnosticResult.blocked(
+            agent_message="Verification blocked — proof artifact verification failed",
+            developer_fields={
+                "constraint_id": "trust_gate.attestation_verification_error",
+                "error": str(exc),
+                "policy": "mandatory",
+                "verdict_status": result.status.value,
+                "verdict_proof_ref": result.proof_ref,
+            },
+        )
+
+    if not is_valid:
+        logger.warning(
+            "trust_gate.blocked constraint_id=%s reason=invalid_attestation_token error=%s",
+            result.constraint_id or "unknown",
+            error,
+        )
+        return DiagnosticResult.blocked(
+            agent_message="Verification blocked — proof artifact invalid",
+            developer_fields={
+                "constraint_id": "trust_gate.invalid_attestation_token",
+                "validation_error": error,
+                "policy": "mandatory",
+                "verdict_status": result.status.value,
+                "verdict_proof_ref": result.proof_ref,
+            },
+        )
+
+    # Attestation valid — pass through
+    return result
+
+
 __all__ = [
     "DiagnosticStatus",
     "DiagnosticResult",
     "AdvisoryCheck",
     "compute_proof_ref",
+    "enforce_trust_decision",
 ]

--- a/tests/test_attestation_coverage.py
+++ b/tests/test_attestation_coverage.py
@@ -273,7 +273,8 @@ class TestAttestationCoverage(unittest.TestCase):
         with patch("src.qwed_new.core.attestation.get_attestation_service", return_value=self.service):
             result = create_verification_attestation(
                 status="verified", verified=True,
-                engine="test_engine", query="test query"
+                engine="test_engine", query="test query",
+                proof_data="sha256:abc123"
             )
             self.assertIsInstance(result, AttestationResult)
             self.assertTrue(result.is_issued)
@@ -296,7 +297,7 @@ class TestAttestationCoverage(unittest.TestCase):
     def test_create_verification_attestation_failure(self):
         """Failure path must return AttestationResult with BLOCKED status, never None."""
         with patch("src.qwed_new.core.attestation.get_attestation_service", side_effect=Exception("Boom")):
-            result = create_verification_attestation("s", True, "e", "q")
+            result = create_verification_attestation("s", True, "e", "q", proof_data="sha256:abc123")
             self.assertIsNotNone(result, "Must never return None")
             self.assertEqual(result.status, AttestationStatus.BLOCKED)
             self.assertFalse(result.is_issued)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -16,6 +16,7 @@ Covers:
 - Constraint violations raise ValueError
 """
 
+import hashlib
 import unittest
 from unittest.mock import MagicMock, patch
 from src.qwed_new.core.diagnostics import (
@@ -760,10 +761,14 @@ class TestEnforceTrustDecision(unittest.TestCase):
     # --- (c) VERIFIED + valid token → passes ---
 
     def test_verified_valid_token_passes(self):
-        """VERIFIED with valid token must return the original result."""
+        """VERIFIED with valid token (matching claims) must return the original."""
         with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
             mock_svc = MagicMock()
-            mock_svc.verify_attestation.return_value = (True, {"qwed": {"result": {}}}, None)
+            mock_svc.verify_attestation.return_value = (
+                True,
+                {"qwed": {"result": {"status": "VERIFIED", "engine": "math"}}},
+                None,
+            )
             mock_get.return_value = mock_svc
 
             r = enforce_trust_decision(
@@ -774,6 +779,32 @@ class TestEnforceTrustDecision(unittest.TestCase):
         self.assertTrue(r.is_verified)
         self.assertEqual(r.constraint_id, "math.identity")
         self.assertIsNotNone(r.proof_ref)
+
+    def test_verified_valid_token_with_query_passes(self):
+        """VERIFIED with valid token + matching query_hash must pass."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            expected_qh = "sha256:" + hashlib.sha256(b"2+2=4").hexdigest()
+            mock_svc.verify_attestation.return_value = (
+                True,
+                {
+                    "qwed": {
+                        "result": {"status": "VERIFIED", "engine": "math"},
+                        "query_hash": expected_qh,
+                    }
+                },
+                None,
+            )
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                attestation_token="valid.jwt.token",
+                query="2+2=4",
+            )
+
+        self.assertTrue(r.is_verified)
+        self.assertEqual(r.constraint_id, "math.identity")
 
     # --- (d) Policy toggle: optional attestation ---
 
@@ -853,6 +884,85 @@ class TestEnforceTrustDecision(unittest.TestCase):
         self.assertEqual(
             r.developer_fields.get("constraint_id"),
             "trust_gate.mandatory_attestation_missing",
+        )
+
+    # --- Claims binding: token must match result ---
+
+    def test_claims_status_mismatch_blocks(self):
+        """Token with status != VERIFIED must be blocked."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (
+                True,
+                {"qwed": {"result": {"status": "FAILED"}}},
+                None,
+            )
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                attestation_token="mismatched.status.token",
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(
+            r.developer_fields.get("constraint_id"),
+            "trust_gate.claims_status_mismatch",
+        )
+
+    def test_claims_query_mismatch_blocks(self):
+        """Token with wrong query_hash must be blocked."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (
+                True,
+                {
+                    "qwed": {
+                        "result": {"status": "VERIFIED"},
+                        "query_hash": "sha256:abc123",
+                    }
+                },
+                None,
+            )
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                attestation_token="wrong.query.token",
+                query="some other query",
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(
+            r.developer_fields.get("constraint_id"),
+            "trust_gate.claims_query_mismatch",
+        )
+
+    def test_claims_proof_mismatch_blocks(self):
+        """Token with proof_hash != result.proof_ref must be blocked."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (
+                True,
+                {
+                    "qwed": {
+                        "result": {"status": "VERIFIED"},
+                        "proof_hash": "sha256:wrongproof",
+                    }
+                },
+                None,
+            )
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                attestation_token="wrong.proof.token",
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(
+            r.developer_fields.get("constraint_id"),
+            "trust_gate.claims_proof_mismatch",
         )
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -17,11 +17,13 @@ Covers:
 """
 
 import unittest
+from unittest.mock import MagicMock, patch
 from src.qwed_new.core.diagnostics import (
     DiagnosticStatus,
     DiagnosticResult,
     AdvisoryCheck,
     compute_proof_ref,
+    enforce_trust_decision,
 )
 
 
@@ -695,6 +697,163 @@ class TestRealisticScenarios(unittest.TestCase):
         admitted = [r for r in results if r.is_authoritative]
         self.assertEqual(len(admitted), 1)
         self.assertEqual(admitted[0].constraint_id, "a")
+
+
+
+
+
+# ---------------------------------------------------------------------------
+# Issue #191 — enforce_trust_decision: consumption-side attestation enforcement
+# ---------------------------------------------------------------------------
+
+class TestEnforceTrustDecision(unittest.TestCase):
+    """Issue #191: trust-boundary gates must enforce attestation presence."""
+
+    def setUp(self):
+        self.verified = DiagnosticResult.verified(
+            agent_message="Math check passed",
+            developer_fields={"constraint_id": "math.identity"},
+            evidence={"result": 42},
+        )
+        self.unverifiable = DiagnosticResult.unverifiable(
+            agent_message="Math check inconclusive",
+            developer_fields={"constraint_id": "math.inconclusive"},
+        )
+        self.blocked = DiagnosticResult.blocked(
+            agent_message="Math check blocked",
+            developer_fields={"constraint_id": "math.blocked"},
+        )
+
+    # --- (a) VERIFIED + no token → BLOCKED ---
+
+    def test_verified_no_token_returns_blocked(self):
+        """VERIFIED without attestation token must return BLOCKED."""
+        r = enforce_trust_decision(self.verified)
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(
+            r.developer_fields.get("constraint_id"),
+            "trust_gate.mandatory_attestation_missing",
+        )
+        self.assertIn("proof artifact missing", r.agent_message.lower())
+
+    # --- (b) VERIFIED + invalid token → BLOCKED ---
+
+    def test_verified_invalid_token_returns_blocked(self):
+        """VERIFIED with invalid token must return BLOCKED."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (False, None, "signature invalid")
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                attestation_token="invalid.jwt.token",
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(
+            r.developer_fields.get("constraint_id"),
+            "trust_gate.invalid_attestation_token",
+        )
+        self.assertIn("proof artifact invalid", r.agent_message.lower())
+
+    # --- (c) VERIFIED + valid token → passes ---
+
+    def test_verified_valid_token_passes(self):
+        """VERIFIED with valid token must return the original result."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (True, {"qwed": {"result": {}}}, None)
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                attestation_token="valid.jwt.token",
+            )
+
+        self.assertTrue(r.is_verified)
+        self.assertEqual(r.constraint_id, "math.identity")
+        self.assertIsNotNone(r.proof_ref)
+
+    # --- (d) Policy toggle: optional attestation ---
+
+    def test_verified_optional_attestation_without_token_passes(self):
+        """require_attestation=False must allow VERIFIED without token."""
+        r = enforce_trust_decision(
+            self.verified,
+            require_attestation=False,
+            attestation_token=None,
+        )
+        self.assertTrue(r.is_verified)
+        self.assertEqual(r.constraint_id, "math.identity")
+
+    def test_verified_optional_policy_still_blocks_invalid_token(self):
+        """Even with optional policy, invalid token must still be blocked."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (False, None, "bad sig")
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                require_attestation=False,
+                attestation_token="bad.token.here",
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(
+            r.developer_fields.get("constraint_id"),
+            "trust_gate.invalid_attestation_token",
+        )
+
+    # --- Fail-closed states pass through regardless ---
+
+    def test_unverifiable_passes_through_without_token(self):
+        """UNVERIFIABLE must pass through without attestation."""
+        r = enforce_trust_decision(self.unverifiable)
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(r.constraint_id, "math.inconclusive")
+
+    def test_blocked_passes_through_without_token(self):
+        """BLOCKED must pass through without attestation."""
+        r = enforce_trust_decision(self.blocked)
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(r.constraint_id, "math.blocked")
+
+    def test_unverifiable_with_token_passes_through(self):
+        """UNVERIFIABLE must pass through even with a token (attestation irrelevant)."""
+        r = enforce_trust_decision(self.unverifiable, attestation_token="some.token")
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(r.constraint_id, "math.inconclusive")
+
+    # --- Edge cases ---
+
+    def test_verified_verification_error_returns_blocked(self):
+        """If attestation verification raises, result must be BLOCKED."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.side_effect = RuntimeError("crypto failure")
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                attestation_token="raising.token",
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(
+            r.developer_fields.get("constraint_id"),
+            "trust_gate.attestation_verification_error",
+        )
+
+    def test_verified_with_empty_token_is_blocked(self):
+        """Empty string token should be treated as missing."""
+        r = enforce_trust_decision(self.verified, attestation_token="")
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(
+            r.developer_fields.get("constraint_id"),
+            "trust_gate.mandatory_attestation_missing",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -974,7 +974,7 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
             r = enforce_trust_decision(
                 self.verified,
-                attestation_token="QWED_TEST_NO_QWED_CLAIMS",
+                attestation_token="QWED_TEST_VALUE_NO_QWED_CLAIMS",
             )
 
         self.assertTrue(r.is_fail_closed)
@@ -993,7 +993,7 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
             r = enforce_trust_decision(
                 self.verified,
-                attestation_token="QWED_TEST_NO_RESULT_CLAIM",
+                attestation_token="QWED_TEST_VALUE_NO_RESULT_CLAIM",
             )
 
         self.assertTrue(r.is_fail_closed)
@@ -1008,7 +1008,7 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
             r = enforce_trust_decision(
                 self.verified,
-                attestation_token="QWED_TEST_QWED_NOT_DICT",
+                attestation_token="QWED_TEST_VALUE_QWED_NOT_DICT",
             )
 
         self.assertTrue(r.is_fail_closed)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -748,7 +748,7 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
             r = enforce_trust_decision(
                 self.verified,
-                attestation_token="invalid.jwt.token",
+                attestation_token="QWED_TEST_INVALID_TOKEN",
             )
 
         self.assertTrue(r.is_fail_closed)
@@ -760,20 +760,25 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
     # --- (c) VERIFIED + valid token → passes ---
 
+    def _verified_claims(self) -> dict:
+        """Build a claim set matching self.verified (proof_ref + status)."""
+        return {
+            "qwed": {
+                "result": {"status": "VERIFIED", "engine": "math"},
+                "proof_hash": self.verified.proof_ref,
+            },
+        }
+
     def test_verified_valid_token_passes(self):
         """VERIFIED with valid token (matching claims) must return the original."""
         with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
             mock_svc = MagicMock()
-            mock_svc.verify_attestation.return_value = (
-                True,
-                {"qwed": {"result": {"status": "VERIFIED", "engine": "math"}}},
-                None,
-            )
+            mock_svc.verify_attestation.return_value = (True, self._verified_claims(), None)
             mock_get.return_value = mock_svc
 
             r = enforce_trust_decision(
                 self.verified,
-                attestation_token="valid.jwt.token",
+                attestation_token="QWED_TEST_VALID_TOKEN",
             )
 
         self.assertTrue(r.is_verified)
@@ -784,22 +789,15 @@ class TestEnforceTrustDecision(unittest.TestCase):
         """VERIFIED with valid token + matching query_hash must pass."""
         with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
             mock_svc = MagicMock()
+            claims = self._verified_claims()
             expected_qh = "sha256:" + hashlib.sha256(b"2+2=4").hexdigest()
-            mock_svc.verify_attestation.return_value = (
-                True,
-                {
-                    "qwed": {
-                        "result": {"status": "VERIFIED", "engine": "math"},
-                        "query_hash": expected_qh,
-                    }
-                },
-                None,
-            )
+            claims["qwed"]["query_hash"] = expected_qh
+            mock_svc.verify_attestation.return_value = (True, claims, None)
             mock_get.return_value = mock_svc
 
             r = enforce_trust_decision(
                 self.verified,
-                attestation_token="valid.jwt.token",
+                attestation_token="QWED_TEST_VALID_TOKEN",
                 query="2+2=4",
             )
 
@@ -828,7 +826,7 @@ class TestEnforceTrustDecision(unittest.TestCase):
             r = enforce_trust_decision(
                 self.verified,
                 require_attestation=False,
-                attestation_token="bad.token.here",
+                attestation_token="QWED_TEST_BAD_TOKEN",
             )
 
         self.assertTrue(r.is_fail_closed)
@@ -853,7 +851,7 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
     def test_unverifiable_with_token_passes_through(self):
         """UNVERIFIABLE must pass through even with a token (attestation irrelevant)."""
-        r = enforce_trust_decision(self.unverifiable, attestation_token="some.token")
+        r = enforce_trust_decision(self.unverifiable, attestation_token="QWED_TEST_DUMMY_TOKEN")
         self.assertTrue(r.is_fail_closed)
         self.assertEqual(r.constraint_id, "math.inconclusive")
 
@@ -868,7 +866,7 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
             r = enforce_trust_decision(
                 self.verified,
-                attestation_token="raising.token",
+                attestation_token="QWED_TEST_RAISING_TOKEN",
             )
 
         self.assertTrue(r.is_fail_closed)
@@ -901,7 +899,7 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
             r = enforce_trust_decision(
                 self.verified,
-                attestation_token="mismatched.status.token",
+                attestation_token="QWED_TEST_MISMATCHED_STATUS_TOKEN",
             )
 
         self.assertTrue(r.is_fail_closed)
@@ -928,7 +926,7 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
             r = enforce_trust_decision(
                 self.verified,
-                attestation_token="wrong.query.token",
+                attestation_token="QWED_TEST_WRONG_QUERY_TOKEN",
                 query="some other query",
             )
 
@@ -956,7 +954,7 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
             r = enforce_trust_decision(
                 self.verified,
-                attestation_token="wrong.proof.token",
+                attestation_token="QWED_TEST_WRONG_PROOF_TOKEN",
             )
 
         self.assertTrue(r.is_fail_closed)
@@ -964,6 +962,57 @@ class TestEnforceTrustDecision(unittest.TestCase):
             r.developer_fields.get("constraint_id"),
             "trust_gate.claims_proof_mismatch",
         )
+
+    # --- Claims binding: missing / malformed claims ---
+
+    def test_claims_missing_qwed_blocked(self):
+        """Token without qwed claims must be blocked (fail-closed)."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (True, {}, None)
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                attestation_token="QWED_TEST_NO_QWED_CLAIMS",
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(r.developer_fields.get("constraint_id"), "trust_gate.claims_missing")
+
+    def test_claims_missing_result_blocked(self):
+        """Token with qwed but no result must be blocked."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (
+                True,
+                {"qwed": {"query_hash": "sha256:abc"}},
+                None,
+            )
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                attestation_token="QWED_TEST_NO_RESULT_CLAIM",
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(r.developer_fields.get("constraint_id"), "trust_gate.claims_missing")
+
+    def test_claims_qwed_not_dict_blocked(self):
+        """Token where qwed is not a dict must be blocked."""
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (True, {"qwed": "not_a_dict"}, None)
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                self.verified,
+                attestation_token="QWED_TEST_QWED_NOT_DICT",
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(r.developer_fields.get("constraint_id"), "trust_gate.claims_missing")
 
 
 if __name__ == "__main__":

--- a/tests/test_pr188_attestation_fail_closed.py
+++ b/tests/test_pr188_attestation_fail_closed.py
@@ -243,8 +243,21 @@ class TestIssuanceEnforcesProofArtifact(unittest.TestCase):
                 proof_data="sha256:abcdef123456",
             )
         self.assertIsNotNone(result)
+        # Guard did NOT trigger — proof_data was provided
         self.assertNotEqual(result.error_code, "VERIFIED_WITHOUT_PROOF",
                             "proof_data provided — must not trigger the proof check")
+        if result.is_issued:
+            self.assertIsNotNone(result.token)
+            # Verify the token contains proof_hash claim
+            try:
+                svc = get_attestation_service()
+                is_valid, claims, _ = svc.verify_attestation(result.token)
+                if is_valid:
+                    qwed = (claims or {}).get("qwed", {})
+                    self.assertIn("proof_hash", qwed,
+                                  "ISSUED token must contain proof_hash claim")
+            except Exception:
+                pass  # Verification may fail without real crypto; assertion is advisory
 
 
 @unittest.skipUnless(HAS_CRYPTO, "cryptography not installed")

--- a/tests/test_pr188_attestation_fail_closed.py
+++ b/tests/test_pr188_attestation_fail_closed.py
@@ -209,6 +209,17 @@ class TestIssuanceEnforcesProofArtifact(unittest.TestCase):
         self.assertEqual(result.status, AttestationStatus.BLOCKED)
         self.assertEqual(result.error_code, "VERIFIED_WITHOUT_PROOF")
 
+    def test_verified_with_empty_string_proof(self):
+        """verified=True + proof_data='' (empty) must also be BLOCKED."""
+        with patch.object(attest_mod, "HAS_CRYPTO", True):
+            result = create_verification_attestation(
+                status="VERIFIED", verified=True,
+                engine="math", query="2+2",
+                proof_data="",
+            )
+        self.assertEqual(result.status, AttestationStatus.BLOCKED)
+        self.assertEqual(result.error_code, "VERIFIED_WITHOUT_PROOF")
+
     def test_unverified_without_proof_not_blocked(self):
         """verified=False + no proof_data must NOT be blocked (UNVERIFIABLE needs no proof)."""
         with patch.object(attest_mod, "HAS_CRYPTO", True):

--- a/tests/test_pr188_attestation_fail_closed.py
+++ b/tests/test_pr188_attestation_fail_closed.py
@@ -95,7 +95,8 @@ class TestFailClosedContract(unittest.TestCase):
         """Happy path: successful attestation returns ISSUED status with JWT."""
         with patch.object(attest_mod, "get_attestation_service", return_value=self.service):
             result = create_verification_attestation(
-                status="VERIFIED", verified=True, engine="math", query="2+2=4"
+                status="VERIFIED", verified=True, engine="math", query="2+2=4",
+                proof_data="sha256:abc123"
             )
 
         self.assertIsInstance(result, AttestationResult)
@@ -109,7 +110,8 @@ class TestFailClosedContract(unittest.TestCase):
         """The token inside AttestationResult must be a verifiable JWT."""
         with patch.object(attest_mod, "get_attestation_service", return_value=self.service):
             result = create_verification_attestation(
-                status="VERIFIED", verified=True, engine="math", query="is 4 prime?"
+                status="VERIFIED", verified=True, engine="math", query="is 4 prime?",
+                proof_data="sha256:def456"
             )
 
         self.assertTrue(result.is_issued)
@@ -124,7 +126,8 @@ class TestFailClosedContract(unittest.TestCase):
 
         with patch.object(attest_mod, "get_attestation_service", return_value=broken_service):
             result = create_verification_attestation(
-                status="VERIFIED", verified=True, engine="math", query="2+2"
+                status="VERIFIED", verified=True, engine="math", query="2+2",
+                proof_data="sha256:ghi789"
             )
 
         self.assertIsNotNone(result, "MUST NOT return None — fail-closed contract")
@@ -138,7 +141,8 @@ class TestFailClosedContract(unittest.TestCase):
         """If get_attestation_service() itself raises, result is BLOCKED."""
         with patch.object(attest_mod, "get_attestation_service", side_effect=Exception("svc down")):
             result = create_verification_attestation(
-                status="VERIFIED", verified=True, engine="math", query="q"
+                status="VERIFIED", verified=True, engine="math", query="q",
+                proof_data="sha256:jkl012"
             )
 
         self.assertEqual(result.status, AttestationStatus.BLOCKED)
@@ -147,14 +151,14 @@ class TestFailClosedContract(unittest.TestCase):
 
     def test_no_none_return_success_path(self):
         with patch.object(attest_mod, "get_attestation_service", return_value=self.service):
-            result = create_verification_attestation("VERIFIED", True, "math", "2+2")
+            result = create_verification_attestation("VERIFIED", True, "math", "2+2", proof_data="sha256:mno345")
         self.assertIsNotNone(result)
 
     def test_no_none_return_signing_failure_path(self):
         svc = AttestationService(issuer_did="did:test:188", key_suffix="fail")
         svc.create_attestation = MagicMock(side_effect=ValueError("bad key"))
         with patch.object(attest_mod, "get_attestation_service", return_value=svc):
-            result = create_verification_attestation("VERIFIED", True, "math", "2+2")
+            result = create_verification_attestation("VERIFIED", True, "math", "2+2", proof_data="sha256:pqr678")
         self.assertIsNotNone(result)
 
     def test_caller_must_hardblock_on_blocked(self):
@@ -163,12 +167,73 @@ class TestFailClosedContract(unittest.TestCase):
         broken.create_attestation = MagicMock(side_effect=RuntimeError("fail"))
 
         with patch.object(attest_mod, "get_attestation_service", return_value=broken):
-            result = create_verification_attestation("VERIFIED", True, "math", "q")
+            result = create_verification_attestation("VERIFIED", True, "math", "q", proof_data="sha256:stu901")
 
         self.assertFalse(
             result.is_issued,
             "Caller MUST NOT proceed as VERIFIED when attestation is BLOCKED"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #191 — VERIFIED status requires proof artifact (issuance-side)
+# These tests patch HAS_CRYPTO=True to reach the VERIFIED_WITHOUT_PROOF guard.
+# They do NOT require the cryptography package to be actually installed.
+# ---------------------------------------------------------------------------
+
+class TestIssuanceEnforcesProofArtifact(unittest.TestCase):
+    """Issue #191: attestation issuance must reject VERIFIED without proof."""
+
+    def test_verified_without_proof_returns_blocked(self):
+        """verified=True + proof_data=None must return BLOCKED, never ISSUED."""
+        with patch.object(attest_mod, "HAS_CRYPTO", True):
+            result = create_verification_attestation(
+                status="VERIFIED", verified=True,
+                engine="math", query="2+2",
+            )
+        self.assertIsNotNone(result, "MUST NOT return None — fail-closed contract")
+        self.assertEqual(result.status, AttestationStatus.BLOCKED)
+        self.assertFalse(result.is_issued)
+        self.assertEqual(result.error_code, "VERIFIED_WITHOUT_PROOF")
+        self.assertIsNone(result.token)
+        self.assertIn("proof", (result.error or "").lower())
+
+    def test_verified_without_proof_explicit_none(self):
+        """verified=True + proof_data=None (explicit) must also be BLOCKED."""
+        with patch.object(attest_mod, "HAS_CRYPTO", True):
+            result = create_verification_attestation(
+                status="VERIFIED", verified=True,
+                engine="math", query="2+2",
+                proof_data=None,
+            )
+        self.assertEqual(result.status, AttestationStatus.BLOCKED)
+        self.assertEqual(result.error_code, "VERIFIED_WITHOUT_PROOF")
+
+    def test_unverified_without_proof_not_blocked(self):
+        """verified=False + no proof_data must NOT be blocked (UNVERIFIABLE needs no proof)."""
+        with patch.object(attest_mod, "HAS_CRYPTO", True):
+            result = create_verification_attestation(
+                status="FAILED", verified=False,
+                engine="math", query="2+2",
+            )
+        # Should reach the Exception path (no real crypto) or ATTEMPT to sign
+        # Regardless, it should NOT be VERIFIED_WITHOUT_PROOF error
+        self.assertIsNotNone(result)
+        self.assertNotEqual(result.error_code, "VERIFIED_WITHOUT_PROOF",
+                            "verified=False must not trigger the proof check")
+
+    def test_verified_with_proof_not_blocked(self):
+        """verified=True + proof_data present must proceed past the guard (may still
+        fail at signing, but NOT with VERIFIED_WITHOUT_PROOF)."""
+        with patch.object(attest_mod, "HAS_CRYPTO", True):
+            result = create_verification_attestation(
+                status="VERIFIED", verified=True,
+                engine="math", query="2+2",
+                proof_data="sha256:abcdef123456",
+            )
+        self.assertIsNotNone(result)
+        self.assertNotEqual(result.error_code, "VERIFIED_WITHOUT_PROOF",
+                            "proof_data provided — must not trigger the proof check")
 
 
 @unittest.skipUnless(HAS_CRYPTO, "cryptography not installed")

--- a/tests/test_pr188_attestation_fail_closed.py
+++ b/tests/test_pr188_attestation_fail_closed.py
@@ -10,6 +10,7 @@ Acceptance criteria verified here:
 - [x] Tests cover signing failure, crypto unavailable, restart continuity, caller fail-closed
 """
 
+import hashlib
 import unittest
 from unittest.mock import patch, MagicMock
 import src.qwed_new.core.attestation as attest_mod
@@ -154,6 +155,24 @@ class TestFailClosedContract(unittest.TestCase):
             result = create_verification_attestation("VERIFIED", True, "math", "2+2", proof_data="sha256:mno345")
         self.assertIsNotNone(result)
 
+    def test_issued_with_proof_hash(self):
+        """ISSUED token with proof_data must contain proof_hash matching the artifact."""
+        with patch.object(attest_mod, "get_attestation_service", return_value=self.service):
+            result = create_verification_attestation(
+                "VERIFIED", True, "math", "2+2",
+                proof_data="sha256:abcdef123456",
+            )
+        self.assertTrue(result.is_issued, f"Expected ISSUED, got {result.error}")
+        self.assertIsNotNone(result.token)
+        is_valid, claims, err = self.service.verify_attestation(result.token)
+        self.assertTrue(is_valid, f"Token verification failed: {err}")
+        qwed = (claims or {}).get("qwed", {})
+        self.assertIn("proof_hash", qwed, "ISSUED token must contain proof_hash claim")
+        self.assertEqual(
+            qwed["proof_hash"],
+            "sha256:" + hashlib.sha256("sha256:abcdef123456".encode()).hexdigest(),
+        )
+
     def test_no_none_return_signing_failure_path(self):
         svc = AttestationService(issuer_did="did:test:188", key_suffix="fail")
         svc.create_attestation = MagicMock(side_effect=ValueError("bad key"))
@@ -246,18 +265,6 @@ class TestIssuanceEnforcesProofArtifact(unittest.TestCase):
         # Guard did NOT trigger — proof_data was provided
         self.assertNotEqual(result.error_code, "VERIFIED_WITHOUT_PROOF",
                             "proof_data provided — must not trigger the proof check")
-        if result.is_issued:
-            self.assertIsNotNone(result.token)
-            # Verify the token contains proof_hash claim
-            try:
-                svc = get_attestation_service()
-                is_valid, claims, _ = svc.verify_attestation(result.token)
-                if is_valid:
-                    qwed = (claims or {}).get("qwed", {})
-                    self.assertIn("proof_hash", qwed,
-                                  "ISSUED token must contain proof_hash claim")
-            except Exception:
-                pass  # Verification may fail without real crypto; assertion is advisory
 
 
 @unittest.skipUnless(HAS_CRYPTO, "cryptography not installed")

--- a/tests/test_pr5_determinism_alignment.py
+++ b/tests/test_pr5_determinism_alignment.py
@@ -67,6 +67,8 @@ async def test_control_plane_marks_translated_math_as_inconclusive(monkeypatch):
         "translation_claim_self_consistent": True,
         "provider_used": "openai_compat",
         "overall_status": "INCONCLUSIVE",
+        "trust_enforced": "not_applicable",
+        "attestation_policy": "advisory",
     }
     assert captured["organization_id"] == 42
     assert captured["status"] == "INCONCLUSIVE"


### PR DESCRIPTION
## **User description**
## Summary

Closes #191 — both sides of the proof enforcement boundary.

**Issuance side** (`attestation.py`): `create_verification_attestation()` now rejects `verified=True` when `proof_data is None`, returning `BLOCKED` with error code `VERIFIED_WITHOUT_PROOF`. The cryptographic attestation layer will no longer sign a `VERIFIED` result that lacks a proof artifact.

**Consumption side** (`diagnostics.py`): New `enforce_trust_decision()` function — the single enforcement point every release gate must route through. It verifies attestation tokens before admitting `VERIFIED` results for control flow.

## Changes

### `src/qwed_new/core/attestation.py` (issuance-side fix)
- Added guard at line 498: if `verified=True` and `proof_data is None`, return `AttestationResult(status=BLOCKED, error_code="VERIFIED_WITHOUT_PROOF")` instead of attempting to sign without a proof artifact
- Structured WARNING log on every block decision

### `src/qwed_new/core/diagnostics.py` (consumption-side fix)
- Added `enforce_trust_decision()` function (line 532):
  - `result: DiagnosticResult` — the engine's verification output
  - `require_attestation: bool` — policy toggle (default `True`)
  - `attestation_token: Optional[str]` — JWT from `create_verification_attestation()`
  - `trusted_issuers: Optional[List[str]]` — optional issuer DID allowlist
- Logic:
  - UNVERIFIABLE/BLOCKED → pass through (no attestation needed)
  - VERIFIED + no token + mandatory policy → BLOCKED (`trust_gate.mandatory_attestation_missing`)
  - VERIFIED + no token + optional policy → pass through (advisory)
  - VERIFIED + invalid/expired token → BLOCKED (`trust_gate.invalid_attestation_token`)
  - VERIFIED + verification error → BLOCKED (`trust_gate.attestation_verification_error`)
  - VERIFIED + valid token → pass through
- Every block decision logs structured WARNING with constraint_id, reason, policy
- Exported via `__all__` and `core/__init__.py`

### `tests/test_pr188_attestation_fail_closed.py`
- New class `TestIssuanceEnforcesProofArtifact` (4 tests):
  - `test_verified_without_proof_returns_blocked`
  - `test_verified_without_proof_explicit_none`
  - `test_unverified_without_proof_not_blocked`
  - `test_verified_with_proof_not_blocked`
- Updated 6 call sites in `TestFailClosedContract` to pass `proof_data`

### `tests/test_attestation_coverage.py`
- Updated 2 call sites to pass `proof_data`

### `tests/test_diagnostics.py`
- New class `TestEnforceTrustDecision` (10 tests):
  - (a) VERIFIED + no token → BLOCKED
  - (b) VERIFIED + invalid token → BLOCKED
  - (c) VERIFIED + valid token → passes
  - (d) Policy toggle (mandatory vs optional) both paths covered
  - UNVERIFIABLE/BLOCKED pass through regardless of attestation
  - Empty string token treated as missing
  - Verification exception → BLOCKED

## Acceptance Criteria Coverage

- [x] No trust-boundary path can consume effective VERIFIED without required attestation artifact
- [x] Status-only checks replaced by centralized policy-bound trust decision validation
- [x] Missing/invalid attestation deterministically yields fail-closed state
- [x] Tests cover:
  - (a) VERIFIED + no token
  - (b) VERIFIED + invalid token
  - (c) VERIFIED + valid token
  - (d) Policy toggle (mandatory vs optional) with explicit audit tagging
- [x] Documentation states proof enforcement semantics at consumption boundary (docstring)

## Related

- Closes #191
- Complements #188 (attestation fail-closed contract)
- Depends on #204 (DiagnosticResult model) — `enforce_trust_decision` consumes `DiagnosticResult`, not ad-hoc dicts
- Part of #167 (trust-boundary hardening)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trust-boundary enforcement for verified diagnostic outcomes, including consumption-side attestation validation.
  * Exposed trust-decision enforcement publicly for use by other components.
* **Bug Fixes**
  * Verification is now fail-closed: when results are marked verified but proof data is missing, responses are blocked with a clear `VERIFIED_WITHOUT_PROOF` error and no token.
  * Invalid, failed, or mismatched attestation checks now fail safely instead of passing through.
* **Tests**
  * Expanded coverage for proof requirements, token/claim binding behavior, and trust-decision outcomes (including Issue `#191` scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Require proof artifacts for verified attestations

### What Changed
- Verified attestations are blocked when proof data is missing or empty instead of being issued without evidence.
- Trust-boundary checks now reject missing, invalid, or failed attestation verification when attestations are mandatory.
- Attestation claims are checked against the verification result, including status, query hash, and proof hash.
- Advisory mode still allows verified results without a token, while invalid tokens remain blocked.
- Math verification now reports trust-enforcement outcomes, and coverage was added for missing proof, invalid tokens, policy modes, and claim mismatches.

### Impact
`✅ No verified attestations without proof`
`✅ Fewer unauthenticated verified results reaching release gates`
`✅ Clearer rejection of mismatched or invalid proof artifacts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
