### PR TITLE
feat: migrate FactVerifier to DiagnosticResult with advisory-only LLM (#259)

### DIFF
--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -371,13 +371,13 @@ async def verify_fact(
             organization_id=tenant.organization_id,
             query=claim,
             result=str(result),
-            is_verified=(result.get("verdict") == "SUPPORTED"),
+            is_verified=result.is_verified,
             domain="FACT"
         )
         session.add(log)
         session.commit()
         
-        return result
+        return result.to_dict()
         
     except Exception as e:
         logger.error(f"Fact verification error: {redact_pii(str(e))}", exc_info=False)

--- a/src/qwed_new/core/batch.py
+++ b/src/qwed_new/core/batch.py
@@ -260,10 +260,11 @@ class BatchVerificationService:
         elif item.verification_type == VerificationType.FACT:
             from qwed_new.core.fact_verifier import FactVerifier
             verifier = FactVerifier()
-            return verifier.verify_fact(
+            result = verifier.verify_fact(
                 item.query,
                 item.params.get("context", "")
             )
+            return result.to_dict()
         
         elif item.verification_type == VerificationType.SQL:
             from qwed_new.core.sql_verifier import SQLVerifier

--- a/src/qwed_new/core/fact_verifier.py
+++ b/src/qwed_new/core/fact_verifier.py
@@ -135,47 +135,53 @@ class FactVerifier:
         scores = {}
         advisory_checks = []
 
-        # Step 1: Segment context into sentences
-        sentences = self._segment_sentences(context)
+        try:
+            # Step 1: Segment context into sentences
+            sentences = self._segment_sentences(context)
 
-        # Step 2: Find relevant sentences (citations)
-        citations = self._find_relevant_sentences(claim, sentences)
+            # Step 2: Find relevant sentences (citations)
+            citations = self._find_relevant_sentences(claim, sentences)
 
-        # Step 3: Semantic similarity scoring
-        semantic_score = self._calculate_semantic_similarity(claim, context)
-        scores["semantic_similarity"] = semantic_score
-        methods_used.append({"name": "semantic_similarity", "advisory_only": False})
+            # Step 3: Semantic similarity scoring
+            semantic_score = self._calculate_semantic_similarity(claim, context)
+            scores["semantic_similarity"] = semantic_score
+            methods_used.append({"name": "semantic_similarity", "advisory_only": False})
 
-        # Step 4: Keyword overlap analysis
-        keyword_score, keyword_details = self._analyze_keyword_overlap(claim, context)
-        scores["keyword_overlap"] = keyword_score
-        methods_used.append({"name": "keyword_overlap", "advisory_only": False})
+            # Step 4: Keyword overlap analysis
+            keyword_score, keyword_details = self._analyze_keyword_overlap(claim, context)
+            scores["keyword_overlap"] = keyword_score
+            methods_used.append({"name": "keyword_overlap", "advisory_only": False})
 
-        # Step 5: Entity matching (numbers, dates, names)
-        entity_match, entity_details = self._match_entities(claim, context)
-        scores["entity_match"] = entity_match
-        methods_used.append({"name": "entity_matching", "advisory_only": False})
+            # Step 5: Entity matching (numbers, dates, names)
+            entity_match, entity_details = self._match_entities(claim, context)
+            scores["entity_match"] = entity_match
+            methods_used.append({"name": "entity_matching", "advisory_only": False})
 
-        # Step 6: Negation detection
-        has_negation, negation_details = self._detect_negation_conflict(claim, citations)
-        scores["negation_conflict"] = 1.0 if has_negation else 0.0
-        methods_used.append({"name": "negation_detection", "advisory_only": False})
+            # Step 6: Negation detection
+            has_negation, negation_details = self._detect_negation_conflict(claim, citations)
+            scores["negation_conflict"] = 1.0 if has_negation else 0.0
+            methods_used.append({"name": "negation_detection", "advisory_only": False})
 
-        # Step 7: Calculate deterministic verdict
-        verdict, confidence, reasoning = self._calculate_verdict(
-            semantic_score=semantic_score,
-            keyword_score=keyword_score,
-            entity_match=entity_match,
-            has_negation=has_negation,
-            citations=citations,
-            keyword_details=keyword_details,
-            entity_details=entity_details,
-            negation_details=negation_details
-        )
+            # Step 7: Calculate deterministic verdict
+            verdict, confidence, reasoning = self._calculate_verdict(
+                semantic_score=semantic_score,
+                keyword_score=keyword_score,
+                entity_match=entity_match,
+                has_negation=has_negation,
+                citations=citations,
+                keyword_details=keyword_details,
+                entity_details=entity_details,
+                negation_details=negation_details
+            )
+        except Exception as exc:
+            return DiagnosticResult.blocked(
+                "Fact verification pipeline failed",
+                {"constraint_id": "fact_verifier.execution_error", "error": str(exc)},
+            )
 
-        # Step 8: LLM fallback is advisory-only (fixes #133)
+        # Step 8: LLM fallback is advisory-only (fixes #133), confidence-gated
         llm_advisory = None
-        if self.use_llm_fallback and provider:
+        if confidence < min_confidence and self.use_llm_fallback and provider:
             methods_used.append({"name": "llm_fallback", "advisory_only": True})
             llm_result = self._llm_fallback(claim, context, provider)
             if llm_result:
@@ -220,11 +226,9 @@ class FactVerifier:
 
         if verdict == "REFUTED":
             developer_fields["constraint_id"] = "fact_verifier.deterministic_refuted"
-            evidence = {"citations": developer_fields["citations"], "reasoning": reasoning}
-            return DiagnosticResult.verified(
-                "Fact claim deterministically refuted — negation conflict detected",
+            return DiagnosticResult.blocked(
+                "Fact claim refuted by deterministic analysis — negation conflict detected",
                 developer_fields,
-                evidence,
             )
 
         developer_fields["constraint_id"] = "fact_verifier.inconclusive"

--- a/src/qwed_new/core/fact_verifier.py
+++ b/src/qwed_new/core/fact_verifier.py
@@ -15,9 +15,12 @@ from typing import Dict, Any, List, Optional, Tuple
 from dataclasses import dataclass, field
 import re
 import math
+import logging
 from collections import Counter
 
 from qwed_new.core.diagnostics import DiagnosticResult, AdvisoryCheck
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -174,9 +177,10 @@ class FactVerifier:
                 negation_details=negation_details
             )
         except Exception as exc:
+            logger.exception("Fact verification pipeline failed")
             return DiagnosticResult.blocked(
                 "Fact verification pipeline failed",
-                {"constraint_id": "fact_verifier.execution_error", "error": str(exc)},
+                {"constraint_id": "fact_verifier.execution_error", "error_type": type(exc).__name__},
             )
 
         # Step 8: LLM fallback is advisory-only (fixes #133), confidence-gated

--- a/src/qwed_new/core/fact_verifier.py
+++ b/src/qwed_new/core/fact_verifier.py
@@ -2,14 +2,13 @@
 Enterprise Fact Verification Engine.
 
 Verifies factual claims against source context using deterministic methods:
-1. Semantic Similarity - sentence embeddings comparison
+1. Semantic Similarity - TF-IDF cosine similarity
 2. Citation Extraction - finds supporting/refuting sentences
 3. Keyword Overlap - lexical matching
 4. Entity Matching - proper nouns, numbers, dates
-5. Multi-Source Validation - cross-reference multiple sources
+5. Negation Detection - identifies conflicts
 
-This is NOT an LLM passthrough. The LLM is only used as a fallback
-for complex reasoning after deterministic methods are exhausted.
+LLM fallback is advisory-only and never determines the final verdict.
 """
 
 from typing import Dict, Any, List, Optional, Tuple
@@ -17,6 +16,8 @@ from dataclasses import dataclass, field
 import re
 import math
 from collections import Counter
+
+from qwed_new.core.diagnostics import DiagnosticResult, AdvisoryCheck
 
 
 @dataclass
@@ -107,70 +108,60 @@ class FactVerifier:
         context: str, 
         provider: Optional[str] = None,
         min_confidence: float = 0.7
-    ) -> Dict[str, Any]:
+    ) -> DiagnosticResult:
         """
         Verify a factual claim against a source context.
-        
-        Args:
-            claim: The statement to verify (e.g., "The policy covers water damage").
-            context: The source text (e.g., policy document, article).
-            provider: Optional LLM provider for fallback.
-            min_confidence: Minimum confidence to return verdict without LLM.
-            
-        Returns:
-            dict: {
-                "verdict": "SUPPORTED" | "REFUTED" | "NEUTRAL" | "INSUFFICIENT_EVIDENCE",
-                "confidence": float,
-                "reasoning": str,
-                "citations": list[dict],
-                "methods_used": list[str]
-            }
 
-        Example:
-            >>> context = "The sky is blue."
-            >>> result = verifier.verify_fact("The sky is blue", context)
-            >>> print(result["verdict"])
-            'SUPPORTED'
+        LLM fallback is advisory-only — it populates advisory_checks and
+        never overwrites the deterministic verdict (fixes #133).
+
+        Args:
+            claim: The statement to verify.
+            context: The source text.
+            provider: Optional LLM provider for advisory fallback.
+            min_confidence: Minimum confidence for deterministic verdict.
+
+        Returns:
+            DiagnosticResult — VERIFIED for deterministic SUPPORTED/REFUTED,
+            UNVERIFIABLE for NEUTRAL/INSUFFICIENT_EVIDENCE, BLOCKED on error.
         """
         if not claim or not context:
-            return {
-                "verdict": "INSUFFICIENT_EVIDENCE",
-                "confidence": 0.0,
-                "reasoning": "Empty claim or context provided",
-                "citations": [],
-                "methods_used": []
-            }
-        
+            return DiagnosticResult.unverifiable(
+                "Empty claim or context provided",
+                {"constraint_id": "fact_verifier.empty_input"}
+            )
+
         methods_used = []
         scores = {}
-        
+        advisory_checks = []
+
         # Step 1: Segment context into sentences
         sentences = self._segment_sentences(context)
-        
+
         # Step 2: Find relevant sentences (citations)
         citations = self._find_relevant_sentences(claim, sentences)
-        
+
         # Step 3: Semantic similarity scoring
         semantic_score = self._calculate_semantic_similarity(claim, context)
         scores["semantic_similarity"] = semantic_score
-        methods_used.append("semantic_similarity")
-        
+        methods_used.append({"name": "semantic_similarity", "advisory_only": False})
+
         # Step 4: Keyword overlap analysis
         keyword_score, keyword_details = self._analyze_keyword_overlap(claim, context)
         scores["keyword_overlap"] = keyword_score
-        methods_used.append("keyword_overlap")
-        
+        methods_used.append({"name": "keyword_overlap", "advisory_only": False})
+
         # Step 5: Entity matching (numbers, dates, names)
         entity_match, entity_details = self._match_entities(claim, context)
         scores["entity_match"] = entity_match
-        methods_used.append("entity_matching")
-        
+        methods_used.append({"name": "entity_matching", "advisory_only": False})
+
         # Step 6: Negation detection
         has_negation, negation_details = self._detect_negation_conflict(claim, citations)
         scores["negation_conflict"] = 1.0 if has_negation else 0.0
-        methods_used.append("negation_detection")
-        
-        # Step 7: Calculate aggregate verdict
+        methods_used.append({"name": "negation_detection", "advisory_only": False})
+
+        # Step 7: Calculate deterministic verdict
         verdict, confidence, reasoning = self._calculate_verdict(
             semantic_score=semantic_score,
             keyword_score=keyword_score,
@@ -181,32 +172,66 @@ class FactVerifier:
             entity_details=entity_details,
             negation_details=negation_details
         )
-        
-        # Step 8: If low confidence and LLM fallback enabled, consult LLM
-        if confidence < min_confidence and self.use_llm_fallback and provider:
-            methods_used.append("llm_fallback")
+
+        # Step 8: LLM fallback is advisory-only (fixes #133)
+        llm_advisory = None
+        if self.use_llm_fallback and provider:
+            methods_used.append({"name": "llm_fallback", "advisory_only": True})
             llm_result = self._llm_fallback(claim, context, provider)
             if llm_result:
-                # Blend LLM result with our deterministic result
-                verdict = llm_result.get("verdict", verdict)
-                confidence = max(confidence, llm_result.get("confidence", 0) * 0.8)  # Discount LLM confidence
-                reasoning += f"\n\nLLM Analysis: {llm_result.get('reasoning', '')}"
-        
-        return {
-            "verdict": verdict,
-            "confidence": round(confidence, 3),
-            "reasoning": reasoning,
+                llm_advisory = AdvisoryCheck(
+                    name="llm_fallback",
+                    constraint_id="fact_verifier.llm_advisory_only",
+                    details={
+                        "llm_verdict": llm_result.get("verdict"),
+                        "llm_confidence": llm_result.get("confidence"),
+                        "llm_reasoning": llm_result.get("reasoning"),
+                        "advisory_only": True,
+                    }
+                )
+                advisory_checks.append(llm_advisory)
+
+        developer_fields: Dict[str, Any] = {
+            "methods_used": methods_used,
+            "deterministic_confidence": round(confidence, 3),
+            "deterministic_verdict": verdict,
+            "evidence": reasoning,
             "citations": [
                 {
                     "sentence": c.sentence,
                     "relevance_score": round(c.relevance_score, 3),
                     "support_type": c.support_type
                 }
-                for c in citations[:5]  # Top 5 citations
+                for c in citations[:5]
             ],
-            "methods_used": methods_used,
-            "scores": {k: round(v, 3) for k, v in scores.items()}
+            "scores": {k: round(v, 3) for k, v in scores.items()},
         }
+        if advisory_checks:
+            developer_fields["advisory_checks"] = advisory_checks
+
+        # Map deterministic verdict to DiagnosticResult
+        if verdict == "SUPPORTED":
+            evidence = {"citations": developer_fields["citations"], "reasoning": reasoning}
+            return DiagnosticResult.verified(
+                "Fact claim verified by deterministic analysis",
+                developer_fields,
+                evidence,
+            )
+
+        if verdict == "REFUTED":
+            developer_fields["constraint_id"] = "fact_verifier.deterministic_refuted"
+            evidence = {"citations": developer_fields["citations"], "reasoning": reasoning}
+            return DiagnosticResult.verified(
+                "Fact claim deterministically refuted — negation conflict detected",
+                developer_fields,
+                evidence,
+            )
+
+        developer_fields["constraint_id"] = "fact_verifier.inconclusive"
+        return DiagnosticResult.unverifiable(
+            "Fact claim could not be deterministically verified",
+            developer_fields,
+        )
     
     # =========================================================================
     # Sentence Segmentation
@@ -601,22 +626,18 @@ class BatchFactVerifier:
         
         for claim in claims:
             result = self.verifier.verify_fact(claim, context, provider)
-            results.append({
-                "claim": claim,
-                **result
-            })
+            d = result.to_dict()
+            d["claim"] = claim
+            results.append(d)
         
-        # Summary statistics
-        verdicts = [r["verdict"] for r in results]
+        statuses = [r["status"] for r in results]
         
         return {
             "results": results,
             "summary": {
                 "total": len(claims),
-                "supported": verdicts.count("SUPPORTED"),
-                "refuted": verdicts.count("REFUTED"),
-                "neutral": verdicts.count("NEUTRAL"),
-                "insufficient": verdicts.count("INSUFFICIENT_EVIDENCE"),
-                "average_confidence": sum(r["confidence"] for r in results) / len(results) if results else 0
+                "verified": statuses.count("VERIFIED"),
+                "unverifiable": statuses.count("UNVERIFIABLE"),
+                "blocked": statuses.count("BLOCKED"),
             }
         }

--- a/tests/security/test_hybrid_advisory_only.py
+++ b/tests/security/test_hybrid_advisory_only.py
@@ -467,13 +467,14 @@ class TestFactVerifierAdvisoryOnly:
         assert result.is_verified
         assert result.proof_ref is not None
 
-    def test_refuted_verified(self):
-        """REFUTED (negation conflict) → VERIFIED with proof_ref."""
+    def test_refuted_blocked(self):
+        """REFUTED (negation conflict) → BLOCKED."""
         result = self.verifier.verify_fact(
             "The policy covers water damage",
             "The policy does not cover water damage"
         )
-        assert result.is_verified
+        assert not result.is_verified
+        assert result.status.value == "BLOCKED"
         assert result.developer_fields["deterministic_verdict"] == "REFUTED"
 
     def test_neutral_unverifiable(self):

--- a/tests/security/test_hybrid_advisory_only.py
+++ b/tests/security/test_hybrid_advisory_only.py
@@ -535,13 +535,42 @@ class TestFactVerifierLLMAdvisoryOnly:
     def test_llm_does_not_change_verdict(self):
         """LLM advisory is separate — verdict stays deterministic."""
         verifier = FactVerifier(use_llm_fallback=True)
-        # Low-confidence claim will trigger LLM path
         result = verifier.verify_fact(
             "Random unrelated claim",
             "Completely different topic here",
             provider="dummy",
         )
-        # Even with provider set, LLM result is advisory only
         assert hasattr(result, "status")
-        # The deterministic verdict is stored in developer_fields
         assert "deterministic_verdict" in result.developer_fields
+
+    def test_llm_advisory_check_populated(self, monkeypatch):
+        """When LLM returns a result, advisory_checks are populated."""
+        verifier = FactVerifier(use_llm_fallback=True)
+
+        def mock_llm(claim, context, provider):
+            return {"verdict": "SUPPORTED", "confidence": 0.85, "reasoning": "Mock LLM analysis"}
+
+        monkeypatch.setattr(verifier, "_llm_fallback", mock_llm)
+        result = verifier.verify_fact(
+            "Random unrelated claim",
+            "Completely different topic here",
+            provider="dummy",
+        )
+        checks = result.advisory_checks
+        assert len(checks) >= 1
+        llm_check = [c for c in checks if c.name == "llm_fallback"]
+        assert len(llm_check) == 1
+        assert llm_check[0].advisory_only
+        assert llm_check[0].details["llm_verdict"] == "SUPPORTED"
+
+    def test_pipeline_exception_returns_blocked(self, monkeypatch):
+        """Exception in deterministic pipeline → BLOCKED."""
+        verifier = FactVerifier(use_llm_fallback=False)
+
+        def crash(*args, **kwargs):
+            raise RuntimeError("Something broke")
+
+        monkeypatch.setattr(verifier, "_segment_sentences", crash)
+        result = verifier.verify_fact("claim", "context")
+        assert result.status.value == "BLOCKED"
+        assert result.constraint_id == "fact_verifier.execution_error"

--- a/tests/security/test_hybrid_advisory_only.py
+++ b/tests/security/test_hybrid_advisory_only.py
@@ -6,6 +6,7 @@ from qwed_new.core.image_verifier import ImageVerifier
 from qwed_new.core.graph_fact_verifier import GraphFactVerifier
 from qwed_new.core.reasoning_verifier import ReasoningVerifier
 from qwed_new.core.consensus_verifier import ConsensusVerifier, EngineResult, SECURE_EXECUTION_REQUIRED
+from qwed_new.core.fact_verifier import FactVerifier
 
 
 class StubVLMProvider:
@@ -449,3 +450,97 @@ class TestImageVerifierExtraCoverage:
         result = self.verifier.verify_image(b'\x89PNG\r\n\x1a\n' + b'A' * 100, "some semantic claim")
         assert not result.is_verified
         assert result.status.value == "UNVERIFIABLE"
+
+
+# ========================================================================
+# FactVerifier — advisory-only tests (#259, #133)
+# ========================================================================
+
+class TestFactVerifierAdvisoryOnly:
+
+    def setup_method(self):
+        self.verifier = FactVerifier(use_llm_fallback=False)
+
+    def test_supported_verified(self):
+        """Deterministic SUPPORTED → VERIFIED with proof_ref."""
+        result = self.verifier.verify_fact("The sky is blue", "The sky is blue today")
+        assert result.is_verified
+        assert result.proof_ref is not None
+
+    def test_refuted_verified(self):
+        """REFUTED (negation conflict) → VERIFIED with proof_ref."""
+        result = self.verifier.verify_fact(
+            "The policy covers water damage",
+            "The policy does not cover water damage"
+        )
+        assert result.is_verified
+        assert result.developer_fields["deterministic_verdict"] == "REFUTED"
+
+    def test_neutral_unverifiable(self):
+        """NEUTRAL → UNVERIFIABLE."""
+        result = self.verifier.verify_fact(
+            "Quantum physics is complex",
+            "The weather is nice today"
+        )
+        assert not result.is_verified
+        assert result.status.value == "UNVERIFIABLE"
+
+    def test_empty_input_unverifiable(self):
+        """Empty claim → UNVERIFIABLE."""
+        result = self.verifier.verify_fact("", "context")
+        assert not result.is_verified
+        assert result.constraint_id == "fact_verifier.empty_input"
+
+    def test_insufficient_evidence_unverifiable(self):
+        """Low aggregate → UNVERIFIABLE."""
+        result = self.verifier.verify_fact(
+            "Unrelated claim about nothing",
+            "Completely different context here"
+        )
+        assert not result.is_verified
+
+    def test_methods_used_structured(self):
+        """methods_used contains structured entries with advisory_only flag."""
+        result = self.verifier.verify_fact("The sky is blue", "The sky is blue today")
+        methods = result.developer_fields["methods_used"]
+        assert len(methods) >= 4
+        for m in methods:
+            assert "name" in m
+            assert "advisory_only" in m
+
+    def test_deterministic_confidence_in_fields(self):
+        """Confidence is in developer_fields, not in status."""
+        result = self.verifier.verify_fact("The sky is blue", "The sky is blue today")
+        assert "deterministic_confidence" in result.developer_fields
+        # No confidence field at top level
+        d = result.to_dict()
+        assert "confidence" not in d.get("developer_fields", {})
+
+    def test_evidence_in_developer_fields(self):
+        """Deterministic reasoning is in developer_fields evidence."""
+        result = self.verifier.verify_fact("The sky is blue", "The sky is blue today")
+        assert "evidence" in result.developer_fields
+
+    def test_citations_included(self):
+        """Citations are included in developer_fields."""
+        result = self.verifier.verify_fact("The sky is blue", "The sky is blue today")
+        assert len(result.developer_fields.get("citations", [])) > 0
+
+
+class TestFactVerifierLLMAdvisoryOnly:
+
+    """LLM fallback never overwrites deterministic verdict (#133)."""
+
+    def test_llm_does_not_change_verdict(self):
+        """LLM advisory is separate — verdict stays deterministic."""
+        verifier = FactVerifier(use_llm_fallback=True)
+        # Low-confidence claim will trigger LLM path
+        result = verifier.verify_fact(
+            "Random unrelated claim",
+            "Completely different topic here",
+            provider="dummy",
+        )
+        # Even with provider set, LLM result is advisory only
+        assert hasattr(result, "status")
+        # The deterministic verdict is stored in developer_fields
+        assert "deterministic_verdict" in result.developer_fields

--- a/tests/test_api_exceptions.py
+++ b/tests/test_api_exceptions.py
@@ -84,6 +84,45 @@ def test_verify_fact_exception_handling():
         assert data["error"] == "Internal verification error"
         assert "API_KEY_LEAK" not in str(data)
 
+def test_verify_fact_success_path():
+    """
+    Test that verify_fact success returns DiagnosticResult via to_dict().
+    """
+    from qwed_new.core.diagnostics import DiagnosticResult, AdvisoryCheck, DiagnosticStatus
+    mock_result = DiagnosticResult(
+        status=DiagnosticStatus.VERIFIED,
+        agent_message="Test verified",
+        developer_fields={
+            "methods_used": [{"name": "heuristic", "advisory_only": False}],
+            "advisory_checks": [
+                AdvisoryCheck(
+                    name="llm_fallback",
+                    details={"llm_verdict": "SUPPORTED", "confidence": 0.85},
+                )
+            ],
+        },
+        proof_ref="test_ref",
+    )
+    with patch('qwed_new.core.fact_verifier.FactVerifier.verify_fact', return_value=mock_result):
+        response = client.post(
+            "/verify/fact",
+            json={
+                "claim": "Test claim",
+                "context": "Test context"
+            }
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "VERIFIED"
+        assert data["proof_ref"] == "test_ref"
+        assert data["is_authoritative"] is True
+        assert "developer_fields" in data
+        checks = data["developer_fields"]["advisory_checks"]
+        assert len(checks) == 1
+        assert checks[0]["name"] == "llm_fallback"
+        assert checks[0]["advisory_only"] is True
+
 def test_verify_code_exception_handling():
     """
     Test that verify_code catches internal errors and returns a sanitized message.

--- a/tests/test_redos_fixes.py
+++ b/tests/test_redos_fixes.py
@@ -17,7 +17,9 @@ def test_fact_verifier_bounded_regex():
     result = verifier.verify_fact(claim, context)
     
     # Verify entity matching logic still works
-    assert "2024" in result["reasoning"] or result["scores"]["entity_match"] > 0.5
+    entity_match = result.developer_fields["scores"]["entity_match"]
+    evidence = result.developer_fields.get("evidence", "")
+    assert "2024" in evidence or entity_match > 0.5
     
     # 2. Long Input - Should be truncated/handled safely
     # Create valid sentence structure but very long
@@ -27,7 +29,7 @@ def test_fact_verifier_bounded_regex():
     # This triggers _segment_sentences with the new safe_pattern
     result = verifier.verify_fact("test", long_context)
     # Should run without timeout/error
-    assert result["verdict"] is not None
+    assert result.status is not None
 
 def test_image_verifier_bounded_regex():
     """


### PR DESCRIPTION
Closes #259
Fixes #133

Migrates `FactVerifier` to return `DiagnosticResult` with advisory-only LLM fallback.

### Changes

**Bug #133 fix — LLM fallback no longer overwrites deterministic verdict**
- LLM result goes into `advisory_checks` only, never changes `deterministic_verdict`
- `SUPPORTED`/`REFUTED` → `VERIFIED` with `proof_ref`
- `NEUTRAL`/`INSUFFICIENT_EVIDENCE` → `UNVERIFIABLE`
- Empty input → `UNVERIFIABLE` with `constraint_id: fact_verifier.empty_input`

**`methods_used` promoted to structured format**
```python
# Before
methods_used: ["semantic_similarity", "keyword_overlap", "llm_fallback"]

# After
methods_used: [
    {"name": "semantic_similarity", "advisory_only": False},
    {"name": "keyword_overlap", "advisory_only": False},
    {"name": "llm_fallback", "advisory_only": True},
]
```

**Confidence moved to `developer_fields`** (never verdict-deciding)
- `developer_fields.deterministic_confidence` — deterministic score
- LLM confidence in `advisory_checks.llm_confidence` — advisory only

**Evidence split**
- Deterministic evidence → `developer_fields.evidence`
- LLM analysis → `advisory_checks.llm_reasoning`
- Agent-facing → `agent_message` (no raw LLM output)

**`BatchFactVerifier`** updated to use `to_dict()` with status-based summary counts (`verified`/`unverifiable`/`blocked`).

### Status mapping

| Deterministic verdict | DiagnosticResult |
|----------------------|-----------------|
| SUPPORTED | VERIFIED with proof_ref |
| REFUTED (negation) | VERIFIED with proof_ref |
| NEUTRAL | UNVERIFIABLE |
| INSUFFICIENT_EVIDENCE | UNVERIFIABLE |
| Empty input | UNVERIFIABLE |

### Tests
- 10 new regression tests in `test_hybrid_advisory_only.py`
  - `TestFactVerifierAdvisoryOnly` (9 tests) — SUPPORTED, REFUTED, NEUTRAL, empty, insufficient, methods structure, confidence, evidence, citations
  - `TestFactVerifierLLMAdvisoryOnly` (1 test) — LLM does not change verdict
- 1522 total passed, 102 skipped (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fact verification now returns a standardized diagnostic format with clear statuses (verified, blocked, unverifiable), plus structured evidence/citations/method details.
  * Batch verification summaries now count by diagnostic status (verified/unverifiable/blocked) for clearer reporting.

* **Bug Fixes**
  * LLM fallback is advisory-only and no longer overwrites deterministic outcomes.
  * Empty/neutral/inconclusive claims are consistently marked as unverifiable.
  * Long-input cases have improved verification handling.

* **Tests**
  * Updated and expanded coverage for the advisory-only fallback behavior and result structure changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Make fact verification fail closed and keep LLM results advisory

### What Changed
- Fact verification now returns structured statuses: verified claims are marked `VERIFIED`, refuted claims are `BLOCKED`, and inconclusive claims are `UNVERIFIABLE`
- LLM fallback results are recorded as advisory information and can no longer change the deterministic verdict
- Verification failures are reported as `BLOCKED` instead of raising unhandled errors
- API and batch fact-verification responses now expose the structured result and status-based summaries
- Added regression coverage for refuted claims, advisory LLM results, empty or inconclusive input, pipeline failures, and long inputs

### Impact
`✅ Fewer incorrect verified claims from LLM fallback`
`✅ Fail-closed handling for refuted claims and verification errors`
`✅ Clearer fact-verification statuses and batch summaries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
