### PR TITLE
fix(api): migrate all /verify/* endpoints to return DiagnosticResult (#264)

### DIFF
--- a/SECURITY_AUDIT_REPORT.md
+++ b/SECURITY_AUDIT_REPORT.md
@@ -1,0 +1,630 @@
+# QWED Verification Framework — Adversarial Security Architecture Audit
+
+**Auditor:** Principal Security Researcher / Formal Methods Reviewer  
+**Date:** 2026-07-29  
+**Scope:** Architectural trust guarantees, verification bypass, trust forgery, fail-open paths  
+**Methodology:** Red-team analysis of implementation as source of truth  
+**Prior Work Reviewed:** GitHub issues #162–#259, PRs #161–#261 (to avoid duplication)
+
+---
+
+## Executive Summary
+
+The QWED verification framework has a well-designed `DiagnosticResult` model with structurally enforced invariants (VERIFIED requires `proof_ref`, non-VERIFIED forbids it). However, **the majority of verification endpoints bypass this model entirely**, returning raw dicts where `status: "VERIFIED"` is set without cryptographic proof artifacts. The `enforce_trust_decision` gate exists but is called in advisory-only mode (`require_attestation=False`) on the main code path. Several engines emit VERIFIED based on heuristic/probabilistic methods rather than deterministic proof. These are architectural failures that can violate the core verification thesis.
+
+**Critical findings: 3 | High: 5 | Medium: 4 | Low: 2 | Informational: 2**
+
+---
+
+## FINDING 1: Consensus Verifier Emits VERIFIED Without proof_ref
+
+**Severity:** Critical  
+**Category:** Trust Boundary Violation / DiagnosticResult Invariant Violation  
+**Affected Components:** `consensus_verifier.py`, `api/main.py` (`/verify/consensus`)
+
+### Attack Scenario
+An attacker submits a query to `/verify/consensus` with `verification_mode: "single"`. The SymPy engine evaluates the expression and returns `is_correct: True`. The consensus verifier sets `diagnostic_status = "VERIFIED"` and `confidence = 1.0`. The API endpoint returns this to the caller with `agreement_status: "unanimous"`. The caller treats this as authoritative verification.
+
+### Why It Works
+`_calculate_consensus` in `consensus_verifier.py` (line 789):
+```python
+diagnostic_status = "VERIFIED" if (status == "unanimous" and not blocked) else "UNVERIFIABLE"
+```
+This sets a string `"VERIFIED"` based on engine agreement, but:
+1. The `ConsensusResult` dataclass has no `proof_ref` field — it's not a `DiagnosticResult`.
+2. The "VERIFIED" is based on `is_correct` from `verify_math`, which is a **numerical tolerance comparison** (`diff <= tolerance_decimal`), not a formal proof.
+3. The API endpoint at `/verify/consensus` returns the result without routing through `enforce_trust_decision`.
+4. The `is_verified` field in `VerificationLog` is set as `result.confidence >= request.min_confidence` — a confidence threshold, not proof presence.
+
+### Potential Impact
+An attacker can obtain "VERIFIED" consensus results that are based on floating-point tolerance comparison rather than formal proof. These results carry no `proof_ref` and cannot be cryptographically validated downstream. The trust guarantee is forged.
+
+### Recommended Fix
+1. `ConsensusResult` must either be a `DiagnosticResult` or carry a `proof_ref` that is `None` unless a proof-bearing engine produced it.
+2. `diagnostic_status = "VERIFIED"` must require `proof_ref is not None` — same invariant as `DiagnosticResult.__post_init__`.
+3. The `/verify/consensus` endpoint must route through `enforce_trust_decision`.
+4. Tolerance-based math comparison (`is_correct`) must not produce VERIFIED — it should produce UNVERIFIABLE with advisory_checks, or the math engine must be migrated to produce a proof artifact (convergence trace, symbolic simplification trace).
+
+### Architectural Impact
+**Can this violate the core verification thesis? YES** — VERIFIED is emitted without proof, based on numerical tolerance.
+
+---
+
+## FINDING 2: API Endpoints Return Raw Dicts with `status: "VERIFIED"` Bypassing DiagnosticResult
+
+**Severity:** Critical  
+**Category:** Trust Boundary Violation / State Machine Audit  
+**Affected Components:** `api/main.py` (all `/verify/*` endpoints), `core/verifier.py`, `core/batch.py`
+
+### Attack Scenario
+An attacker calls `/verify/math` with `expression: "2+2"`. The endpoint parses the expression, simplifies it with SymPy, evaluates to `4.0`, and returns:
+```json
+{"is_valid": true, "value": 4.0, "simplified": "4", "original": "2 + 2"}
+```
+The `is_verified` field in the audit log is set to `true` based on `result.get("is_valid", False)`. No `DiagnosticResult` is constructed. No `proof_ref` exists. No attestation is issued or validated.
+
+### Why It Works
+Every API endpoint in `main.py` returns raw dicts from verifiers:
+- `/verify/math` (line 590): `is_verified=result.get("is_valid", False)` — string-keyed dict check
+- `/verify/sql` (line 646): `is_verified=result.get("is_valid", False)`
+- `/verify/code` (line 424): `is_verified=result.get("is_safe", False)`
+- `/verify/natural_language` (line 218): `is_verified=result.get("status") == "VERIFIED"`
+- `/verify/logic` (line 258): `is_verified=(result["status"] == "SAT" or result["status"] == "UNSAT")`
+
+None of these endpoints:
+1. Construct a `DiagnosticResult` (which would enforce the proof_ref invariant)
+2. Call `enforce_trust_decision` (the trust boundary gate)
+3. Issue or validate attestations
+4. Check for `proof_ref` presence
+
+The `VerificationEngine` in `verifier.py` returns dicts with `"status": "VERIFIED" if is_correct else "CORRECTION_NEEDED"` (line 157) — this is tolerance-based comparison, not proof. The `from_legacy_dict` guard exists but is never invoked for these endpoints.
+
+### Potential Impact
+Every verification endpoint can return "VERIFIED" (or equivalent `is_valid: true`) without any proof artifact. Downstream consumers checking `is_verified` in the audit log or the response dict will trust these results. The `DiagnosticResult` invariant enforcement is completely bypassed.
+
+### Recommended Fix
+1. Every `/verify/*` endpoint must construct a `DiagnosticResult` from the engine output.
+2. Every endpoint must call `enforce_trust_decision(result, require_attestation=True, query=...)` before returning.
+3. The `VerificationLog.is_verified` field must be set based on `result.is_authoritative` (proof_ref presence), not string comparison.
+4. Engines not yet migrated to `DiagnosticResult` (open issues #252–#256) must use `from_legacy_dict` which correctly refuses to produce VERIFIED without proof.
+
+### Architectural Impact
+**Can this violate the core verification thesis? YES** — VERIFIED is emitted and consumed without proof across all primary endpoints.
+
+---
+
+## FINDING 3: Control Plane Trust Enforcement Is Advisory-Only (Fail-Open)
+
+**Severity:** Critical  
+**Category:** Fail-Closed Verification / Trust Boundary Violation  
+**Affected Components:** `core/control_plane.py`
+
+### Attack Scenario
+An attacker calls `/verify/natural_language`. The control plane translates the query, runs `verify_math`, gets `status: "VERIFIED"`. The trust boundary enforcement code runs:
+```python
+enforced = enforce_trust_decision(
+    dr,
+    require_attestation=False,  # ← ADVISORY MODE
+    query=query,
+)
+```
+Because `require_attestation=False`, the function returns the original result even if no attestation token exists. The response includes `trust_enforced: "VERIFIED"` and `attestation_policy: "advisory"`. The caller sees "VERIFIED" and trusts it.
+
+### Why It Works
+In `control_plane.py` (line 142):
+```python
+enforced = enforce_trust_decision(
+    dr,
+    require_attestation=False,
+    query=query,
+)
+```
+The comment says "Advisory mode (require_attestation=False) until engines are fully migrated to DiagnosticResult." But this means:
+1. VERIFIED results pass through without attestation validation.
+2. No attestation token is issued or required.
+3. The `trust_enforced` field in the response is set to the enforced status, but since enforcement is advisory, it's always the original status.
+4. If `from_legacy_dict` raises (which it does for legacy VERIFIED results), the code catches the exception and sets `trust_enforced: "not_applicable"` — but still returns the original VERIFIED result to the caller.
+
+### Potential Impact
+The trust boundary gate exists but is effectively disabled. Any VERIFIED result from the math engine passes through to the caller without attestation. The "enforcement" is cosmetic.
+
+### Recommended Fix
+1. Set `require_attestation=True` for all production paths.
+2. Issue attestations via `create_verification_attestation` for every VERIFIED result.
+3. If attestation issuance fails (BLOCKED/UNVERIFIABLE), the result must be downgraded to UNVERIFIABLE — not returned as VERIFIED.
+4. The `except ValueError` block that catches `from_legacy_dict` failures must not return the original VERIFIED result — it must return UNVERIFIABLE.
+
+### Architectural Impact
+**Can this violate the core verification thesis? YES** — the trust gate is disabled, making VERIFIED results non-authoritative by default.
+
+---
+
+## FINDING 4: FactVerifier Emits VERIFIED for TF-IDF Heuristic Similarity
+
+**Severity:** High  
+**Category:** DiagnosticResult Invariant Violation / Advisory-Only Engine Emitting VERIFIED  
+**Affected Components:** `core/fact_verifier.py`
+
+### Attack Scenario
+An attacker submits a claim "The sky is blue" with context "The sky appears blue during clear weather." The FactVerifier computes:
+- `semantic_score` = TF-IDF cosine similarity (0.85)
+- `keyword_score` = keyword overlap (0.75)
+- `entity_match` = entity matching (1.0)
+- `has_negation` = False
+- `aggregate` = 0.85 * 0.3 + 0.75 * 0.3 + 1.0 * 0.2 + 0.2 = 0.78
+
+Since `aggregate >= 0.7` and support citations >= refute citations, `verdict = "SUPPORTED"`, `confidence = 0.78`. The verifier returns `DiagnosticResult.verified(...)` with `evidence = {"citations": ..., "reasoning": ...}`.
+
+The `proof_ref` is computed as `compute_proof_ref(evidence)` where evidence is `{"citations": [...], "reasoning": "..."}`. This is a hash of heuristic analysis output, not a cryptographic proof of factual correctness.
+
+### Why It Works
+In `fact_verifier.py` (line 223-229):
+```python
+if verdict == "SUPPORTED":
+    evidence = {"citations": developer_fields["citations"], "reasoning": reasoning}
+    return DiagnosticResult.verified(
+        "Fact claim verified by deterministic analysis",
+        developer_fields,
+        evidence,
+    )
+```
+The "SUPPORTED" verdict is based on:
+1. TF-IDF cosine similarity — a lexical overlap metric, not semantic proof
+2. Keyword overlap — set intersection, not meaning
+3. Entity matching — regex-extracted numbers/names
+4. Negation detection — word-list matching
+
+These are **heuristic methods**. The `evidence` dict contains citations and reasoning strings, but hashing heuristic output produces a `proof_ref` that binds to the heuristic analysis, not to a proof of factual correctness. Two different claims with similar word distributions could produce the same "SUPPORTED" verdict.
+
+### Potential Impact
+An attacker can craft claims with high keyword overlap and entity match scores that get VERIFIED despite being factually incorrect. The `proof_ref` provides false assurance — it proves the heuristic ran, not that the claim is true.
+
+### Recommended Fix
+1. FactVerifier should be classified as **advisory-only** (like Image, Graph, Reasoning engines per PR #260).
+2. Replace `DiagnosticResult.verified(...)` with `DiagnosticResult.unverifiable(...)` with `advisory_checks` containing the heuristic analysis.
+3. The `evidence` dict should not be hashed into a `proof_ref` for heuristic methods.
+
+### Architectural Impact
+**Can this violate the core verification thesis? YES** — VERIFIED is emitted for heuristic analysis, not deterministic proof.
+
+---
+
+## FINDING 5: AgentStateGuard Emits VERIFIED with String "proof" Instead of proof_ref
+
+**Severity:** High  
+**Category:** Trust Boundary Violation / DiagnosticResult Invariant Violation  
+**Affected Components:** `guards/agent_state_guard.py`
+
+### Attack Scenario
+An agent submits a state payload that matches the configured JSON schema. The `AgentStateGuard.verify_state_payload` returns:
+```python
+{
+    "verified": True,
+    "status": "VERIFIED",
+    "proof": "State payload matched the configured strict schema.",
+    "normalized_state": self._canonicalize(state_data),
+}
+```
+A downstream consumer checks `result["verified"]` or `result["status"] == "VERIFIED"` and admits the state transition. No `proof_ref` exists. The "proof" is a human-readable string, not a cryptographic hash.
+
+### Why It Works
+`AgentStateGuard` returns plain dicts, not `DiagnosticResult` objects. The `"proof"` field is a descriptive string ("State payload matched the configured strict schema."), not a `sha256:...` proof reference. The `"verified": True` flag is set based on schema validation passing, but:
+1. Schema validation is structural, not semantic — it checks types and required fields, not correctness.
+2. No `proof_ref` is computed from the normalized state.
+3. No attestation is issued.
+4. The dict format bypasses `DiagnosticResult.__post_init__` invariant enforcement.
+
+### Potential Impact
+An attacker can submit a state payload that structurally matches the schema but is semantically invalid. The guard returns VERIFIED, and downstream consumers trust it. The "proof" string provides no cryptographic binding to the verified state.
+
+### Recommended Fix
+1. Return `DiagnosticResult` instead of raw dicts.
+2. Compute `proof_ref = compute_proof_ref(normalized_state)` for VERIFIED results.
+3. The "proof" string should be in `developer_fields`, not a top-level field masquerading as cryptographic proof.
+
+### Architectural Impact
+**Can this violate the core verification thesis? YES** — VERIFIED is emitted without proof_ref, with a string "proof" that is not cryptographic.
+
+---
+
+## FINDING 6: Consensus `_verify_with_code` Emits VERIFIED for Successful Code Execution
+
+**Severity:** High  
+**Category:** Trust Boundary Violation / Proof Integrity  
+**Affected Components:** `consensus_verifier.py` (`_verify_with_code`)
+
+### Attack Scenario
+An attacker submits a query to consensus verification with `mode: "high"`. The Python engine generates code `result = 2+2`, executes it in Docker, gets `output = 4`. The engine returns:
+```python
+EngineResult(
+    engine_name="Python",
+    method="code_execution",
+    result=output,
+    confidence=0.99,
+    success=True,
+    status="VERIFIED",  # ← Based on execution success, not proof
+)
+```
+The consensus calculator sees unanimous agreement and sets `diagnostic_status = "VERIFIED"`.
+
+### Why It Works
+In `consensus_verifier.py` (line 641-646):
+```python
+return EngineResult(
+    engine_name="Python", method="code_execution",
+    result=output, confidence=0.99,
+    latency_ms=(time.time() - start) * 1000, success=True,
+    status="VERIFIED",
+)
+```
+Code execution success means the code ran without errors and produced output — it does **not** prove the output is correct. Running `result = 2+2` and getting `4` is empirical testing, not formal verification. The code could have a bug that happens to produce the expected output for the test input but fails for other inputs.
+
+### Potential Impact
+An attacker can get "VERIFIED" consensus results based on code execution, which is empirical testing, not proof. This is especially dangerous in "maximum" mode where code execution is one of multiple engines — its "VERIFIED" vote contributes to consensus.
+
+### Recommended Fix
+1. `_verify_with_code` should return `status="UNVERIFIABLE"` with `advisory_checks` containing the execution result.
+2. Code execution is advisory — it can disprove (by crashing) but cannot prove correctness.
+3. Only formal methods (Z3, symbolic execution with completeness proof) should emit VERIFIED.
+
+### Architectural Impact
+**Can this violate the core verification thesis? YES** — empirical code execution is treated as proof.
+
+---
+
+## FINDING 7: Attestation Verification Only Supports Self-Issued Tokens (Single-Node Trust)
+
+**Severity:** High  
+**Category:** Attestation Integrity / Cryptographic Hygiene  
+**Affected Components:** `core/attestation.py` (`verify_attestation`)
+
+### Attack Scenario
+A distributed deployment has Node A issue an attestation. Node B receives the attestation token and calls `verify_attestation`. Since the issuer DID doesn't match Node B's `self.issuer_did`, the code reaches:
+```python
+return False, None, "External issuer key resolution not implemented"
+```
+The attestation is rejected. Node B cannot verify any attestation issued by Node A.
+
+### Why It Works
+In `attestation.py` (line 411-413):
+```python
+else:
+    # Would need to resolve DID and get public key
+    return False, None, "External issuer key resolution not implemented"
+```
+The attestation system only supports self-issued tokens. The `trusted_issuers` parameter accepts a list of DIDs, but there's no mechanism to resolve a DID to a public key. This means:
+1. In distributed deployments, attestations issued by one node cannot be verified by another.
+2. The trust model is fundamentally single-node.
+3. After a process restart (ephemeral key policy), all previously issued attestations become unverifiable — even by the same node.
+
+### Potential Impact
+In any multi-node deployment, the attestation system is non-functional. Nodes cannot verify each other's attestations, making `enforce_trust_decision` useless for cross-node trust. If `require_attestation=True` were enabled, all cross-node verification would fail-closed (BLOCKED), which is safe but non-functional.
+
+### Recommended Fix
+1. Implement DID resolution to retrieve public keys for external issuers.
+2. Support persistent key storage (not just "ephemeral") for production deployments.
+3. Document that the current implementation is single-node only and `enforce_trust_decision` with `require_attestation=True` will fail-closed in distributed mode.
+
+### Architectural Impact
+**Can this violate the core verification thesis? NO** — it fails closed, but it makes the trust system non-functional in distributed deployments.
+
+---
+
+## FINDING 8: Attestation `jti` and `iat` Use Non-Deterministic Defaults (Issue #250)
+
+**Severity:** High  
+**Category:** Determinism / Attestation Integrity  
+**Affected Components:** `core/attestation.py` (`create_attestation`)
+
+### Attack Scenario
+An auditor attempts to reproduce an attestation by re-running the same verification with the same inputs. The new attestation has a different `jti` (UUID) and `iat` (timestamp), producing a different JWT. The auditor cannot verify that the original attestation was deterministically issued from the verification result.
+
+### Why It Works
+In `attestation.py` (lines 282-284):
+```python
+now = issued_at if issued_at is not None else int(time.time())
+expiry = now + (self.validity_days * 24 * 60 * 60)
+attestation_id = jti if jti is not None else f"att_{uuid.uuid4().hex[:12]}"
+```
+While `issued_at` and `jti` are injectable for determinism, the defaults use `time.time()` and `uuid.uuid4()`. This means:
+1. Two identical verification results produce different attestations.
+2. The attestation cannot be reproduced from the verification result alone.
+3. The `proof_hash` in the attestation is bound to the proof data, but the attestation itself is non-deterministic.
+
+### Potential Impact
+Non-deterministic attestations break reproducibility guarantees. An attacker could argue that a given attestation was fabricated because it cannot be reproduced. Audit trails become non-verifiable.
+
+### Recommended Fix
+This is already tracked in Issue #250. The fix should:
+1. Remove `time.time()` and `uuid.uuid4()` defaults.
+2. Require `issued_at` and `jti` to be explicitly provided.
+3. Derive `jti` deterministically from the verification result hash.
+
+### Architectural Impact
+**Can this violate the core verification thesis? NO** — non-determinism affects reproducibility, not trust correctness. But it weakens auditability.
+
+---
+
+## FINDING 9: Batch Math Verification Returns `is_valid: True` Without Proof
+
+**Severity:** Medium  
+**Category:** Trust Boundary Violation / Proof Integrity  
+**Affected Components:** `core/batch.py` (`_verify_item`)
+
+### Attack Scenario
+An attacker submits a batch with `{"query": "x**2 + 2*x + 1 = (x+1)**2", "type": "math"}`. The batch processor:
+```python
+left, right = expression.split("=", 1)
+left_expr = safe_parse_expr(left)
+right_expr = safe_parse_expr(right)
+diff = simplify(left_expr - right_expr)
+is_valid = diff == 0
+return {"is_valid": is_valid, "type": "math", "message": "Identity verified"}
+```
+Returns `is_valid: True` based on SymPy simplification. No `DiagnosticResult`, no `proof_ref`, no attestation.
+
+### Why It Works
+The batch math path (line 222-237) directly uses `simplify(left - right) == 0` to determine validity. While SymPy simplification is deterministic, the result is returned as a raw dict without:
+1. `DiagnosticResult` construction
+2. `proof_ref` computation
+3. `enforce_trust_decision` validation
+4. Attestation issuance
+
+### Potential Impact
+Batch verification results carry the same trust as individual verification but without any of the trust boundary enforcement. An attacker can use batch endpoints to obtain "verified" results that bypass the (already advisory) trust gate in the control plane.
+
+### Recommended Fix
+1. Route batch math verification through `DiagnosticResult.verified()` with evidence.
+2. Call `enforce_trust_decision` on each batch item result.
+3. Set `is_verified` in batch results based on `proof_ref` presence.
+
+### Architectural Impact
+**Can this violate the core verification thesis? YES** — VERIFIED (as `is_valid: True`) is emitted without proof in batch mode.
+
+---
+
+## FINDING 10: `verify_attestation` Decodes Payload Before Signature Verification (Information Leakage)
+
+**Severity:** Medium  
+**Category:** Cryptographic Hygiene / Attestation Integrity  
+**Affected Components:** `core/attestation.py` (`verify_attestation`)
+
+### Attack Scenario
+An attacker sends a malformed JWT with a valid structure but invalid signature. The `verify_attestation` function:
+1. Splits the JWT and extracts the payload segment
+2. Base64-decodes the payload
+3. Parses it as JSON
+4. Extracts the `iss` claim
+5. Checks if `iss` is in `trusted_issuers`
+6. Only then attempts cryptographic verification
+
+The attacker can observe different error messages for "Untrusted issuer" vs "Invalid token" vs "Token too large", enabling issuer enumeration and format probing.
+
+### Why It Works
+In `attestation.py` (lines 381-413):
+```python
+# Decode without verification first to get issuer.
+unverified = json.loads(payload_data)
+issuer = unverified.get("iss")
+if issuer not in trusted_issuers:
+    return False, None, f"Untrusted issuer: {safe_issuer}"
+# ... then verify signature
+claims = jwt.decode(jwt_token, public_key, algorithms=["ES256"], ...)
+```
+The `iss` claim is checked before signature verification. While the claims aren't "trusted" until after signature verification, the error message difference reveals whether the `iss` value matches a trusted issuer.
+
+### Potential Impact
+An attacker can enumerate trusted issuer DIDs by observing error messages. This is information leakage, not direct trust forgery, but it aids reconnaissance.
+
+### Recommended Fix
+1. Perform signature verification first, then check `iss` against `trusted_issuers`.
+2. Return a generic "Invalid token" error for all failures (untrusted issuer, invalid signature, expired, etc.).
+3. Log detailed errors server-side only.
+
+### Architectural Impact
+**Can this violate the core verification thesis? NO** — information leakage, not trust forgery.
+
+---
+
+## FINDING 11: AgentStateGuard Canonicalization Lacks Unicode Normalization
+
+**Severity:** Medium  
+**Category:** Canonicalization  
+**Affected Components:** `guards/agent_state_guard.py` (`_canonicalize`)
+
+### Attack Scenario
+An attacker submits two state payloads:
+1. `{"name": "café", "value": 1}` (NFC form: `é` = U+00E9)
+2. `{"name": "café", "value": 1}` (NFD form: `é` = U+0065 + U+0301)
+
+Both are semantically identical, but `_canonicalize` sorts dict keys and recursively processes values without Unicode normalization. The two payloads produce different `normalized_state` outputs and different verification results if compared.
+
+### Why It Works
+In `agent_state_guard.py` (line 903-911):
+```python
+@classmethod
+def _canonicalize(cls, value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: cls._canonicalize(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [cls._canonicalize(item) for item in value]
+    return value
+```
+No `unicodedata.normalize()` is applied. String values and keys are compared as-is. Python's `sorted()` uses code-point ordering, which differs between NFC and NFD forms of the same character.
+
+### Potential Impact
+Logically equivalent state payloads with different Unicode representations can produce different verification outcomes. An attacker could exploit this to bypass transition rules by submitting NFD-encoded state that differs from the NFC-encoded current state at the byte level but is semantically identical.
+
+### Recommended Fix
+1. Apply `unicodedata.normalize("NFC", value)` to all string values and keys in `_canonicalize`.
+2. Document the normalization policy in the guard's contract.
+
+### Architectural Impact
+**Can this violate the core verification thesis? NO** — but it can create inconsistent verification states for equivalent inputs.
+
+---
+
+## FINDING 12: `enforce_trust_decision` Has TOCTOU Between Validation and Return
+
+**Severity:** Medium  
+**Category:** Time-of-Check / Time-of-Use (TOCTOU)  
+**Affected Components:** `core/diagnostics.py` (`enforce_trust_decision`)
+
+### Attack Scenario
+`enforce_trust_decision` validates the attestation token against the `result` object, then returns the original `result` object:
+```python
+validation = _validate_attestation_claims(result, token_claims, query, policy)
+if validation is not None:
+    return validation
+return result  # ← Original mutable reference returned
+```
+If the caller modifies `result` after `enforce_trust_decision` returns (e.g., changing `developer_fields`), the validated state diverges from the returned state.
+
+### Why It Works
+`DiagnosticResult` is `frozen=True`, so `status` and `proof_ref` are immutable. However, `developer_fields` is a `Dict[str, Any]` which is **mutable**. The `result.developer_fields` dict can be modified after enforcement, and the attestation token's claims (which were validated against `result.status` and `result.proof_ref`) would still appear valid but no longer match the modified result.
+
+### Potential Impact
+An attacker who can modify the `developer_fields` dict after enforcement can change the evidence associated with a VERIFIED result without invalidating the attestation. The `proof_ref` and `status` are immutable, but the developer-facing evidence can be tampered with.
+
+### Recommended Fix
+1. Deep-copy `developer_fields` before returning from `enforce_trust_decision`.
+2. Or make `developer_fields` immutable (e.g., `MappingProxyType`).
+
+### Architectural Impact
+**Can this violate the core verification thesis? NO** — `proof_ref` and `status` are immutable. But developer evidence can be tampered with post-verification.
+
+---
+
+## FINDING 13: Cache Keys for `cached_verify` Don't Include Tenant Context
+
+**Severity:** Low  
+**Category:** Trust Boundary Violation / Cache Integrity  
+**Affected Components:** `core/cache.py` (`cached_verify`, `VerificationCache._generate_key`)
+
+### Attack Scenario
+Tenant A verifies `(AND (GT x 5) (LT y 10))` and the result is cached. Tenant B submits the same DSL code. Since `cached_verify` uses `LOCAL_ONLY` mode with no tenant_id, the cache key is `hash({"dsl": "...", "vars": None})` — same for both tenants. Tenant B gets Tenant A's cached result.
+
+### Why It Works
+`cached_verify` (line 813):
+```python
+cache = get_cache(use_redis=False, mode=CacheBackendMode.LOCAL_ONLY)
+```
+This creates a global `VerificationCache` with no tenant isolation. The `_generate_key` method only uses `dsl_code` and `variables`, not tenant context. While `get_cache` supports `tenant_id` for Redis mode, the `LOCAL_ONLY` convenience wrapper doesn't pass it.
+
+### Potential Impact
+Cross-tenant cache leakage in single-process deployments using `cached_verify`. Tenant B can receive Tenant A's verification results, including potentially sensitive evidence in the result dict.
+
+### Recommended Fix
+1. `cached_verify` should accept and pass `tenant_id` to `get_cache`.
+2. Or document that `cached_verify` is for single-tenant use only.
+
+### Architectural Impact
+**Can this violate the core verification thesis? NO** — but it's a data isolation violation.
+
+---
+
+## FINDING 14: `_verify_with_stats` in Consensus Emits VERIFIED for Statistical Computation
+
+**Severity:** Low  
+**Category:** Trust Boundary Violation  
+**Affected Components:** `consensus_verifier.py` (`_verify_with_stats`)
+
+### Attack Scenario
+An attacker submits "What is the average of 1, 2, 3?" to consensus verification. The Stats engine computes `statistics.mean([1, 2, 3]) = 2.0` and returns `status="VERIFIED"`. But computing a mean is not verification — it's computation. There's no claim being verified, just a calculation being performed.
+
+### Why It Works
+In `consensus_verifier.py` (line 697-704):
+```python
+return EngineResult(
+    engine_name="Stats", method="statistical_analysis",
+    result=result,
+    confidence=0.98 if result is not None else 0.0,
+    success=result is not None,
+    status="VERIFIED" if result is not None else "UNVERIFIABLE",
+)
+```
+`status="VERIFIED"` is set whenever a statistical computation succeeds, regardless of whether a claim was actually verified.
+
+### Recommended Fix
+1. Statistical computation should produce `UNVERIFIABLE` with advisory_checks containing the computed value.
+2. Only comparison against a claimed value (with proof of correctness) should produce VERIFIED.
+
+### Architectural Impact
+**Can this violate the core verification thesis? YES** — computation is conflated with verification.
+
+---
+
+## AREAS THAT APPEAR SOUND
+
+### Attestation Issuance Fail-Closed (Issue #188 — Fixed)
+`create_verification_attestation` correctly returns `AttestationResult` with `BLOCKED` or `UNVERIFIABLE` status on failure. The `verified and not proof_data` check (line 520) correctly blocks VERIFIED attestations without proof. The `AttestationResult.is_issued` property provides a clear contract.
+
+### DiagnosticResult Invariant Enforcement
+`DiagnosticResult.__post_init__` correctly enforces:
+- VERIFIED requires `proof_ref is not None`
+- Non-VERIFIED requires `proof_ref is None`
+- `agent_message` must be non-empty
+
+The `from_legacy_dict` method correctly refuses to produce VERIFIED from legacy data. The `AdvisoryCheck.advisory_only` field is structurally enforced to `True`.
+
+### Cache Fail-Closed (Issue #189 — Fixed)
+`RedisCache` in `STRICT_DISTRIBUTED` mode correctly raises `CacheBackendUnavailableError` when Redis is unavailable. The `EXPLICIT_DEGRADED` mode tags results with `_degraded_mode=True`. The per-tenant cache isolation in `get_cache` prevents cross-tenant leakage in Redis mode.
+
+### Safe Parser (CWE-95 — Fixed)
+`safe_parse_expr` correctly:
+- Removes `__builtins__` from eval global dict
+- Uses a denylist for dangerous constructs
+- Enforces AST depth limits (30) and SymPy tree depth limits (40)
+- Validates expression length (5000 chars)
+- Restricts the evaluation namespace to math symbols only
+
+### Audit Logger Chain Integrity (Issue #173 — Fixed)
+`AuditLogger` correctly:
+- Requires `QWED_AUDIT_SECRET_KEY` environment variable (fail-closed)
+- Uses HMAC-SHA256 for signatures with `hmac.compare_digest`
+- Verifies chain continuity before appending
+- Uses `BEGIN IMMEDIATE` for SQLite serialization
+
+### Reasoning Verifier Advisory-Only (Issue #164 — Fixed)
+`ReasoningVerifier._to_diagnostic_result` correctly returns `DiagnosticResult.unverifiable(...)` for all cases, with heuristic analysis in `advisory_checks`. No VERIFIED is emitted.
+
+### Symbolic Verifier Fail-Closed (Issue #161 — Fixed)
+`SymbolicVerifier` correctly returns `UNVERIFIABLE` for "no counterexample found" (not VERIFIED), acknowledging that timeout-bounded search is not a completeness proof.
+
+---
+
+## SUMMARY TABLE
+
+| # | Finding | Severity | Core Thesis Violation | Already Tracked? |
+|---|---------|----------|----------------------|------------------|
+| 1 | Consensus emits VERIFIED without proof_ref | Critical | YES | No |
+| 2 | API endpoints bypass DiagnosticResult | Critical | YES | Partially (#258) |
+| 3 | Control plane trust enforcement is advisory-only | Critical | YES | No |
+| 4 | FactVerifier emits VERIFIED for heuristics | High | YES | No |
+| 5 | AgentStateGuard emits VERIFIED with string "proof" | High | YES | No |
+| 6 | Code execution treated as proof in consensus | High | YES | No |
+| 7 | Attestation only supports self-issued tokens | High | NO | No |
+| 8 | Non-deterministic attestation defaults | High | NO | YES (#250) |
+| 9 | Batch math returns is_valid without proof | Medium | YES | No |
+| 10 | Payload decoded before signature verification | Medium | NO | No |
+| 11 | No Unicode normalization in canonicalization | Medium | NO | No |
+| 12 | TOCTOU in enforce_trust_decision | Medium | NO | No |
+| 13 | Cache keys lack tenant context | Low | NO | No |
+| 14 | Stats computation treated as verification | Low | YES | No |
+
+---
+
+## RECOMMENDED PRIORITY ORDER
+
+1. **Finding 3** (Control plane advisory-only) — Flip `require_attestation=True` and issue attestations. This is the single change that activates the trust boundary.
+2. **Finding 2** (API endpoints bypass DiagnosticResult) — Route all endpoints through `DiagnosticResult` + `enforce_trust_decision`.
+3. **Finding 1** (Consensus VERIFIED without proof) — Add `proof_ref` to `ConsensusResult` or convert to `DiagnosticResult`.
+4. **Finding 4** (FactVerifier VERIFIED for heuristics) — Reclassify as advisory-only.
+5. **Finding 5** (AgentStateGuard string "proof") — Convert to `DiagnosticResult` with `proof_ref`.
+6. **Finding 6** (Code execution as proof) — Reclassify as advisory-only in consensus.
+7. **Finding 7** (Single-node attestation) — Implement DID resolution or document limitation.
+8. **Finding 8** (Non-deterministic defaults) — Already tracked in #250.
+
+---
+
+*This audit was conducted with red-team mindset, treating the implementation as the source of truth. Existing documentation was not assumed correct. Every finding was verified against the actual code.*

--- a/SECURITY_AUDIT_REPORT.md
+++ b/SECURITY_AUDIT_REPORT.md
@@ -12,7 +12,7 @@
 
 The QWED verification framework has a well-designed `DiagnosticResult` model with structurally enforced invariants (VERIFIED requires `proof_ref`, non-VERIFIED forbids it). However, **the majority of verification endpoints bypass this model entirely**, returning raw dicts where `status: "VERIFIED"` is set without cryptographic proof artifacts. The `enforce_trust_decision` gate exists but is called in advisory-only mode (`require_attestation=False`) on the main code path. Several engines emit VERIFIED based on heuristic/probabilistic methods rather than deterministic proof. These are architectural failures that can violate the core verification thesis.
 
-**Critical findings: 3 | High: 5 | Medium: 4 | Low: 2 | Informational: 2**
+**Critical findings: 3 | High: 5 | Medium: 4 | Low: 2**
 
 ---
 
@@ -151,9 +151,9 @@ An attacker submits a claim "The sky is blue" with context "The sky appears blue
 - `keyword_score` = keyword overlap (0.75)
 - `entity_match` = entity matching (1.0)
 - `has_negation` = False
-- `aggregate` = 0.85 * 0.3 + 0.75 * 0.3 + 1.0 * 0.2 + 0.2 = 0.78
+- `aggregate` = 0.85 * 0.3 + 0.75 * 0.3 + 1.0 * 0.2 + 0.2 = 0.88
 
-Since `aggregate >= 0.7` and support citations >= refute citations, `verdict = "SUPPORTED"`, `confidence = 0.78`. The verifier returns `DiagnosticResult.verified(...)` with `evidence = {"citations": ..., "reasoning": ...}`.
+Since `aggregate >= 0.7` and support citations >= refute citations, `verdict = "SUPPORTED"`, `confidence = 0.88`. The verifier returns `DiagnosticResult.verified(...)` with `evidence = {"citations": ..., "reasoning": ...}`.
 
 The `proof_ref` is computed as `compute_proof_ref(evidence)` where evidence is `{"citations": [...], "reasoning": "..."}`. This is a hash of heuristic analysis output, not a cryptographic proof of factual correctness.
 
@@ -434,8 +434,8 @@ An attacker can enumerate trusted issuer DIDs by observing error messages. This 
 
 ### Attack Scenario
 An attacker submits two state payloads:
-1. `{"name": "café", "value": 1}` (NFC form: `é` = U+00E9)
-2. `{"name": "café", "value": 1}` (NFD form: `é` = U+0065 + U+0301)
+1. `{"name": "caf\u00e9", "value": 1}` (NFC form: `é` = U+00E9)
+2. `{"name": "cafe\u0301", "value": 1}` (NFD form: `é` = U+0065 + U+0301)
 
 Both are semantically identical, but `_canonicalize` sorts dict keys and recursively processes values without Unicode normalization. The two payloads produce different `normalized_state` outputs and different verification results if compared.
 

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -224,10 +224,18 @@ async def verify_natural_language(
     try:
         dr = DiagnosticResult.from_legacy_dict(verification_result, engine="math")
     except ValueError:
-        dr = DiagnosticResult.blocked(
-            "Verification blocked — proof artifact unavailable",
-            {"constraint_id": "api.natural_language.legacy_conversion_failed", "legacy_status": verification_result.get("status")},
-        )
+        legacy_status = verification_result.get("status")
+        if legacy_status == "VERIFIED":
+            dr = DiagnosticResult.verified(
+                "Verification succeeded",
+                developer_fields=verification_result,
+                evidence={"legacy_status": legacy_status, "result_data": str(verification_result)},
+            )
+        else:
+            dr = DiagnosticResult.blocked(
+                "Verification blocked — proof artifact unavailable",
+                {"constraint_id": "api.natural_language.legacy_conversion_failed", "legacy_status": legacy_status},
+            )
     dr = _enforce_trust(dr, query=request.query)
 
     log = VerificationLog(

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -273,8 +273,6 @@ async def verify_logic(
         )
 
         status = result.get("status", "ERROR")
-        if status == "BLOCKED":
-            raise HTTPException(status_code=403, detail=result.get("error", "Blocked due to an unspecified error"))
 
         if status == "SAT":
             dr = DiagnosticResult.verified(

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -659,11 +659,10 @@ async def verify_math(
                         developer_fields={"is_valid": True, "value": value, "exact_value": str(exact), "simplified": str(simplified), "original": str(parsed)},
                         evidence={"exact_value": str(exact), "simplified": str(simplified)},
                     )
-                except Exception:
-                    dr = DiagnosticResult.verified(
-                        "Expression simplified",
-                        developer_fields={"is_valid": True, "simplified": str(simplified), "original": str(parsed), "is_symbolic": True},
-                        evidence={"simplified": str(simplified)},
+                except (TypeError, ValueError):
+                    dr = DiagnosticResult.unverifiable(
+                        "Expression is not numeric",
+                        developer_fields={"is_valid": False, "simplified": str(simplified), "original": str(parsed)},
                     )
 
         dr = _enforce_trust(dr, query=expression)

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -215,6 +215,7 @@ async def verify_natural_language(
     check_rate_limit(tenant.api_key)
 
     dr = None
+    result = None
     try:
         result = await control_plane.process_natural_language(
             request.query,
@@ -442,15 +443,14 @@ async def verify_fact(
     check_rate_limit(tenant.api_key)
     claim = request.get("claim")
     context = request.get("context")
+    if not claim or not context:
+        raise HTTPException(status_code=400, detail="Missing 'claim' or 'context'")
 
     try:
         from qwed_new.core.fact_verifier import FactVerifier
         verifier = FactVerifier()
         
         provider = request.get("provider")
-        
-        if not claim or not context:
-            raise HTTPException(status_code=400, detail="Missing 'claim' or 'context'")
         
         result = verifier.verify_fact(claim, context, provider=provider)
 
@@ -585,6 +585,8 @@ async def verify_math(
 ):
     check_rate_limit(tenant.api_key)
     expression = request.get("expression")
+    if not expression:
+        raise HTTPException(status_code=400, detail="Missing 'expression'")
 
     try:
         import sympy
@@ -592,9 +594,6 @@ async def verify_math(
         from sympy import simplify, symbols, Eq, solve
 
         context_data = request.get("context", {})
-
-        if not expression:
-            raise HTTPException(status_code=400, detail="Missing 'expression'")
 
         if "=" in expression:
             left_str, right_str = expression.split("=", 1)
@@ -702,7 +701,10 @@ async def verify_math(
         return _merge_response(dr)
 
 
-@app.post("/verify/sql")
+@app.post(
+    "/verify/sql",
+    responses={400: {"description": "Missing required field: 'query' or 'schema_ddl'"}},
+)
 async def verify_sql(
     request: dict,
     tenant: TenantContext = Depends(get_current_tenant),

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -214,28 +214,24 @@ async def verify_natural_language(
 ):
     check_rate_limit(tenant.api_key)
 
-    result = await control_plane.process_natural_language(
-        request.query,
-        organization_id=tenant.organization_id,
-        preferred_provider=request.provider
-    )
+    try:
+        result = await control_plane.process_natural_language(
+            request.query,
+            organization_id=tenant.organization_id,
+            preferred_provider=request.provider
+        )
+    except Exception as e:
+        logger.error("Natural language verification error: %s", redact_pii(str(e)), exc_info=False)
+        result = {"error": INTERNAL_VERIFICATION_ERROR}
 
     verification_result = result.get("verification", {})
     try:
         dr = DiagnosticResult.from_legacy_dict(verification_result, engine="math")
     except ValueError:
-        legacy_status = verification_result.get("status")
-        if legacy_status == "VERIFIED":
-            dr = DiagnosticResult.verified(
-                "Verification succeeded",
-                developer_fields=verification_result,
-                evidence={"legacy_status": legacy_status, "result_data": str(verification_result)},
-            )
-        else:
-            dr = DiagnosticResult.blocked(
-                "Verification blocked — proof artifact unavailable",
-                {"constraint_id": "api.natural_language.legacy_conversion_failed", "legacy_status": legacy_status},
-            )
+        dr = DiagnosticResult.unverifiable(
+            "Verification result unavailable — legacy engine did not retain proof artifacts",
+            {"constraint_id": "api.natural_language.legacy_conversion_failed", "legacy_status": verification_result.get("status")},
+        )
     dr = _enforce_trust(dr, query=request.query)
 
     log = VerificationLog(
@@ -249,9 +245,12 @@ async def verify_natural_language(
     session.add(log)
     session.commit()
 
-    return result | {"proof_ref": dr.proof_ref, "diagnostic_status": dr.status.value, "is_authoritative": dr.is_authoritative}
+    return _merge_response(dr)
 
-@app.post("/verify/logic")
+@app.post(
+    "/verify/logic",
+    responses={403: {"description": "Logic verification blocked by engine"}},
+)
 async def verify_logic(
     request: VerifyRequest,
     tenant: TenantContext = Depends(get_current_tenant),
@@ -298,7 +297,8 @@ async def verify_logic(
         session.add(log)
         session.commit()
 
-        return result | {"proof_ref": dr.proof_ref, "diagnostic_status": dr.status.value, "is_authoritative": dr.is_authoritative}
+        return _merge_response(dr)
+
 
     except HTTPException:
         raise
@@ -311,7 +311,7 @@ async def verify_logic(
             else control_plane.router.route(request.query, request.provider)
         )
         dr = DiagnosticResult.blocked(
-            "Internal verification error",
+            INTERNAL_VERIFICATION_ERROR,
             {"constraint_id": "api.logic.execution_error", "provider_used": provider_used},
         )
         dr = _enforce_trust(dr, query=request.query)
@@ -390,7 +390,7 @@ async def verify_stats(
     except Exception as e:
         logger.error(f"Stats verification error: {redact_pii(str(e))}", exc_info=False)
         dr = DiagnosticResult.blocked(
-            "Internal processing error",
+            INTERNAL_PROCESSING_ERROR,
             {"constraint_id": "api.stats.execution_error"},
         )
         dr = _enforce_trust(dr, query=query)
@@ -440,10 +440,11 @@ async def verify_fact(
         if isinstance(result, DiagnosticResult):
             dr = result
         elif hasattr(result, "to_dict") and hasattr(result, "is_verified"):
+            verdict = result.verdict if hasattr(result, "verdict") else "UNKNOWN"
             dr = DiagnosticResult.verified(
                 "Fact verification complete",
                 developer_fields=result.to_dict(),
-                evidence={"claim": claim, "verdict": result.verdict if hasattr(result, "verdict") else "UNKNOWN"},
+                evidence={"claim": claim, "verdict": verdict},
             ) if result.is_verified else DiagnosticResult.unverifiable(
                 "Fact not supported",
                 developer_fields=result.to_dict(),
@@ -472,7 +473,7 @@ async def verify_fact(
     except Exception as e:
         logger.error(f"Fact verification error: {redact_pii(str(e))}", exc_info=False)
         dr = DiagnosticResult.blocked(
-            "Internal verification error",
+            INTERNAL_VERIFICATION_ERROR,
             {"constraint_id": "api.fact.execution_error", "verdict": "ERROR"},
         )
         dr = _enforce_trust(dr, query=claim)
@@ -543,7 +544,7 @@ async def verify_code(
     except Exception as e:
         logger.error(f"Code verification error: {redact_pii(str(e))}", exc_info=False)
         dr = DiagnosticResult.blocked(
-            "Internal verification error",
+            INTERNAL_VERIFICATION_ERROR,
             {"constraint_id": "api.code.execution_error", "is_safe": False},
         )
         dr = _enforce_trust(dr, query=code)
@@ -668,7 +669,7 @@ async def verify_math(
     except Exception as e:
         logger.error(f"Math verification error: {redact_pii(str(e))}", exc_info=False)
         dr = DiagnosticResult.blocked(
-            "Internal verification error",
+            INTERNAL_VERIFICATION_ERROR,
             {"constraint_id": "api.math.execution_error"},
         )
         dr = _enforce_trust(dr, query=expression)
@@ -736,7 +737,7 @@ async def verify_sql(
     except Exception as e:
         logger.error(f"SQL verification error: {redact_pii(str(e))}", exc_info=False)
         dr = DiagnosticResult.blocked(
-            "Internal verification error",
+            INTERNAL_VERIFICATION_ERROR,
             {"constraint_id": "api.sql.execution_error", "is_valid": False},
         )
         dr = _enforce_trust(dr, query=query)
@@ -793,7 +794,8 @@ async def verify_image(
         if isinstance(result, DiagnosticResult):
             dr = result
         else:
-            evidence = {"claim": claim, "verdict": result.verdict if hasattr(result, "verdict") else "UNKNOWN"}
+            image_verdict = result.verdict if hasattr(result, "verdict") else "UNKNOWN"
+            evidence = {"claim": claim, "verdict": image_verdict}
             if result.is_verified:
                 dr = DiagnosticResult.verified(
                     "Image claim verified",
@@ -824,7 +826,7 @@ async def verify_image(
     except Exception as e:
         logger.error(f"Image verification error: {redact_pii(str(e))}", exc_info=False)
         dr = DiagnosticResult.blocked(
-            "Internal processing error",
+            INTERNAL_PROCESSING_ERROR,
             {"constraint_id": "api.image.execution_error", "verdict": "INCONCLUSIVE", "confidence": 0.0},
         )
         dr = _enforce_trust(dr, query=claim)
@@ -900,7 +902,7 @@ async def verify_rag(
             )
         except ValueError as exc:
             logger.warning("RAG config error: %s", redact_pii(str(exc)))
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise HTTPException(status_code=400, detail="Invalid RAG guard configuration") from exc
         
         audit_result = {
             "verified": result.get("verified", False),
@@ -1210,7 +1212,10 @@ async def _process_agent_verification(agent: Agent, request: AgentVerifyRequest)
         logger.error(f"Agent verification failed: {redact_pii(str(e))}", exc_info=False)
         raise HTTPException(status_code=500, detail="Internal agent verification error") from e
 
-@app.post("/agents/register")
+@app.post(
+    "/agents/register",
+    responses={500: {"description": "Agent registration failed due to an internal error"}},
+)
 async def register_agent(
     request: AgentRegistrationRequest,
     tenant: TenantContext = Depends(get_current_tenant),
@@ -1242,7 +1247,7 @@ async def register_agent(
         }
     except Exception as e:
         logger.error(f"Agent registration error: {redact_pii(str(e))}", exc_info=False)
-        raise HTTPException(status_code=500, detail="Agent registration failed")
+        raise HTTPException(status_code=500, detail="Agent registration failed") from e
 
 @app.post(
     "/agents/{agent_id}/verify",
@@ -1521,7 +1526,7 @@ async def verify_with_consensus(
         "total_latency_ms": round(result.total_latency_ms, 2),
         "meets_requirement": result.confidence >= request.min_confidence,
     }
-    return response | {"proof_ref": dr.proof_ref, "diagnostic_status": dr.status.value, "is_authoritative": dr.is_authoritative}
+    return response | _merge_response(dr)
 # --- Enterprise Security Endpoints (Week 2) ---
 
 from qwed_new.core.compliance_exporter import ComplianceExporter

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -121,6 +121,13 @@ def _enforce_trust(
     """
     return enforce_trust_decision(dr, require_attestation=False, query=query)
 
+
+_DIAGNOSTIC_KEYS = frozenset({"status", "agent_message", "developer_fields", "proof_ref", "is_authoritative"})
+def _merge_response(dr: DiagnosticResult) -> dict:
+    """Merge diagnostic result with developer fields, ensuring diagnostic keys win."""
+    safe = {k: v for k, v in dr.developer_fields.items() if k not in _DIAGNOSTIC_KEYS}
+    return dr.to_dict() | safe
+
 class VerifyRequest(BaseModel):
     query: str
     provider: Optional[str] = None
@@ -217,10 +224,9 @@ async def verify_natural_language(
     try:
         dr = DiagnosticResult.from_legacy_dict(verification_result, engine="math")
     except ValueError:
-        dr = DiagnosticResult.verified(
-            "Verification complete",
-            developer_fields=verification_result,
-            evidence=verification_result,
+        dr = DiagnosticResult.blocked(
+            "Verification blocked — proof artifact unavailable",
+            {"constraint_id": "api.natural_language.legacy_conversion_failed", "legacy_status": verification_result.get("status")},
         )
     dr = _enforce_trust(dr, query=request.query)
 
@@ -310,7 +316,7 @@ async def verify_logic(
         )
         session.add(log)
         session.commit()
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
 @app.post(
     "/verify/stats",
@@ -348,10 +354,9 @@ async def verify_stats(
             raise HTTPException(status_code=403, detail="Verification blocked by security policy")
 
         if result.get("status") == "SUCCESS":
-            dr = DiagnosticResult.verified(
-                "Statistical analysis complete",
+            dr = DiagnosticResult.unverifiable(
+                "Statistical analysis executed",
                 developer_fields=result,
-                evidence={"query": query, "analysis": result.get("analysis", "")},
             )
         else:
             dr = DiagnosticResult.blocked(
@@ -370,7 +375,7 @@ async def verify_stats(
         session.add(log)
         session.commit()
 
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
     except HTTPException:
         raise
 
@@ -390,7 +395,7 @@ async def verify_stats(
         )
         session.add(log)
         session.commit()
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
 
 @app.post("/verify/fact")
@@ -410,13 +415,13 @@ async def verify_fact(
     }
     """
     check_rate_limit(tenant.api_key)
-    
+    claim = request.get("claim")
+    context = request.get("context")
+
     try:
         from qwed_new.core.fact_verifier import FactVerifier
         verifier = FactVerifier()
         
-        claim = request.get("claim")
-        context = request.get("context")
         provider = request.get("provider")
         
         if not claim or not context:
@@ -424,18 +429,19 @@ async def verify_fact(
         
         result = verifier.verify_fact(claim, context, provider=provider)
 
-        # FactVerifier may return DiagnosticResult or FactCheckResult
-        if hasattr(result, "to_dict") and hasattr(result, "is_verified"):
+        if isinstance(result, DiagnosticResult):
+            dr = result
+        elif hasattr(result, "to_dict") and hasattr(result, "is_verified"):
             dr = DiagnosticResult.verified(
-                result.get("message", "Fact verification complete") if isinstance(result, dict) else str(result),
-                developer_fields=result.to_dict() if hasattr(result, "to_dict") else {},
+                "Fact verification complete",
+                developer_fields=result.to_dict(),
                 evidence={"claim": claim, "verdict": result.verdict if hasattr(result, "verdict") else "UNKNOWN"},
             ) if result.is_verified else DiagnosticResult.unverifiable(
                 "Fact not supported",
-                developer_fields=result.to_dict() if hasattr(result, "to_dict") else {},
+                developer_fields=result.to_dict(),
             )
         else:
-            dr = result if isinstance(result, DiagnosticResult) else DiagnosticResult.unverifiable(
+            dr = DiagnosticResult.unverifiable(
                 "Fact verification inconclusive",
                 developer_fields={"result": str(result)},
             )
@@ -451,7 +457,7 @@ async def verify_fact(
         session.add(log)
         session.commit()
 
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
     except Exception as e:
         logger.error(f"Fact verification error: {redact_pii(str(e))}", exc_info=False)
@@ -469,7 +475,7 @@ async def verify_fact(
         )
         session.add(log)
         session.commit()
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
 
 @app.post("/verify/code")
@@ -479,12 +485,12 @@ async def verify_code(
     session: Session = Depends(get_session)
 ):
     check_rate_limit(tenant.api_key)
+    code = request.get("code")
 
     try:
         from qwed_new.core.code_verifier import CodeVerifier
         verifier = CodeVerifier()
 
-        code = request.get("code")
         language = request.get("language", "python")
 
         if not code:
@@ -492,12 +498,16 @@ async def verify_code(
 
         result = verifier.verify_code(code, language=language)
 
-        is_safe = result.get("is_safe", False)
-        if is_safe:
+        if result.get("status") == "SAFE":
             dr = DiagnosticResult.verified(
                 "Code is safe",
                 developer_fields=result,
                 evidence={"language": language, "analysis": result.get("analysis", "")},
+            )
+        elif result.get("status") == "REVIEW":
+            dr = DiagnosticResult.unverifiable(
+                "Code requires manual review",
+                developer_fields=result,
             )
         else:
             dr = DiagnosticResult.blocked(
@@ -516,7 +526,7 @@ async def verify_code(
         session.add(log)
         session.commit()
 
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
     except Exception as e:
         logger.error(f"Code verification error: {redact_pii(str(e))}", exc_info=False)
@@ -534,7 +544,7 @@ async def verify_code(
         )
         session.add(log)
         session.commit()
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
 
 @app.post("/verify/math")
@@ -544,13 +554,13 @@ async def verify_math(
     session: Session = Depends(get_session)
 ):
     check_rate_limit(tenant.api_key)
+    expression = request.get("expression")
 
     try:
         import sympy
         from qwed_new.core.safe_parser import safe_parse_expr
         from sympy import simplify, symbols, Eq, solve
 
-        expression = request.get("expression")
         context_data = request.get("context", {})
 
         if not expression:
@@ -588,44 +598,37 @@ async def verify_math(
                     is_ambiguous = True
 
             parsed = safe_parse_expr(expression_normalized)
+            simplified = simplify(parsed)
 
-            if "/0" in expression.replace(" ", "") or "/ 0" in expression:
+            if simplified.has(sympy.zoo) or simplified.has(sympy.nan):
                 dr = DiagnosticResult.blocked(
                     "Expression contains division by zero",
                     developer_fields={"is_valid": False, "error": "Division by zero"},
                 )
-            elif "log(0)" in expression.replace(" ", ""):
+            elif simplified.has(sympy.oo) or simplified.has(-sympy.oo):
                 dr = DiagnosticResult.blocked(
-                    "log(0) is undefined",
+                    "Expression is undefined",
                     developer_fields={"is_valid": False, "error": "undefined"},
                 )
-            elif "sqrt(-" in expression.replace(" ", ""):
-                if context_data.get("domain") == "real":
-                    dr = DiagnosticResult.blocked(
-                        "Square root of negative number is undefined in real domain",
-                        developer_fields={"is_valid": False, "error": "domain error"},
-                    )
-                else:
-                    simplified = simplify(parsed)
-                    dr = DiagnosticResult.verified(
-                        "Expression evaluated",
-                        developer_fields={"is_valid": True, "simplified": str(simplified), "original": str(parsed), "is_complex": True},
-                        evidence={"simplified": str(simplified), "original": str(parsed)},
-                    )
+            elif simplified.is_real is False and context_data.get("domain") == "real":
+                dr = DiagnosticResult.blocked(
+                    "Square root of negative number is undefined in real domain",
+                    developer_fields={"is_valid": False, "error": "domain error"},
+                )
             elif is_ambiguous:
-                simplified = simplify(parsed)
                 dr = DiagnosticResult.blocked(
                     "Expression may be ambiguous due to implicit multiplication after division",
                     developer_fields={"is_valid": False, "result": False, "status": "BLOCKED", "warning": "ambiguous", "simplified": str(simplified), "note": "Interpreted using standard order of operations", "original": str(parsed)},
                 )
             else:
-                simplified = simplify(parsed)
+                is_numeric = simplified.free_symbols == set()
                 try:
+                    exact = sympy.nsimplify(simplified) if is_numeric else simplified
                     value = float(simplified)
                     dr = DiagnosticResult.verified(
                         "Expression evaluated",
-                        developer_fields={"is_valid": True, "value": value, "simplified": str(simplified), "original": str(parsed)},
-                        evidence={"value": value, "simplified": str(simplified)},
+                        developer_fields={"is_valid": True, "value": value, "exact_value": str(exact), "simplified": str(simplified), "original": str(parsed)},
+                        evidence={"exact_value": str(exact), "simplified": str(simplified)},
                     )
                 except Exception:
                     dr = DiagnosticResult.verified(
@@ -646,7 +649,7 @@ async def verify_math(
         session.add(log)
         session.commit()
 
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
     except HTTPException:
         raise
@@ -666,21 +669,7 @@ async def verify_math(
         )
         session.add(log)
         session.commit()
-        return dr.to_dict() | dr.developer_fields
-
-    dr = _enforce_trust(dr, query=expression)
-
-    log = VerificationLog(
-        organization_id=tenant.organization_id,
-        query=expression,
-        result=str(dr.to_dict()),
-        is_verified=dr.is_authoritative,
-        domain="MATH"
-    )
-    session.add(log)
-    session.commit()
-
-    return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
 
 @app.post("/verify/sql")
@@ -690,12 +679,12 @@ async def verify_sql(
     session: Session = Depends(get_session)
 ):
     check_rate_limit(tenant.api_key)
+    query = request.get("query")
 
     try:
         from qwed_new.core.sql_verifier import SQLVerifier
         verifier = SQLVerifier()
 
-        query = request.get("query")
         schema_ddl = request.get("schema_ddl")
         dialect = request.get("dialect", "sqlite")
 
@@ -728,7 +717,7 @@ async def verify_sql(
         session.add(log)
         session.commit()
 
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
     except Exception as e:
         logger.error(f"SQL verification error: {redact_pii(str(e))}", exc_info=False)
@@ -746,7 +735,7 @@ async def verify_sql(
         )
         session.add(log)
         session.commit()
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
 
 @app.post("/verify/image")
@@ -787,18 +776,21 @@ async def verify_image(
         verifier = ImageVerifier(use_vlm_fallback=False)
         result = verifier.verify_image(image_bytes, claim)
 
-        evidence = {"claim": claim, "verdict": result.verdict if hasattr(result, "verdict") else "UNKNOWN"}
-        if result.is_verified:
-            dr = DiagnosticResult.verified(
-                "Image claim verified",
-                developer_fields=result.to_dict(),
-                evidence=evidence,
-            )
+        if isinstance(result, DiagnosticResult):
+            dr = result
         else:
-            dr = DiagnosticResult.unverifiable(
-                "Image claim not supported",
-                developer_fields=result.to_dict(),
-            )
+            evidence = {"claim": claim, "verdict": result.verdict if hasattr(result, "verdict") else "UNKNOWN"}
+            if result.is_verified:
+                dr = DiagnosticResult.verified(
+                    "Image claim verified",
+                    developer_fields=result.to_dict(),
+                    evidence=evidence,
+                )
+            else:
+                dr = DiagnosticResult.unverifiable(
+                    "Image claim not supported",
+                    developer_fields=result.to_dict(),
+                )
         dr = _enforce_trust(dr, query=claim)
 
         log = VerificationLog(
@@ -811,7 +803,7 @@ async def verify_image(
         session.add(log)
         session.commit()
 
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
     except HTTPException:
         raise
@@ -831,7 +823,7 @@ async def verify_image(
         )
         session.add(log)
         session.commit()
-        return dr.to_dict() | dr.developer_fields
+        return _merge_response(dr)
 
 class RAGVerifyRequest(BaseModel):
     target_document_id: str
@@ -1455,11 +1447,17 @@ async def verify_with_consensus(
     
     # Log to database
     if result.agreement_status == "unanimous":
-        dr = DiagnosticResult.verified(
-            "Consensus verification: unanimous",
-            developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
-            evidence={"agreement_status": result.agreement_status, "confidence": result.confidence},
-        )
+        if hasattr(result, "status") and result.status == "BLOCKED":
+            dr = DiagnosticResult.blocked(
+                "Consensus verification: blocked",
+                developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
+            )
+        else:
+            dr = DiagnosticResult.verified(
+                "Consensus verification: unanimous",
+                developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
+                evidence={"agreement_status": result.agreement_status, "confidence": result.confidence},
+            )
     elif result.agreement_status == "majority":
         dr = DiagnosticResult.unverifiable(
             "Consensus verification: majority agreement",

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -666,7 +666,7 @@ async def verify_math(
                             developer_fields={"is_valid": True, "value": value, "exact_value": str(exact), "simplified": str(simplified), "original": str(parsed)},
                             evidence={"exact_value": str(exact), "simplified": str(simplified)},
                         )
-                    except (TypeError, ValueError):
+                    except (TypeError, ValueError, OverflowError):
                         dr = DiagnosticResult.unverifiable(
                             "Expression is not numeric",
                             developer_fields={"is_valid": False, "simplified": str(simplified), "original": str(parsed)},
@@ -1522,16 +1522,39 @@ async def verify_with_consensus(
     )
 
     if result.agreement_status == "blocked_secure_execution":
-        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
-    
-    # Check if confidence meets requirement
-    if result.confidence < request.min_confidence:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Confidence ({result.confidence:.1%}) below required minimum ({request.min_confidence:.1%})"
+        dr = DiagnosticResult.blocked(
+            "Consensus verification: blocked — secure execution",
+            developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
         )
-    
-    # Log to database
+        dr = _enforce_trust(dr, query=request.query)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=request.query,
+            result=f"Consensus: {result.agreement_status}",
+            is_verified=dr.is_authoritative,
+            domain="CONSENSUS"
+        )
+        session.add(log)
+        session.commit()
+        return _merge_response(dr)
+
+    if result.confidence < request.min_confidence:
+        dr = DiagnosticResult.unverifiable(
+            f"Confidence ({result.confidence:.1%}) below required minimum ({request.min_confidence:.1%})",
+            developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used, "min_confidence": request.min_confidence},
+        )
+        dr = _enforce_trust(dr, query=request.query)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=request.query,
+            result=f"Consensus: {result.agreement_status}, Confidence: {result.confidence:.1%}",
+            is_verified=dr.is_authoritative,
+            domain="CONSENSUS"
+        )
+        session.add(log)
+        session.commit()
+        return _merge_response(dr)
+
     if result.agreement_status == "unanimous":
         if hasattr(result, "status") and result.status == "BLOCKED":
             dr = DiagnosticResult.blocked(

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -8,6 +8,7 @@ import logging
 from fractions import Fraction
 
 from qwed_new.core.security import redact_pii
+from qwed_new.core.diagnostics import DiagnosticResult, enforce_trust_decision
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -108,6 +109,18 @@ def on_startup():
 # Initialize Kernel (Control Plane)
 control_plane = ControlPlane()
 
+# Trust boundary enforcement helper (currently advisory until #265)
+def _enforce_trust(
+    dr: DiagnosticResult, query: str
+) -> DiagnosticResult:
+    """Route a DiagnosticResult through trust boundary enforcement.
+
+    Currently operates in advisory mode (require_attestation=False) pending
+    attestation issuance wiring. Callers must use the returned DiagnosticResult
+    for audit logging and response construction.
+    """
+    return enforce_trust_decision(dr, require_attestation=False, query=query)
+
 class VerifyRequest(BaseModel):
     query: str
     provider: Optional[str] = None
@@ -192,36 +205,37 @@ async def verify_natural_language(
     tenant: TenantContext = Depends(get_current_tenant),
     session: Session = Depends(get_session)
 ):
-    """
-    Main entry point: Verifies a natural language math query.
-    Now routed through the QWED Control Plane with multi-tenancy.
-    
-    Rate Limits:
-    - Per API Key: 100 requests/minute
-    - Global: 1000 requests/minute
-    """
-    # Check rate limits
     check_rate_limit(tenant.api_key)
-    
+
     result = await control_plane.process_natural_language(
         request.query,
         organization_id=tenant.organization_id,
         preferred_provider=request.provider
     )
-    
-    # Log request to audit trail
+
+    verification_result = result.get("verification", {})
+    try:
+        dr = DiagnosticResult.from_legacy_dict(verification_result, engine="math")
+    except ValueError:
+        dr = DiagnosticResult.verified(
+            "Verification complete",
+            developer_fields=verification_result,
+            evidence=verification_result,
+        )
+    dr = _enforce_trust(dr, query=request.query)
+
     log = VerificationLog(
         organization_id=tenant.organization_id,
         user_id=tenant.user_id if hasattr(tenant, 'user_id') else None,
         query=request.query,
         result=str(result),
-        is_verified=result.get("status") == "VERIFIED",
+        is_verified=dr.is_authoritative,
         domain="MATH"
     )
     session.add(log)
     session.commit()
-        
-    return result
+
+    return result | {"proof_ref": dr.proof_ref, "diagnostic_status": dr.status.value, "is_authoritative": dr.is_authoritative}
 
 @app.post("/verify/logic")
 async def verify_logic(
@@ -229,40 +243,49 @@ async def verify_logic(
     tenant: TenantContext = Depends(get_current_tenant),
     session: Session = Depends(get_session)
 ):
-    """
-    Verifies a logic puzzle.
-    Now routed through the QWED Control Plane.
-    
-    Rate Limits:
-    - Per API Key: 100 requests/minute
-    - Global: 1000 requests/minute
-    """
-    # Check rate limits
     check_rate_limit(tenant.api_key)
-    
+
     try:
         result = await control_plane.process_logic_query(
             request.query,
             organization_id=tenant.organization_id,
             preferred_provider=request.provider
         )
-        
-        if result["status"] == "BLOCKED":
+
+        status = result.get("status", "ERROR")
+        if status == "BLOCKED":
             raise HTTPException(status_code=403, detail=result["error"])
-        
-        # Log to database
+
+        if status == "SAT":
+            dr = DiagnosticResult.verified(
+                "Logic constraints are satisfiable",
+                developer_fields=result,
+                evidence={"model": str(result.get("model")), "dsl_code": result.get("dsl_code", "")},
+            )
+        elif status == "UNSAT":
+            dr = DiagnosticResult.unverifiable(
+                "Logic constraints are unsatisfiable",
+                developer_fields=result,
+            )
+        else:
+            dr = DiagnosticResult.blocked(
+                result.get("error", "Logic verification failed"),
+                developer_fields=result,
+            )
+        dr = _enforce_trust(dr, query=request.query)
+
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=request.query,
             result=str(result),
-            is_verified=(result["status"] == "SAT" or result["status"] == "UNSAT"),
+            is_verified=dr.is_authoritative,
             domain="LOGIC"
         )
         session.add(log)
         session.commit()
-            
-        return result
-        
+
+        return result | {"proof_ref": dr.proof_ref, "diagnostic_status": dr.status.value, "is_authoritative": dr.is_authoritative}
+
     except HTTPException:
         raise
     except Exception as e:
@@ -273,11 +296,21 @@ async def verify_logic(
             if isinstance(response_result, dict) and response_result.get("provider_used")
             else control_plane.router.route(request.query, request.provider)
         )
-        return {
-            "status": "ERROR",
-            "error": INTERNAL_VERIFICATION_ERROR,
-            "provider_used": provider_used,
-        }
+        dr = DiagnosticResult.blocked(
+            "Internal verification error",
+            {"constraint_id": "api.logic.execution_error", "provider_used": provider_used},
+        )
+        dr = _enforce_trust(dr, query=request.query)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=request.query,
+            result=str(dr.to_dict()),
+            is_verified=False,
+            domain="LOGIC"
+        )
+        session.add(log)
+        session.commit()
+        return dr.to_dict() | dr.developer_fields
 
 @app.post(
     "/verify/stats",
@@ -313,27 +346,51 @@ async def verify_stats(
             raise HTTPException(status_code=503, detail="Service temporarily unavailable")
         if result.get("status") == "BLOCKED":
             raise HTTPException(status_code=403, detail="Verification blocked by security policy")
-        
+
+        if result.get("status") == "SUCCESS":
+            dr = DiagnosticResult.verified(
+                "Statistical analysis complete",
+                developer_fields=result,
+                evidence={"query": query, "analysis": result.get("analysis", "")},
+            )
+        else:
+            dr = DiagnosticResult.blocked(
+                result.get("message", "Statistical analysis failed"),
+                developer_fields=result,
+            )
+        dr = _enforce_trust(dr, query=query)
+
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=query,
-            result=str(result),
-            is_verified=(result["status"] == "SUCCESS"),
+            result=str(dr.to_dict()),
+            is_verified=dr.is_authoritative,
             domain="STATS"
         )
         session.add(log)
         session.commit()
-        
-        return result
+
+        return dr.to_dict() | dr.developer_fields
     except HTTPException:
         raise
-        
+
     except Exception as e:
         logger.error(f"Stats verification error: {redact_pii(str(e))}", exc_info=False)
-        return {
-            "status": "ERROR",
-            "error": INTERNAL_PROCESSING_ERROR
-        }
+        dr = DiagnosticResult.blocked(
+            "Internal processing error",
+            {"constraint_id": "api.stats.execution_error"},
+        )
+        dr = _enforce_trust(dr, query=query)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=query,
+            result=str(dr.to_dict()),
+            is_verified=False,
+            domain="STATS"
+        )
+        session.add(log)
+        session.commit()
+        return dr.to_dict() | dr.developer_fields
 
 
 @app.post("/verify/fact")
@@ -366,26 +423,53 @@ async def verify_fact(
             raise HTTPException(status_code=400, detail="Missing 'claim' or 'context'")
         
         result = verifier.verify_fact(claim, context, provider=provider)
-        
+
+        # FactVerifier may return DiagnosticResult or FactCheckResult
+        if hasattr(result, "to_dict") and hasattr(result, "is_verified"):
+            dr = DiagnosticResult.verified(
+                result.get("message", "Fact verification complete") if isinstance(result, dict) else str(result),
+                developer_fields=result.to_dict() if hasattr(result, "to_dict") else {},
+                evidence={"claim": claim, "verdict": result.verdict if hasattr(result, "verdict") else "UNKNOWN"},
+            ) if result.is_verified else DiagnosticResult.unverifiable(
+                "Fact not supported",
+                developer_fields=result.to_dict() if hasattr(result, "to_dict") else {},
+            )
+        else:
+            dr = result if isinstance(result, DiagnosticResult) else DiagnosticResult.unverifiable(
+                "Fact verification inconclusive",
+                developer_fields={"result": str(result)},
+            )
+        dr = _enforce_trust(dr, query=claim)
+
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=claim,
-            result=str(result),
-            is_verified=result.is_verified,
+            result=str(dr.to_dict()),
+            is_verified=dr.is_authoritative,
             domain="FACT"
         )
         session.add(log)
         session.commit()
-        
-        return result.to_dict()
-        
+
+        return dr.to_dict() | dr.developer_fields
+
     except Exception as e:
         logger.error(f"Fact verification error: {redact_pii(str(e))}", exc_info=False)
-        return {
-            "status": "ERROR",
-            "error": INTERNAL_VERIFICATION_ERROR,
-            "verdict": "ERROR"
-        }
+        dr = DiagnosticResult.blocked(
+            "Internal verification error",
+            {"constraint_id": "api.fact.execution_error", "verdict": "ERROR"},
+        )
+        dr = _enforce_trust(dr, query=claim)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=claim,
+            result=str(dr.to_dict()),
+            is_verified=False,
+            domain="FACT"
+        )
+        session.add(log)
+        session.commit()
+        return dr.to_dict() | dr.developer_fields
 
 
 @app.post("/verify/code")
@@ -394,48 +478,63 @@ async def verify_code(
     tenant: TenantContext = Depends(get_current_tenant),
     session: Session = Depends(get_session)
 ):
-    """
-    Verify code for security vulnerabilities using AST analysis.
-    
-    Request body:
-    {
-        "code": "import os\\nos.system('ls')",
-        "language": "python" (optional, default: python)
-    }
-    """
     check_rate_limit(tenant.api_key)
-    
+
     try:
         from qwed_new.core.code_verifier import CodeVerifier
         verifier = CodeVerifier()
-        
+
         code = request.get("code")
         language = request.get("language", "python")
-        
+
         if not code:
             raise HTTPException(status_code=400, detail="Missing 'code'")
-        
+
         result = verifier.verify_code(code, language=language)
-        
+
+        is_safe = result.get("is_safe", False)
+        if is_safe:
+            dr = DiagnosticResult.verified(
+                "Code is safe",
+                developer_fields=result,
+                evidence={"language": language, "analysis": result.get("analysis", "")},
+            )
+        else:
+            dr = DiagnosticResult.blocked(
+                result.get("message", "Code contains security vulnerabilities"),
+                developer_fields=result,
+            )
+        dr = _enforce_trust(dr, query=code)
+
         log = VerificationLog(
             organization_id=tenant.organization_id,
-            query=code[:200],  # Truncate for logging
-            result=str(result),
-            is_verified=result.get("is_safe", False),
+            query=code[:200],
+            result=str(dr.to_dict()),
+            is_verified=dr.is_authoritative,
             domain="CODE"
         )
         session.add(log)
         session.commit()
-        
-        return result
-        
+
+        return dr.to_dict() | dr.developer_fields
+
     except Exception as e:
         logger.error(f"Code verification error: {redact_pii(str(e))}", exc_info=False)
-        return {
-            "status": "ERROR",
-            "error": INTERNAL_VERIFICATION_ERROR,
-            "is_safe": False
-        }
+        dr = DiagnosticResult.blocked(
+            "Internal verification error",
+            {"constraint_id": "api.code.execution_error", "is_safe": False},
+        )
+        dr = _enforce_trust(dr, query=code)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=code[:200],
+            result=str(dr.to_dict()),
+            is_verified=False,
+            domain="CODE"
+        )
+        session.add(log)
+        session.commit()
+        return dr.to_dict() | dr.developer_fields
 
 
 @app.post("/verify/math")
@@ -444,168 +543,144 @@ async def verify_math(
     tenant: TenantContext = Depends(get_current_tenant),
     session: Session = Depends(get_session)
 ):
-    """
-    Verify mathematical expression or equation.
-    
-    Request body:
-    {
-        "expression": "2+2=4" or "x**2 - y**2 = (x-y)*(x+y)",
-        "context": {"domain": "real"} (optional)
-    }
-    """
     check_rate_limit(tenant.api_key)
-    
+
     try:
         import sympy
         from qwed_new.core.safe_parser import safe_parse_expr
         from sympy import simplify, symbols, Eq, solve
-        
+
         expression = request.get("expression")
         context_data = request.get("context", {})
-        
+
         if not expression:
             raise HTTPException(status_code=400, detail="Missing 'expression'")
-        
-        # Check if it's an equation (contains =) or just an expression
+
         if "=" in expression:
-            # It's an equation - verify if it's true/false
             left_str, right_str = expression.split("=", 1)
-            
-            # Parse both sides
             left = safe_parse_expr(left_str)
             right = safe_parse_expr(right_str)
-            
-            # Simplify and check equivalence
             difference = simplify(left - right)
             is_valid = difference == 0
-            
-            result = {
-                "is_valid": is_valid,
-                "result": is_valid,
+
+            fields = {
                 "left_side": str(left),
                 "right_side": str(right),
                 "simplified_difference": str(difference),
-                "message": "Identity is true" if is_valid else "Identity is false"
             }
+            if is_valid:
+                dr = DiagnosticResult.verified(
+                    "Identity is true",
+                    developer_fields={"is_valid": True, "result": True, **fields},
+                    evidence=fields,
+                )
+            else:
+                dr = DiagnosticResult.blocked(
+                    "Identity is false",
+                    developer_fields={"is_valid": False, "result": False, **fields},
+                )
         else:
-            # Just an expression - evaluate or simplify
-            try:
-                # Convert implicit multiplication to explicit (e.g., 2(x+1) -> 2*(x+1))
-                import re
-                expression_normalized = re.sub(r'(\d)(\()', r'\1*\2', expression)
-                
-                # Check for ambiguous expressions BEFORE parsing
-                is_ambiguous = False
-                if "/" in expression and "(" in expression:
-                    # Match patterns like /2(, /10(, etc. (division followed by number then parenthesis)
-                    if re.search(r'/\d+\(', expression.replace(" ", "")):
-                        is_ambiguous = True
-                
-                parsed = safe_parse_expr(expression_normalized)
-                
-                # Check for division by zero before simplifying
-                if "/0" in expression.replace(" ", "") or "/ 0" in expression:
-                    result = {
-                        "is_valid": False,
-                        "error": "Division by zero",
-                        "message": "Expression contains division by zero"
-                    }
-                    
-                # Check for log(0) or log(negative)
-                elif "log(0)" in expression.replace(" ", ""):
-                    result = {
-                        "is_valid": False,
-                        "error": "undefined",
-                        "message": "log(0) is undefined"
-                    }
-                    
-                # Check for sqrt of negative in real domain
-                elif "sqrt(-" in expression.replace(" ", ""):
-                    if context_data.get("domain") == "real":
-                        result = {
-                            "is_valid": False,
-                            "error": "domain error",
-                            "message": "Square root of negative number is undefined in real domain"
-                        }
-                    else:
-                        simplified = simplify(parsed)
-                        result = {
-                            "is_valid": True,
-                            "simplified": str(simplified),
-                            "original": str(parsed),
-                            "is_complex": True
-                        }
-                        
-                # Check for ambiguous expressions (BEFORE simplification)
-                elif is_ambiguous:
-                    simplified = simplify(parsed)
-                    result = {
-                        "is_valid": False,
-                        "result": False,
-                        "status": "BLOCKED",
-                        "warning": "ambiguous",
-                        "message": "Expression may be ambiguous due to implicit multiplication after division",
-                        "simplified": str(simplified),
-                        "note": "Interpreted using standard order of operations",
-                        "original": str(parsed)
-                    }
-                    
-                # Normal expression - evaluate or simplify
+            import re
+            expression_normalized = re.sub(r'(\d)(\()', r'\1*\2', expression)
+            is_ambiguous = False
+            if "/" in expression and "(" in expression:
+                if re.search(r'/\d+\(', expression.replace(" ", "")):
+                    is_ambiguous = True
+
+            parsed = safe_parse_expr(expression_normalized)
+
+            if "/0" in expression.replace(" ", "") or "/ 0" in expression:
+                dr = DiagnosticResult.blocked(
+                    "Expression contains division by zero",
+                    developer_fields={"is_valid": False, "error": "Division by zero"},
+                )
+            elif "log(0)" in expression.replace(" ", ""):
+                dr = DiagnosticResult.blocked(
+                    "log(0) is undefined",
+                    developer_fields={"is_valid": False, "error": "undefined"},
+                )
+            elif "sqrt(-" in expression.replace(" ", ""):
+                if context_data.get("domain") == "real":
+                    dr = DiagnosticResult.blocked(
+                        "Square root of negative number is undefined in real domain",
+                        developer_fields={"is_valid": False, "error": "domain error"},
+                    )
                 else:
                     simplified = simplify(parsed)
-                    
-                    # Try to evaluate if it's numeric
-                    try:
-                        value = float(simplified)
-                        result = {
-                            "is_valid": True,
-                            "value": value,
-                            "simplified": str(simplified),
-                            "original": str(parsed)
-                        }
-                    except Exception:
-                        # Symbolic expression
-                        result = {
-                            "is_valid": True,
-                            "simplified": str(simplified),
-                            "original": str(parsed),
-                            "is_symbolic": True
-                        }
-            except ZeroDivisionError:
-                result = {
-                    "is_valid": False,
-                    "error": "Division by zero",
-                    "message": "Expression contains division by zero"
-                }
-            except Exception as e:
-                if "log" in str(e).lower() or "sqrt" in str(e).lower():
-                    result = {
-                        "is_valid": False,
-                        "error": "Domain error",
-                        "message": str(e)
-                    }
-                else:
-                    raise
-        
+                    dr = DiagnosticResult.verified(
+                        "Expression evaluated",
+                        developer_fields={"is_valid": True, "simplified": str(simplified), "original": str(parsed), "is_complex": True},
+                        evidence={"simplified": str(simplified), "original": str(parsed)},
+                    )
+            elif is_ambiguous:
+                simplified = simplify(parsed)
+                dr = DiagnosticResult.blocked(
+                    "Expression may be ambiguous due to implicit multiplication after division",
+                    developer_fields={"is_valid": False, "result": False, "status": "BLOCKED", "warning": "ambiguous", "simplified": str(simplified), "note": "Interpreted using standard order of operations", "original": str(parsed)},
+                )
+            else:
+                simplified = simplify(parsed)
+                try:
+                    value = float(simplified)
+                    dr = DiagnosticResult.verified(
+                        "Expression evaluated",
+                        developer_fields={"is_valid": True, "value": value, "simplified": str(simplified), "original": str(parsed)},
+                        evidence={"value": value, "simplified": str(simplified)},
+                    )
+                except Exception:
+                    dr = DiagnosticResult.verified(
+                        "Expression simplified",
+                        developer_fields={"is_valid": True, "simplified": str(simplified), "original": str(parsed), "is_symbolic": True},
+                        evidence={"simplified": str(simplified)},
+                    )
+
+        dr = _enforce_trust(dr, query=expression)
+
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=expression,
-            result=str(result),
-            is_verified=result.get("is_valid", False),
+            result=str(dr.to_dict()),
+            is_verified=dr.is_authoritative,
             domain="MATH"
         )
         session.add(log)
         session.commit()
-        
-        return result
-        
+
+        return dr.to_dict() | dr.developer_fields
+
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Math verification error: {redact_pii(str(e))}", exc_info=False)
-        return {
-            "status": "ERROR",
-            "error": INTERNAL_VERIFICATION_ERROR,
-            "is_valid": False
-        }
+        dr = DiagnosticResult.blocked(
+            "Internal verification error",
+            {"constraint_id": "api.math.execution_error"},
+        )
+        dr = _enforce_trust(dr, query=expression)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=expression,
+            result=str(dr.to_dict()),
+            is_verified=False,
+            domain="MATH"
+        )
+        session.add(log)
+        session.commit()
+        return dr.to_dict() | dr.developer_fields
+
+    dr = _enforce_trust(dr, query=expression)
+
+    log = VerificationLog(
+        organization_id=tenant.organization_id,
+        query=expression,
+        result=str(dr.to_dict()),
+        is_verified=dr.is_authoritative,
+        domain="MATH"
+    )
+    session.add(log)
+    session.commit()
+
+    return dr.to_dict() | dr.developer_fields
 
 
 @app.post("/verify/sql")
@@ -614,50 +689,64 @@ async def verify_sql(
     tenant: TenantContext = Depends(get_current_tenant),
     session: Session = Depends(get_session)
 ):
-    """
-    Verify SQL query against a provided schema.
-    
-    Request body:
-    {
-        "query": "SELECT * FROM users",
-        "schema_ddl": "CREATE TABLE users (id INT, name TEXT)",
-        "dialect": "sqlite" (optional, default: sqlite)
-    }
-    """
     check_rate_limit(tenant.api_key)
-    
+
     try:
         from qwed_new.core.sql_verifier import SQLVerifier
         verifier = SQLVerifier()
-        
+
         query = request.get("query")
         schema_ddl = request.get("schema_ddl")
         dialect = request.get("dialect", "sqlite")
-        
+
         if not query or not schema_ddl:
             raise HTTPException(status_code=400, detail="Missing 'query' or 'schema_ddl'")
-        
+
         result = verifier.verify_sql(query, schema_ddl, dialect=dialect)
-        
+
+        is_valid = result.get("is_valid", False)
+        if is_valid:
+            dr = DiagnosticResult.verified(
+                "SQL query is valid for the given schema",
+                developer_fields=result,
+                evidence={"query": query, "dialect": dialect, "analysis": result.get("analysis", "")},
+            )
+        else:
+            dr = DiagnosticResult.blocked(
+                result.get("message", "SQL query is invalid or unsafe"),
+                developer_fields=result,
+            )
+        dr = _enforce_trust(dr, query=query)
+
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=query,
-            result=str(result),
-            is_verified=result.get("is_valid", False),
+            result=str(dr.to_dict()),
+            is_verified=dr.is_authoritative,
             domain="SQL"
         )
         session.add(log)
         session.commit()
-        
-        return result
-        
+
+        return dr.to_dict() | dr.developer_fields
+
     except Exception as e:
         logger.error(f"SQL verification error: {redact_pii(str(e))}", exc_info=False)
-        return {
-            "status": "ERROR",
-            "error": INTERNAL_VERIFICATION_ERROR,
-            "is_valid": False
-        }
+        dr = DiagnosticResult.blocked(
+            "Internal verification error",
+            {"constraint_id": "api.sql.execution_error", "is_valid": False},
+        )
+        dr = _enforce_trust(dr, query=query)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=query,
+            result=str(dr.to_dict()),
+            is_verified=False,
+            domain="SQL"
+        )
+        session.add(log)
+        session.commit()
+        return dr.to_dict() | dr.developer_fields
 
 
 @app.post("/verify/image")
@@ -697,30 +786,52 @@ async def verify_image(
         # Verify claim against image
         verifier = ImageVerifier(use_vlm_fallback=False)
         result = verifier.verify_image(image_bytes, claim)
-        
-        # Log the verification
+
+        evidence = {"claim": claim, "verdict": result.verdict if hasattr(result, "verdict") else "UNKNOWN"}
+        if result.is_verified:
+            dr = DiagnosticResult.verified(
+                "Image claim verified",
+                developer_fields=result.to_dict(),
+                evidence=evidence,
+            )
+        else:
+            dr = DiagnosticResult.unverifiable(
+                "Image claim not supported",
+                developer_fields=result.to_dict(),
+            )
+        dr = _enforce_trust(dr, query=claim)
+
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=f"Image claim: {claim}",
-            result=str(result),
-            is_verified=result.is_verified,
+            result=str(dr.to_dict()),
+            is_verified=dr.is_authoritative,
             domain="IMAGE"
         )
         session.add(log)
         session.commit()
 
-        return result.to_dict()
-        
+        return dr.to_dict() | dr.developer_fields
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Image verification error: {redact_pii(str(e))}", exc_info=False)
-        return {
-            "status": "ERROR",
-            "error": "Internal processing error",
-            "verdict": "INCONCLUSIVE",
-            "confidence": 0.0
-        }
+        dr = DiagnosticResult.blocked(
+            "Internal processing error",
+            {"constraint_id": "api.image.execution_error", "verdict": "INCONCLUSIVE", "confidence": 0.0},
+        )
+        dr = _enforce_trust(dr, query=claim)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=f"Image claim: {claim}",
+            result=str(dr.to_dict()),
+            is_verified=False,
+            domain="IMAGE"
+        )
+        session.add(log)
+        session.commit()
+        return dr.to_dict() | dr.developer_fields
 
 class RAGVerifyRequest(BaseModel):
     target_document_id: str
@@ -1343,20 +1454,38 @@ async def verify_with_consensus(
         )
     
     # Log to database
+    if result.agreement_status == "unanimous":
+        dr = DiagnosticResult.verified(
+            "Consensus verification: unanimous",
+            developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
+            evidence={"agreement_status": result.agreement_status, "confidence": result.confidence},
+        )
+    elif result.agreement_status == "majority":
+        dr = DiagnosticResult.unverifiable(
+            "Consensus verification: majority agreement",
+            developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
+        )
+    else:
+        dr = DiagnosticResult.unverifiable(
+            "Consensus verification: no agreement",
+            developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
+        )
+    dr = _enforce_trust(dr, query=request.query)
+
     log = VerificationLog(
         organization_id=tenant.organization_id,
         query=request.query,
         result=f"Consensus: {result.agreement_status}, Confidence: {result.confidence:.1%}",
-        is_verified=(result.confidence >= request.min_confidence),
+        is_verified=dr.is_authoritative,
         domain="CONSENSUS"
     )
     session.add(log)
     session.commit()
-    
+
     # Format response
-    return {
+    response = {
         "final_answer": result.final_answer,
-        "confidence": round(result.confidence * 100, 2),  # Convert to percentage
+        "confidence": round(result.confidence * 100, 2),
         "engines_used": result.engines_used,
         "agreement_status": result.agreement_status,
         "verification_chain": [
@@ -1366,13 +1495,14 @@ async def verify_with_consensus(
                 "result": str(r.result),
                 "confidence": round(r.confidence * 100, 2),
                 "latency_ms": round(r.latency_ms, 2),
-                "success": r.success
+                "success": r.success,
             }
             for r in result.verification_chain
         ],
         "total_latency_ms": round(result.total_latency_ms, 2),
-        "meets_requirement": result.confidence >= request.min_confidence
+        "meets_requirement": result.confidence >= request.min_confidence,
     }
+    return response | {"proof_ref": dr.proof_ref, "diagnostic_status": dr.status.value, "is_authoritative": dr.is_authoritative}
 # --- Enterprise Security Endpoints (Week 2) ---
 
 from qwed_new.core.compliance_exporter import ComplianceExporter

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -892,7 +892,7 @@ async def verify_rag(
             )
         except ValueError as exc:
             logger.warning("RAG config error: %s", redact_pii(str(exc)))
-            raise HTTPException(status_code=400, detail="Invalid RAG configuration") from exc
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         
         audit_result = {
             "verified": result.get("verified", False),
@@ -1458,6 +1458,11 @@ async def verify_with_consensus(
         if hasattr(result, "status") and result.status == "BLOCKED":
             dr = DiagnosticResult.blocked(
                 "Consensus verification: blocked",
+                developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
+            )
+        elif hasattr(result, "status") and result.status == "UNVERIFIABLE":
+            dr = DiagnosticResult.unverifiable(
+                "Consensus verification: incomplete — some engines blocked",
                 developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
             )
         else:

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -133,12 +133,13 @@ def _merge_response(dr: DiagnosticResult) -> dict:
 def _safe_commit_log(session, log):
     """Write a VerificationLog safely, rolling back on failure."""
     try:
-        _safe_commit_log(session, log)
+        session.add(log)
+        session.commit()
     except Exception:
         try:
             session.rollback()
         except Exception:
-            pass
+            logger.exception("Rollback failed while handling commit/log failure")
 
 
 class VerifyRequest(BaseModel):
@@ -372,11 +373,20 @@ async def verify_stats(
         result = verifier.verify_stats(query, df, provider=None)
 
         if result.get("status") == "SUCCESS":
-            dr = DiagnosticResult.verified(
-                "Statistical analysis executed",
-                developer_fields=result,
-                evidence={"status": "SUCCESS", "analysis": str(result.get("analysis", ""))},
-            )
+            # SUCCESS means analysis executed — not that the claim was proven.
+            # Only return VERIFIED if the result explicitly confirms the claim.
+            claim_supported = result.get("claim_supported")
+            if claim_supported is True:
+                dr = DiagnosticResult.verified(
+                    "Statistical claim verified",
+                    developer_fields=result,
+                    evidence={"status": "SUCCESS", "claim_supported": True, "analysis": str(result.get("analysis", ""))},
+                )
+            else:
+                dr = DiagnosticResult.unverifiable(
+                    "Statistical analysis completed but claim not established",
+                    developer_fields=result,
+                )
         elif result.get("status") == "BLOCKED" and result.get("error") == SECURE_STATS_BLOCKED_CODE:
             dr = DiagnosticResult.blocked(
                 "Service temporarily unavailable",
@@ -1515,6 +1525,23 @@ async def verify_with_consensus(
     if result.agreement_status == "blocked_secure_execution":
         dr = DiagnosticResult.blocked(
             "Consensus verification: blocked — secure execution",
+            developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
+        )
+        dr = _enforce_trust(dr, query=request.query)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=request.query,
+            result=f"Consensus: {result.agreement_status}",
+            is_verified=dr.is_authoritative,
+            domain="CONSENSUS"
+        )
+        _safe_commit_log(session, log)
+        return _merge_response(dr)
+
+    # All engines blocked — preserve BLOCKED status (fail-closed)
+    if result.agreement_status == "blocked":
+        dr = DiagnosticResult.blocked(
+            "Consensus verification: all engines blocked",
             developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
         )
         dr = _enforce_trust(dr, query=request.query)

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -230,7 +230,7 @@ async def verify_natural_language(
         )
 
     if dr is None:
-        verification_result = result.get("verification", {})
+        verification_result = result.get("verification", {}) if isinstance(result, dict) else {}
         try:
             dr = DiagnosticResult.from_legacy_dict(verification_result, engine="math")
         except ValueError:
@@ -263,6 +263,7 @@ async def verify_logic(
     session: Session = Depends(get_session)
 ):
     check_rate_limit(tenant.api_key)
+    result = None
 
     try:
         result = await control_plane.process_logic_query(
@@ -310,10 +311,9 @@ async def verify_logic(
         raise
     except Exception as e:
         logger.error(f"Logic verification error: {redact_pii(str(e))}", exc_info=False)
-        response_result = locals().get("result")
         provider_used = (
-            response_result.get("provider_used")
-            if isinstance(response_result, dict) and response_result.get("provider_used")
+            result.get("provider_used")
+            if isinstance(result, dict) and result.get("provider_used")
             else control_plane.router.route(request.query, request.provider)
         )
         dr = DiagnosticResult.blocked(
@@ -641,7 +641,7 @@ async def verify_math(
                 )
             elif simplified.is_real is False and context_data.get("domain") == "real":
                 dr = DiagnosticResult.blocked(
-                    "Square root of negative number is undefined in real domain",
+                    "Expression is not real-valued in the requested real domain",
                     developer_fields={"is_valid": False, "error": "domain error"},
                 )
             elif is_ambiguous:
@@ -714,16 +714,15 @@ async def verify_sql(
     query = request.get("query")
     if not query:
         raise HTTPException(status_code=400, detail="Missing 'query'")
+    schema_ddl = request.get("schema_ddl")
+    if not schema_ddl:
+        raise HTTPException(status_code=400, detail="Missing 'schema_ddl'")
 
     try:
         from qwed_new.core.sql_verifier import SQLVerifier
         verifier = SQLVerifier()
 
-        schema_ddl = request.get("schema_ddl")
         dialect = request.get("dialect", "sqlite")
-
-        if not schema_ddl:
-            raise HTTPException(status_code=400, detail="Missing 'schema_ddl'")
 
         result = verifier.verify_sql(query, schema_ddl, dialect=dialect)
 
@@ -969,14 +968,15 @@ async def verify_rag(
         raise
     except Exception as e:
         logger.error(f"RAG verification error: {redact_pii(str(e))}", exc_info=False)
+        doc_id = getattr(request, 'target_document_id', 'unknown')
         dr = DiagnosticResult.blocked(
             INTERNAL_PROCESSING_ERROR,
             {"constraint_id": "api.rag.execution_error", "verified": False},
         )
-        dr = _enforce_trust(dr, query=getattr(request, 'target_document_id', 'unknown'))
+        dr = _enforce_trust(dr, query=doc_id)
         log = VerificationLog(
             organization_id=tenant.organization_id,
-            query=f"RAG Document Verify: {request.target_document_id}",
+            query=f"RAG Document Verify: {doc_id}",
             result=str(dr.to_dict()),
             is_verified=False,
             domain="RAG"

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -130,6 +130,17 @@ def _merge_response(dr: DiagnosticResult) -> dict:
     safe = {k: v for k, v in fields.items() if k not in _DIAGNOSTIC_KEYS}
     return serialized | safe
 
+def _safe_commit_log(session, log):
+    """Write a VerificationLog safely, rolling back on failure."""
+    try:
+        _safe_commit_log(session, log)
+    except Exception:
+        try:
+            session.rollback()
+        except Exception:
+            pass
+
+
 class VerifyRequest(BaseModel):
     query: str
     provider: Optional[str] = None
@@ -250,8 +261,7 @@ async def verify_natural_language(
         is_verified=dr.is_authoritative,
         domain="MATH"
     )
-    session.add(log)
-    session.commit()
+    _safe_commit_log(session, log)
 
     return _merge_response(dr)
 
@@ -301,8 +311,7 @@ async def verify_logic(
             is_verified=dr.is_authoritative,
             domain="LOGIC"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
 
         return _merge_response(dr)
 
@@ -328,8 +337,7 @@ async def verify_logic(
             is_verified=False,
             domain="LOGIC"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
 @app.post(
@@ -398,8 +406,7 @@ async def verify_stats(
             is_verified=dr.is_authoritative,
             domain="STATS"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
 
         return _merge_response(dr)
     except HTTPException:
@@ -419,8 +426,7 @@ async def verify_stats(
             is_verified=False,
             domain="STATS"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
 
@@ -480,8 +486,7 @@ async def verify_fact(
             is_verified=dr.is_authoritative,
             domain="FACT"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
 
         return _merge_response(dr)
 
@@ -501,8 +506,7 @@ async def verify_fact(
             is_verified=False,
             domain="FACT"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
 
@@ -551,8 +555,7 @@ async def verify_code(
             is_verified=dr.is_authoritative,
             domain="CODE"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
 
         return _merge_response(dr)
 
@@ -572,8 +575,7 @@ async def verify_code(
             is_verified=False,
             domain="CODE"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
 
@@ -681,8 +683,7 @@ async def verify_math(
             is_verified=dr.is_authoritative,
             domain="MATH"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
 
         return _merge_response(dr)
 
@@ -702,8 +703,7 @@ async def verify_math(
             is_verified=False,
             domain="MATH"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
 
@@ -753,8 +753,7 @@ async def verify_sql(
             is_verified=dr.is_authoritative,
             domain="SQL"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
 
         return _merge_response(dr)
 
@@ -774,8 +773,7 @@ async def verify_sql(
             is_verified=False,
             domain="SQL"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
 
@@ -827,8 +825,7 @@ async def verify_image(
             is_verified=dr.is_authoritative,
             domain="IMAGE"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
 
         return _merge_response(dr)
 
@@ -848,8 +845,7 @@ async def verify_image(
             is_verified=False,
             domain="IMAGE"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
 class RAGVerifyRequest(BaseModel):
@@ -925,8 +921,7 @@ async def verify_rag(
                 is_verified=False,
                 domain="RAG"
             )
-            session.add(log)
-            session.commit()
+            _safe_commit_log(session, log)
             return _merge_response(dr)
         
         is_verified = result.get("verified", False)
@@ -950,8 +945,7 @@ async def verify_rag(
             is_verified=dr.is_authoritative,
             domain="RAG"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         
         return _merge_response(dr)
         
@@ -972,8 +966,7 @@ async def verify_rag(
             is_verified=False,
             domain="RAG"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
 class ProcessVerifyRequest(BaseModel):
@@ -1037,8 +1030,7 @@ async def verify_process(
             is_verified=dr.is_authoritative,
             domain="PROCESS"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         
         return _merge_response(dr)
         
@@ -1058,8 +1050,7 @@ async def verify_process(
             is_verified=False,
             domain="PROCESS"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
 
@@ -1534,8 +1525,7 @@ async def verify_with_consensus(
             is_verified=dr.is_authoritative,
             domain="CONSENSUS"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
     if result.confidence < request.min_confidence:
@@ -1551,8 +1541,7 @@ async def verify_with_consensus(
             is_verified=dr.is_authoritative,
             domain="CONSENSUS"
         )
-        session.add(log)
-        session.commit()
+        _safe_commit_log(session, log)
         return _merge_response(dr)
 
     if result.agreement_status == "unanimous":
@@ -1591,8 +1580,7 @@ async def verify_with_consensus(
         is_verified=dr.is_authoritative,
         domain="CONSENSUS"
     )
-    session.add(log)
-    session.commit()
+    _safe_commit_log(session, log)
 
     # Format response
     response = {

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -362,9 +362,10 @@ async def verify_stats(
             raise HTTPException(status_code=403, detail="Verification blocked by security policy")
 
         if result.get("status") == "SUCCESS":
-            dr = DiagnosticResult.unverifiable(
+            dr = DiagnosticResult.verified(
                 "Statistical analysis executed",
                 developer_fields=result,
+                evidence=result,
             )
         else:
             dr = DiagnosticResult.blocked(
@@ -902,7 +903,7 @@ async def verify_rag(
             )
         except ValueError as exc:
             logger.warning("RAG config error: %s", redact_pii(str(exc)))
-            raise HTTPException(status_code=400, detail="Invalid RAG guard configuration") from exc
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         
         audit_result = {
             "verified": result.get("verified", False),
@@ -1526,7 +1527,7 @@ async def verify_with_consensus(
         "total_latency_ms": round(result.total_latency_ms, 2),
         "meets_requirement": result.confidence >= request.min_confidence,
     }
-    return response | _merge_response(dr)
+    return _merge_response(dr) | response
 # --- Enterprise Security Endpoints (Week 2) ---
 
 from qwed_new.core.compliance_exporter import ComplianceExporter

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -125,8 +125,10 @@ def _enforce_trust(
 _DIAGNOSTIC_KEYS = frozenset({"status", "agent_message", "developer_fields", "proof_ref", "is_authoritative"})
 def _merge_response(dr: DiagnosticResult) -> dict:
     """Merge diagnostic result with developer fields, ensuring diagnostic keys win."""
-    safe = {k: v for k, v in dr.developer_fields.items() if k not in _DIAGNOSTIC_KEYS}
-    return dr.to_dict() | safe
+    serialized = dr.to_dict()
+    fields = serialized.get("developer_fields", {})
+    safe = {k: v for k, v in fields.items() if k not in _DIAGNOSTIC_KEYS}
+    return serialized | safe
 
 class VerifyRequest(BaseModel):
     query: str

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -1025,28 +1025,51 @@ async def verify_process(
                 status_code=400,
                 detail="Invalid mode. Use 'irac' or 'milestones'."
             )
+        
+        if result.get("verified"):
+            dr = DiagnosticResult.verified(
+                "Process verification passed",
+                developer_fields=result,
+                evidence={"mode": request.mode, "verified": True},
+            )
+        else:
+            dr = DiagnosticResult.unverifiable(
+                "Process verification did not pass",
+                developer_fields=result,
+            )
+        dr = _enforce_trust(dr, query=request.trace)
             
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=f"Process Verification ({request.mode})",
-            result=str(result),
-            is_verified=result.get("verified", False),
+            result=str(dr.to_dict()),
+            is_verified=dr.is_authoritative,
             domain="PROCESS"
         )
         session.add(log)
         session.commit()
         
-        return result
+        return _merge_response(dr)
         
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Process verification error: {redact_pii(str(e))}", exc_info=False)
-        return {
-            "status": "ERROR",
-            "error": INTERNAL_PROCESSING_ERROR,
-            "verified": False
-        }
+        dr = DiagnosticResult.blocked(
+            INTERNAL_PROCESSING_ERROR,
+            {"constraint_id": "api.process.execution_error", "verified": False},
+        )
+        dr = _enforce_trust(dr, query=request.trace)
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=f"Process Verification ({request.mode})",
+            result=str(dr.to_dict()),
+            is_verified=False,
+            domain="PROCESS"
+        )
+        session.add(log)
+        session.commit()
+        return _merge_response(dr)
 
 
 # ============================================================

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -214,6 +214,7 @@ async def verify_natural_language(
 ):
     check_rate_limit(tenant.api_key)
 
+    dr = None
     try:
         result = await control_plane.process_natural_language(
             request.query,
@@ -222,16 +223,20 @@ async def verify_natural_language(
         )
     except Exception as e:
         logger.error("Natural language verification error: %s", redact_pii(str(e)), exc_info=False)
-        result = {"error": INTERNAL_VERIFICATION_ERROR}
-
-    verification_result = result.get("verification", {})
-    try:
-        dr = DiagnosticResult.from_legacy_dict(verification_result, engine="math")
-    except ValueError:
-        dr = DiagnosticResult.unverifiable(
-            "Verification result unavailable — legacy engine did not retain proof artifacts",
-            {"constraint_id": "api.natural_language.legacy_conversion_failed", "legacy_status": verification_result.get("status")},
+        dr = DiagnosticResult.blocked(
+            INTERNAL_VERIFICATION_ERROR,
+            {"constraint_id": "api.natural_language.execution_error"},
         )
+
+    if dr is None:
+        verification_result = result.get("verification", {})
+        try:
+            dr = DiagnosticResult.from_legacy_dict(verification_result, engine="math")
+        except ValueError:
+            dr = DiagnosticResult.unverifiable(
+                "Verification result unavailable — legacy engine did not retain proof artifacts",
+                {"constraint_id": "api.natural_language.legacy_conversion_failed", "legacy_status": verification_result.get("status")},
+            )
     dr = _enforce_trust(dr, query=request.query)
 
     log = VerificationLog(
@@ -705,6 +710,8 @@ async def verify_sql(
 ):
     check_rate_limit(tenant.api_key)
     query = request.get("query")
+    if not query:
+        raise HTTPException(status_code=400, detail="Missing 'query'")
 
     try:
         from qwed_new.core.sql_verifier import SQLVerifier
@@ -713,8 +720,8 @@ async def verify_sql(
         schema_ddl = request.get("schema_ddl")
         dialect = request.get("dialect", "sqlite")
 
-        if not query or not schema_ddl:
-            raise HTTPException(status_code=400, detail="Missing 'query' or 'schema_ddl'")
+        if not schema_ddl:
+            raise HTTPException(status_code=400, detail="Missing 'schema_ddl'")
 
         result = verifier.verify_sql(query, schema_ddl, dialect=dialect)
 
@@ -916,7 +923,7 @@ async def verify_rag(
             logger.warning("RAG config error: %s", redact_pii(str(exc)))
             dr = DiagnosticResult.unverifiable(
                 "RAG configuration error",
-                developer_fields={"constraint_id": "api.rag.config_error", "detail": str(exc)},
+                developer_fields={"constraint_id": "api.rag.config_error"},
             )
             dr = _enforce_trust(dr, query=request.target_document_id)
             log = VerificationLog(

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -1597,7 +1597,7 @@ async def verify_with_consensus(
     # Format response
     response = {
         "final_answer": result.final_answer,
-        "confidence": round(result.confidence * 100, 2),
+        "confidence": round(result.confidence, 4),
         "engines_used": result.engines_used,
         "agreement_status": result.agreement_status,
         "verification_chain": [
@@ -1605,7 +1605,7 @@ async def verify_with_consensus(
                 "engine": r.engine_name,
                 "method": r.method,
                 "result": str(r.result),
-                "confidence": round(r.confidence * 100, 2),
+                "confidence": round(r.confidence, 4),
                 "latency_ms": round(r.latency_ms, 2),
                 "success": r.success,
             }

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -238,7 +238,7 @@ async def verify_natural_language(
         organization_id=tenant.organization_id,
         user_id=tenant.user_id if hasattr(tenant, 'user_id') else None,
         query=request.query,
-        result=str(result),
+        result=str(dr.to_dict()),
         is_verified=dr.is_authoritative,
         domain="MATH"
     )
@@ -290,7 +290,7 @@ async def verify_logic(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=request.query,
-            result=str(result),
+            result=str(dr.to_dict()),
             is_verified=dr.is_authoritative,
             domain="LOGIC"
         )
@@ -356,20 +356,31 @@ async def verify_stats(
         verifier = StatsVerifier()
         
         result = verifier.verify_stats(query, df, provider=None)
-        if result.get("status") == "BLOCKED" and result.get("error") == SECURE_STATS_BLOCKED_CODE:
-            raise HTTPException(status_code=503, detail="Service temporarily unavailable")
-        if result.get("status") == "BLOCKED":
-            raise HTTPException(status_code=403, detail="Verification blocked by security policy")
 
         if result.get("status") == "SUCCESS":
             dr = DiagnosticResult.verified(
                 "Statistical analysis executed",
                 developer_fields=result,
-                evidence=result,
+                evidence={"status": "SUCCESS", "analysis": str(result.get("analysis", ""))},
+            )
+        elif result.get("status") == "BLOCKED" and result.get("error") == SECURE_STATS_BLOCKED_CODE:
+            dr = DiagnosticResult.blocked(
+                "Service temporarily unavailable",
+                developer_fields=result,
+            )
+        elif result.get("status") == "BLOCKED":
+            dr = DiagnosticResult.blocked(
+                "Verification blocked by security policy",
+                developer_fields=result,
+            )
+        elif result.get("status") in ("ERROR", "EXECUTION_FAILED"):
+            dr = DiagnosticResult.unverifiable(
+                result.get("message", "Statistical analysis failed"),
+                developer_fields=result,
             )
         else:
             dr = DiagnosticResult.blocked(
-                result.get("message", "Statistical analysis failed"),
+                "Statistical analysis failed",
                 developer_fields=result,
             )
         dr = _enforce_trust(dr, query=query)
@@ -903,37 +914,67 @@ async def verify_rag(
             )
         except ValueError as exc:
             logger.warning("RAG config error: %s", redact_pii(str(exc)))
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            dr = DiagnosticResult.unverifiable(
+                "RAG configuration error",
+                developer_fields={"constraint_id": "api.rag.config_error", "detail": str(exc)},
+            )
+            dr = _enforce_trust(dr, query=request.target_document_id)
+            log = VerificationLog(
+                organization_id=tenant.organization_id,
+                query=f"RAG Document Verify: {request.target_document_id}",
+                result=str(dr.to_dict()),
+                is_verified=False,
+                domain="RAG"
+            )
+            session.add(log)
+            session.commit()
+            return _merge_response(dr)
         
-        audit_result = {
-            "verified": result.get("verified", False),
-            "risk": result.get("risk"),
-            "drm_rate": result.get("drm_rate"),
-            "chunks_checked": result.get("chunks_checked"),
-            "mismatched_count": result.get("mismatched_count"),
-        }
+        is_verified = result.get("verified", False)
+        if is_verified:
+            dr = DiagnosticResult.verified(
+                "RAG context verified",
+                developer_fields=result,
+                evidence={"verified": True, "drm_rate": result.get("drm_rate")},
+            )
+        else:
+            dr = DiagnosticResult.unverifiable(
+                "RAG context mismatch detected",
+                developer_fields=result,
+            )
+        dr = _enforce_trust(dr, query=request.target_document_id)
 
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=f"RAG Document Verify: {request.target_document_id}",
-            result=str(audit_result),
-            is_verified=result.get("verified", False),
+            result=str(dr.to_dict()),
+            is_verified=dr.is_authoritative,
             domain="RAG"
         )
         session.add(log)
         session.commit()
         
-        return result
+        return _merge_response(dr)
         
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"RAG verification error: {redact_pii(str(e))}", exc_info=False)
-        return {
-            "status": "ERROR",
-            "error": INTERNAL_PROCESSING_ERROR,
-            "verified": False
-        }
+        dr = DiagnosticResult.blocked(
+            INTERNAL_PROCESSING_ERROR,
+            {"constraint_id": "api.rag.execution_error", "verified": False},
+        )
+        dr = _enforce_trust(dr, query=getattr(request, 'target_document_id', 'unknown'))
+        log = VerificationLog(
+            organization_id=tenant.organization_id,
+            query=f"RAG Document Verify: {request.target_document_id}",
+            result=str(dr.to_dict()),
+            is_verified=False,
+            domain="RAG"
+        )
+        session.add(log)
+        session.commit()
+        return _merge_response(dr)
 
 class ProcessVerifyRequest(BaseModel):
     trace: str

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -459,6 +459,8 @@ async def verify_fact(
 
         return _merge_response(dr)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Fact verification error: {redact_pii(str(e))}", exc_info=False)
         dr = DiagnosticResult.blocked(
@@ -528,6 +530,8 @@ async def verify_code(
 
         return _merge_response(dr)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Code verification error: {redact_pii(str(e))}", exc_info=False)
         dr = DiagnosticResult.blocked(
@@ -537,7 +541,7 @@ async def verify_code(
         dr = _enforce_trust(dr, query=code)
         log = VerificationLog(
             organization_id=tenant.organization_id,
-            query=code[:200],
+            query=(code or "")[:200],
             result=str(dr.to_dict()),
             is_verified=False,
             domain="CODE"
@@ -719,6 +723,8 @@ async def verify_sql(
 
         return _merge_response(dr)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"SQL verification error: {redact_pii(str(e))}", exc_info=False)
         dr = DiagnosticResult.blocked(
@@ -885,7 +891,8 @@ async def verify_rag(
                 retrieved_chunks=request.chunks
             )
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            logger.warning("RAG config error: %s", redact_pii(str(exc)))
+            raise HTTPException(status_code=400, detail="Invalid RAG configuration") from exc
         
         audit_result = {
             "verified": result.get("verified", False),
@@ -1226,7 +1233,8 @@ async def register_agent(
             "message": "Agent registered successfully. Store the agent_token securely."
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Agent registration error: {redact_pii(str(e))}", exc_info=False)
+        raise HTTPException(status_code=500, detail="Agent registration failed")
 
 @app.post(
     "/agents/{agent_id}/verify",

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -260,7 +260,7 @@ async def verify_logic(
 
         status = result.get("status", "ERROR")
         if status == "BLOCKED":
-            raise HTTPException(status_code=403, detail=result["error"])
+            raise HTTPException(status_code=403, detail=result.get("error", "Blocked due to an unspecified error"))
 
         if status == "SAT":
             dr = DiagnosticResult.verified(
@@ -589,7 +589,7 @@ async def verify_math(
                     evidence=fields,
                 )
             else:
-                dr = DiagnosticResult.blocked(
+                dr = DiagnosticResult.unverifiable(
                     "Identity is false",
                     developer_fields={"is_valid": False, "result": False, **fields},
                 )

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -651,19 +651,26 @@ async def verify_math(
                 )
             else:
                 is_numeric = simplified.free_symbols == set()
-                try:
-                    exact = sympy.nsimplify(simplified) if is_numeric else simplified
-                    value = float(simplified)
+                if not is_numeric:
                     dr = DiagnosticResult.verified(
-                        "Expression evaluated",
-                        developer_fields={"is_valid": True, "value": value, "exact_value": str(exact), "simplified": str(simplified), "original": str(parsed)},
-                        evidence={"exact_value": str(exact), "simplified": str(simplified)},
+                        "Expression simplified",
+                        developer_fields={"is_valid": True, "simplified": str(simplified), "original": str(parsed), "is_symbolic": True},
+                        evidence={"simplified": str(simplified)},
                     )
-                except (TypeError, ValueError):
-                    dr = DiagnosticResult.unverifiable(
-                        "Expression is not numeric",
-                        developer_fields={"is_valid": False, "simplified": str(simplified), "original": str(parsed)},
-                    )
+                else:
+                    try:
+                        exact = sympy.nsimplify(simplified)
+                        value = float(simplified)
+                        dr = DiagnosticResult.verified(
+                            "Expression evaluated",
+                            developer_fields={"is_valid": True, "value": value, "exact_value": str(exact), "simplified": str(simplified), "original": str(parsed)},
+                            evidence={"exact_value": str(exact), "simplified": str(simplified)},
+                        )
+                    except (TypeError, ValueError):
+                        dr = DiagnosticResult.unverifiable(
+                            "Expression is not numeric",
+                            developer_fields={"is_valid": False, "simplified": str(simplified), "original": str(parsed)},
+                        )
 
         dr = _enforce_trust(dr, query=expression)
 

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -809,22 +809,7 @@ async def verify_image(
         verifier = ImageVerifier(use_vlm_fallback=False)
         result = verifier.verify_image(image_bytes, claim)
 
-        if isinstance(result, DiagnosticResult):
-            dr = result
-        else:
-            image_verdict = result.verdict if hasattr(result, "verdict") else "UNKNOWN"
-            evidence = {"claim": claim, "verdict": image_verdict}
-            if result.is_verified:
-                dr = DiagnosticResult.verified(
-                    "Image claim verified",
-                    developer_fields=result.to_dict(),
-                    evidence=evidence,
-                )
-            else:
-                dr = DiagnosticResult.unverifiable(
-                    "Image claim not supported",
-                    developer_fields=result.to_dict(),
-                )
+        dr = result
         dr = _enforce_trust(dr, query=claim)
 
         log = VerificationLog(

--- a/tests/test_api_exceptions.py
+++ b/tests/test_api_exceptions.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock
 from qwed_new.api.main import app, get_current_tenant, get_session, check_rate_limit, TenantContext
@@ -19,10 +20,12 @@ def mock_get_session():
 def mock_check_rate_limit(api_key: str):
     pass # No-op
 
-# Apply overrides
-app.dependency_overrides[get_current_tenant] = mock_get_current_tenant
-app.dependency_overrides[get_session] = mock_get_session
-app.dependency_overrides[check_rate_limit] = mock_check_rate_limit
+@pytest.fixture(autouse=True)
+def _apply_overrides():
+    app.dependency_overrides[get_current_tenant] = mock_get_current_tenant
+    app.dependency_overrides[get_session] = mock_get_session
+    app.dependency_overrides[check_rate_limit] = mock_check_rate_limit
+    yield
 
 client = TestClient(app)
 

--- a/tests/test_api_exceptions.py
+++ b/tests/test_api_exceptions.py
@@ -26,6 +26,9 @@ def _apply_overrides():
     app.dependency_overrides[get_session] = mock_get_session
     app.dependency_overrides[check_rate_limit] = mock_check_rate_limit
     yield
+    app.dependency_overrides.pop(get_current_tenant, None)
+    app.dependency_overrides.pop(get_session, None)
+    app.dependency_overrides.pop(check_rate_limit, None)
 
 client = TestClient(app)
 

--- a/tests/test_api_exceptions.py
+++ b/tests/test_api_exceptions.py
@@ -41,8 +41,8 @@ def test_verify_math_exception_handling():
         # It should return 200 OK (soft failure) as per our logic, or handle it gracefully
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "ERROR"
-        assert data["error"] == "Internal verification error"
+        assert data["status"] == "BLOCKED"
+        assert data["agent_message"] == "Internal verification error"
         assert "CRITICAL SENSITIVE STACK TRACE" not in str(data) # Ensure leak prevention
 
 def test_verify_sql_exception_handling():
@@ -61,8 +61,8 @@ def test_verify_sql_exception_handling():
         
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "ERROR"
-        assert data["error"] == "Internal verification error"
+        assert data["status"] == "BLOCKED"
+        assert data["agent_message"] == "Internal verification error"
         assert "DB_PASSWORD" not in str(data)
 
 def test_verify_fact_exception_handling():
@@ -80,8 +80,8 @@ def test_verify_fact_exception_handling():
         
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "ERROR"
-        assert data["error"] == "Internal verification error"
+        assert data["status"] == "BLOCKED"
+        assert data["agent_message"] == "Internal verification error"
         assert "API_KEY_LEAK" not in str(data)
 
 def test_verify_fact_success_path():
@@ -135,8 +135,8 @@ def test_verify_code_exception_handling():
         
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "ERROR"
-        assert data["error"] == "Internal verification error"
+        assert data["status"] == "BLOCKED"
+        assert data["agent_message"] == "Internal verification error"
         assert "INTERNAL_PATH_LEAK" not in str(data)
 
 def test_verify_image_exception_handling():
@@ -154,8 +154,8 @@ def test_verify_image_exception_handling():
         
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "ERROR"
-        assert data["error"] == "Internal processing error"
+        assert data["status"] == "BLOCKED"
+        assert data["agent_message"] == "Internal processing error"
         assert "VLM_API_KEY_LEAK" not in str(data)
 
 
@@ -174,8 +174,8 @@ def test_verify_stats_exception_handling():
         
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "ERROR"
-        assert data["error"] == "Internal processing error"
+        assert data["status"] == "BLOCKED"
+        assert data["agent_message"] == "Internal processing error"
         assert "SENSITIVE_DATA_LEAK" not in str(data)
 
 def test_agent_tool_call_exception_handling():

--- a/tests/test_api_phase17_endpoints.py
+++ b/tests/test_api_phase17_endpoints.py
@@ -84,10 +84,9 @@ def test_verify_process_endpoint_exception_uses_verified_flag(mock_verify_irac, 
 
     assert response.status_code == 200
     data = response.json()
-    assert data["status"] == "ERROR"
-    assert data["error"] == "Internal processing error"
+    assert data["status"] == "BLOCKED"
+    assert data["agent_message"] == "Internal processing error"
     assert data["verified"] is False
-    assert "is_valid" not in data
 
 @patch("qwed_sdk.guards.rag_guard.RAGGuard.verify_retrieval_context")
 def test_verify_rag_endpoint(mock_verify_retrieval_context, client):

--- a/tests/test_api_phase17_endpoints.py
+++ b/tests/test_api_phase17_endpoints.py
@@ -14,7 +14,8 @@ def client():
     
     yield TestClient(app)
     
-    app.dependency_overrides.clear()
+    del app.dependency_overrides[get_current_tenant]
+    del app.dependency_overrides[get_session]
 
 def test_verify_process_endpoint(client):
     response = client.post("/verify/process", json={
@@ -121,7 +122,7 @@ def test_verify_rag_endpoint_rejects_empty_document_id(client):
     assert response.status_code == 422
 
 @patch("qwed_sdk.guards.rag_guard.RAGGuard.verify_retrieval_context", side_effect=ValueError("Invalid chunk metadata"))
-def test_verify_rag_endpoint_invalid_guard_input_returns_400(mock_verify_retrieval_context, client):
+def test_verify_rag_endpoint_guard_rejection_returns_unverifiable(mock_verify_retrieval_context, client):
     response = client.post("/verify/rag", json={
         "target_document_id": "doc123",
         "chunks": [{"text": "Hello world"}],
@@ -131,6 +132,7 @@ def test_verify_rag_endpoint_invalid_guard_input_returns_400(mock_verify_retriev
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "UNVERIFIABLE"
+    assert data["proof_ref"] is None
 
 @patch("qwed_sdk.guards.rag_guard.RAGGuard.__init__", side_effect=RuntimeError("SecretDBPassword123"))
 def test_verify_rag_endpoint_exception_no_leak(mock_rag_init, client):
@@ -143,6 +145,7 @@ def test_verify_rag_endpoint_exception_no_leak(mock_rag_init, client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "BLOCKED"
+    assert data["proof_ref"] is None
     assert "SecretDBPassword123" not in str(data)
     assert "agent_message" in data
 

--- a/tests/test_api_phase17_endpoints.py
+++ b/tests/test_api_phase17_endpoints.py
@@ -128,8 +128,9 @@ def test_verify_rag_endpoint_invalid_guard_input_returns_400(mock_verify_retriev
         "max_drm_rate": "0"
     }, headers={"x-api-key": "fake-key"})
 
-    assert response.status_code == 400
-    assert response.json()["detail"] == "Invalid chunk metadata"
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
 
 @patch("qwed_sdk.guards.rag_guard.RAGGuard.__init__", side_effect=RuntimeError("SecretDBPassword123"))
 def test_verify_rag_endpoint_exception_no_leak(mock_rag_init, client):
@@ -141,9 +142,9 @@ def test_verify_rag_endpoint_exception_no_leak(mock_rag_init, client):
     
     assert response.status_code == 200
     data = response.json()
-    assert data["status"] == "ERROR"
+    assert data["status"] == "BLOCKED"
     assert "SecretDBPassword123" not in str(data)
-    assert "message" not in data
+    assert "agent_message" in data
 
 @patch("qwed_sdk.guards.mcp_poison_guard.MCPPoisonGuard.verify_tool_definition")
 @patch("qwed_sdk.guards.exfiltration_guard.ExfiltrationGuard.scan_payload")

--- a/tests/test_api_verify_math.py
+++ b/tests/test_api_verify_math.py
@@ -31,7 +31,7 @@ def test_verify_math_ambiguous_expression_fails_closed_and_logs_unverified():
         assert data["is_valid"] is False
         assert data["result"] is False
         assert data["warning"] == "ambiguous"
-        assert "implicit multiplication after division" in data["message"]
+        assert "implicit multiplication after division" in data["agent_message"]
 
         logged = mock_session.add.call_args[0][0]
         assert logged.is_verified is False

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -394,9 +394,9 @@ def test_get_optional_api_key_record_success():
     mock_session = MagicMock()
     mock_session.execute.return_value.scalars.return_value.first.return_value = mock_api_key
 
-    with patch("qwed_new.api.main.hash_api_key", return_value="test-hash-0000"):
+    with patch("qwed_new.api.main.hash_api_key", return_value="test_hash"):
         result = get_optional_api_key_record(
-            x_api_key="test-key-0000",
+            x_api_key="test_value",
             session=mock_session,
         )
 

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -1,0 +1,249 @@
+"""Coverage tests for DiagnosticResult integration in API endpoints.
+
+Targets uncovered code paths reported by SonarQube for #264.
+"""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from fastapi.testclient import TestClient
+
+from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
+
+
+@pytest.fixture
+def client():
+    from qwed_new.api.main import app, get_current_tenant, get_session
+
+    mock_tenant = MagicMock(organization_id=1, api_key="placeholder", organization_name="Test Org")
+    mock_session = MagicMock(add=MagicMock(), commit=MagicMock())
+
+    app.dependency_overrides[get_current_tenant] = lambda: mock_tenant
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    yield TestClient(app)
+
+    app.dependency_overrides.clear()
+
+
+def test_verify_natural_language_success_path(client):
+    """Cover from_legacy_dict success path, _enforce_trust, and VerificationLog."""
+    mock_result = {
+        "verification": {"is_correct": True, "status": "VERIFIED"},
+        "proof_ref": "abc123",
+    }
+    with patch("qwed_new.api.main.control_plane.process_natural_language", new_callable=AsyncMock, return_value=mock_result), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/natural_language",
+            json={"query": "test query"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "proof_ref" in data
+    assert "diagnostic_status" in data
+
+
+def test_verify_natural_language_legacy_fallback(client):
+    """Cover from_legacy_dict ValueError -> blocked fallback."""
+    mock_result = {
+        "verification": {"is_correct": True, "status": "VERIFIED"},
+    }
+    with patch("qwed_new.api.main.control_plane.process_natural_language", new_callable=AsyncMock, return_value=mock_result), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/natural_language",
+            json={"query": "test query"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["diagnostic_status"] == "BLOCKED"
+    assert data["proof_ref"] is None
+
+
+def test_verify_logic_sat_path(client):
+    """Cover SAT path with DiagnosticResult.verified, _enforce_trust, logging."""
+    mock_result = {
+        "status": "SAT",
+        "model": {"x": 6},
+        "dsl_code": "(GT x 5)",
+        "error": None,
+        "provider_used": None,
+    }
+    with patch("qwed_new.api.main.control_plane.process_logic_query", new_callable=AsyncMock, return_value=mock_result), \
+         patch("qwed_new.api.main.check_rate_limit"), \
+         patch("qwed_new.api.main.control_plane.router.route", return_value="openai"):
+        response = client.post(
+            "/verify/logic",
+            json={"query": "x > 5"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "SAT"
+    assert data["diagnostic_status"] == "VERIFIED"
+
+
+def test_verify_logic_unsat_path(client):
+    """Cover UNSAT path with DiagnosticResult.unverifiable."""
+    mock_result = {
+        "status": "UNSAT",
+        "model": {},
+        "dsl_code": "(NOT (GT x 5))",
+        "error": None,
+        "provider_used": None,
+    }
+    with patch("qwed_new.api.main.control_plane.process_logic_query", new_callable=AsyncMock, return_value=mock_result), \
+         patch("qwed_new.api.main.check_rate_limit"), \
+         patch("qwed_new.api.main.control_plane.router.route", return_value="openai"):
+        response = client.post(
+            "/verify/logic",
+            json={"query": "x <= 5"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNSAT"
+    assert data["diagnostic_status"] == "UNVERIFIABLE"
+
+
+def test_verify_stats_success_unverifiable(client):
+    """Cover stats SUCCESS -> UNVERIFIABLE (execution != verification)."""
+    with patch("qwed_new.core.stats_verifier.StatsVerifier.verify_stats", return_value={"status": "SUCCESS", "analysis": "mean=2.0"}), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/stats",
+            files={"file": ("data.csv", b"value\n1\n2\n3\n", "text/csv")},
+            data={"query": "What is the mean?"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+    assert data["is_authoritative"] is False
+
+
+def test_verify_fact_preserves_diagnostic_result(client):
+    """Cover isinstance(result, DiagnosticResult) pass-through in fact endpoint."""
+    dr = DiagnosticResult(
+        status=DiagnosticStatus.BLOCKED,
+        agent_message="Fact refuted by evidence",
+        developer_fields={"verdict": "REFUTED", "confidence": 0.95},
+        proof_ref=None,
+    )
+    with patch("qwed_new.core.fact_verifier.FactVerifier.verify_fact", return_value=dr), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/fact",
+            json={"claim": "Sky is green", "context": "Sky is blue"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "BLOCKED"
+    assert data["agent_message"] == "Fact refuted by evidence"
+    assert data["verdict"] == "REFUTED"
+
+
+def test_verify_code_missing_code_returns_400(client):
+    """Cover HTTPException from missing code field in verify_code."""
+    with patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/code",
+            json={"language": "python"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing 'code'"
+
+
+def test_verify_code_review_status(client):
+    """Cover REVIEW status -> UNVERIFIABLE."""
+    with patch("qwed_new.core.code_verifier.CodeVerifier.verify_code", return_value={"status": "REVIEW", "is_safe": True, "message": "Minor warnings"}), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/code",
+            json={"code": "x = 1", "language": "python"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+
+
+def test_verify_consensus_blocked_status(client):
+    """Cover consensus agreement_status=unanimous with result.status=BLOCKED."""
+    from qwed_new.core.consensus_verifier import ConsensusResult
+
+    fake = MagicMock(spec=ConsensusResult)
+    fake.final_answer = None
+    fake.confidence = 0.0
+    fake.engines_used = 2
+    fake.agreement_status = "unanimous"
+    fake.status = "BLOCKED"
+    fake.verification_chain = []
+    fake.total_latency_ms = 5.0
+
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["diagnostic_status"] == "BLOCKED"
+        assert data["is_authoritative"] is False
+
+
+def test_verify_consensus_unverifiable_status(client):
+    """Cover consensus agreement_status=unanimous with result.status=UNVERIFIABLE."""
+    from qwed_new.core.consensus_verifier import ConsensusResult
+
+    fake = MagicMock(spec=ConsensusResult)
+    fake.final_answer = "maybe"
+    fake.confidence = 0.5
+    fake.engines_used = 2
+    fake.agreement_status = "unanimous"
+    fake.status = "UNVERIFIABLE"
+    fake.verification_chain = []
+    fake.total_latency_ms = 5.0
+
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["diagnostic_status"] == "UNVERIFIABLE"
+        assert data["is_authoritative"] is False
+
+
+def test_verify_consensus_no_agreement(client):
+    """Cover else branch (no_consensus/split) -> UNVERIFIABLE."""
+    from qwed_new.core.consensus_verifier import ConsensusResult
+
+    fake = MagicMock(spec=ConsensusResult)
+    fake.final_answer = None
+    fake.confidence = 0.3
+    fake.engines_used = 3
+    fake.agreement_status = "split"
+    fake.status = None
+    fake.verification_chain = []
+    fake.total_latency_ms = 10.0
+
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["diagnostic_status"] == "UNVERIFIABLE"
+    assert data["is_authoritative"] is False

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -4,7 +4,7 @@ Targets uncovered code paths reported by SonarQube for #264.
 """
 import os
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock, sentinel
+from unittest.mock import patch, MagicMock, AsyncMock
 from fastapi.testclient import TestClient
 from fastapi import HTTPException
 
@@ -94,6 +94,7 @@ def test_verify_natural_language_internal_error(client):
     data = response.json()
     assert data["status"] == "UNVERIFIABLE"
     assert data["proof_ref"] is None
+    assert "Engine down" not in response.text
 
 
 def test_verify_logic_sat_path(client):
@@ -144,7 +145,7 @@ def test_verify_logic_unsat_path(client):
     assert data["proof_ref"] is None
 
 
-def test_verify_stats_success_unverifiable(client):
+def test_verify_stats_success_verified(client):
     """Cover stats SUCCESS -> VERIFIED (execution result IS the evidence)."""
     with patch("qwed_new.core.stats_verifier.StatsVerifier.verify_stats", return_value={"status": "SUCCESS", "analysis": "mean=2.0"}), \
          patch("qwed_new.api.main.check_rate_limit"):
@@ -392,9 +393,9 @@ def test_get_optional_api_key_record_success():
     mock_session = MagicMock()
     mock_session.execute.return_value.scalars.return_value.first.return_value = mock_api_key
 
-    with patch("qwed_new.api.main.hash_api_key", return_value="hashed_value"):
+    with patch("qwed_new.api.main.hash_api_key", return_value="QWED_TEST_VALUE"):
         result = get_optional_api_key_record(
-            x_api_key="sk-test-key",
+            x_api_key="QWED_TEST_VALUE",
             session=mock_session,
         )
 

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -2,6 +2,7 @@
 
 Targets uncovered code paths reported by SonarQube for #264.
 """
+import os
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 from fastapi.testclient import TestClient
@@ -13,7 +14,7 @@ from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
 def client():
     from qwed_new.api.main import app, get_current_tenant, get_session
 
-    mock_tenant = MagicMock(organization_id=1, api_key="sk-test-fixture-key-do-not-use-in-production", organization_name="Test Org")
+    mock_tenant = MagicMock(organization_id=1, api_key=os.environ.get("QWED_TEST_API_KEY", "sentinel"), organization_name="Test Org")
     mock_session = MagicMock(add=MagicMock(), commit=MagicMock())
 
     app.dependency_overrides[get_current_tenant] = lambda: mock_tenant
@@ -40,6 +41,7 @@ def test_verify_natural_language_success_path(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "UNVERIFIABLE"
+    assert data["proof_ref"] is None
 
 
 def test_verify_natural_language_legacy_conversion_fails(client):
@@ -99,6 +101,7 @@ def test_verify_logic_sat_path(client):
     data = response.json()
     assert data["status"] == "VERIFIED"
     assert data["agent_message"] == "Logic constraints are satisfiable"
+    assert data["proof_ref"]
 
 
 def test_verify_logic_unsat_path(client):
@@ -122,10 +125,11 @@ def test_verify_logic_unsat_path(client):
     data = response.json()
     assert data["status"] == "UNVERIFIABLE"
     assert data["agent_message"] == "Logic constraints are unsatisfiable"
+    assert data["proof_ref"] is None
 
 
 def test_verify_stats_success_unverifiable(client):
-    """Cover stats SUCCESS -> UNVERIFIABLE (execution != verification)."""
+    """Cover stats SUCCESS -> VERIFIED (execution result IS the evidence)."""
     with patch("qwed_new.core.stats_verifier.StatsVerifier.verify_stats", return_value={"status": "SUCCESS", "analysis": "mean=2.0"}), \
          patch("qwed_new.api.main.check_rate_limit"):
         response = client.post(
@@ -136,8 +140,9 @@ def test_verify_stats_success_unverifiable(client):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["status"] == "UNVERIFIABLE"
-    assert data["is_authoritative"] is False
+    assert data["status"] == "VERIFIED"
+    assert data["is_authoritative"] is True
+    assert data["proof_ref"]
 
 
 def test_verify_fact_preserves_diagnostic_result(client):
@@ -160,6 +165,7 @@ def test_verify_fact_preserves_diagnostic_result(client):
     assert data["status"] == "BLOCKED"
     assert data["agent_message"] == "Fact refuted by evidence"
     assert data["verdict"] == "REFUTED"
+    assert data["proof_ref"] is None
 
 
 def test_verify_fact_legacy_object_verified(client):
@@ -179,6 +185,7 @@ def test_verify_fact_legacy_object_verified(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "VERIFIED"
+    assert data["proof_ref"]
 
 
 def test_verify_fact_legacy_object_unverified(client):
@@ -197,6 +204,7 @@ def test_verify_fact_legacy_object_unverified(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "UNVERIFIABLE"
+    assert data["proof_ref"] is None
 
 
 def test_verify_fact_unknown_result(client):
@@ -211,6 +219,7 @@ def test_verify_fact_unknown_result(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "UNVERIFIABLE"
+    assert data["proof_ref"] is None
 
 
 def test_verify_sql_unverified(client):
@@ -225,6 +234,7 @@ def test_verify_sql_unverified(client):
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "BLOCKED"
+        assert data["proof_ref"] is None
 
 
 def test_verify_code_missing_code_returns_400(client):
@@ -251,6 +261,7 @@ def test_verify_code_review_status(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "UNVERIFIABLE"
+    assert data["proof_ref"] is None
 
 
 def test_verify_consensus_blocked_status(client):
@@ -278,6 +289,7 @@ def test_verify_consensus_blocked_status(client):
     assert data["status"] == "BLOCKED"
     assert data["is_authoritative"] is False
     assert data["final_answer"] is None
+    assert data["proof_ref"] is None
 
 
 def test_verify_consensus_unverifiable_status(client):
@@ -300,11 +312,12 @@ def test_verify_consensus_unverifiable_status(client):
             json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
         )
 
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "UNVERIFIABLE"
-        assert data["is_authoritative"] is False
-        assert data["final_answer"] == "maybe"
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+    assert data["proof_ref"] is None
+    assert data["is_authoritative"] is False
+    assert data["final_answer"] == "maybe"
 
 
 def test_verify_consensus_no_agreement(client):
@@ -331,3 +344,4 @@ def test_verify_consensus_no_agreement(client):
     data = response.json()
     assert data["status"] == "UNVERIFIABLE"
     assert data["is_authoritative"] is False
+    assert data["proof_ref"] is None

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -13,7 +13,7 @@ from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
 def client():
     from qwed_new.api.main import app, get_current_tenant, get_session
 
-    mock_tenant = MagicMock(organization_id=1, api_key="placeholder", organization_name="Test Org")
+    mock_tenant = MagicMock(organization_id=1, api_key="QWED_TEST_VALUE", organization_name="Test Org")
     mock_session = MagicMock(add=MagicMock(), commit=MagicMock())
 
     app.dependency_overrides[get_current_tenant] = lambda: mock_tenant
@@ -27,7 +27,7 @@ def client():
 def test_verify_natural_language_success_path(client):
     """Cover from_legacy_dict success path, _enforce_trust, and VerificationLog."""
     mock_result = {
-        "verification": {"is_correct": True, "status": "VERIFIED"},
+        "verification": {"is_correct": True},
         "proof_ref": "abc123",
     }
     with patch("qwed_new.api.main.control_plane.process_natural_language", new_callable=AsyncMock, return_value=mock_result), \
@@ -43,10 +43,27 @@ def test_verify_natural_language_success_path(client):
     assert "diagnostic_status" in data
 
 
-def test_verify_natural_language_legacy_fallback(client):
-    """Cover from_legacy_dict ValueError -> blocked fallback."""
+def test_verify_natural_language_legacy_verified(client):
+    """Cover from_legacy_dict ValueError -> VERIFIED passthrough for VERIFIED legacy."""
     mock_result = {
         "verification": {"is_correct": True, "status": "VERIFIED"},
+    }
+    with patch("qwed_new.api.main.control_plane.process_natural_language", new_callable=AsyncMock, return_value=mock_result), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/natural_language",
+            json={"query": "test query"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["diagnostic_status"] == "VERIFIED"
+
+
+def test_verify_natural_language_legacy_unrecognized(client):
+    """Cover from_legacy_dict ValueError -> BLOCKED for unrecognized legacy."""
+    mock_result = {
+        "verification": {"is_correct": True, "status": "XYZZY"},
     }
     with patch("qwed_new.api.main.control_plane.process_natural_language", new_callable=AsyncMock, return_value=mock_result), \
          patch("qwed_new.api.main.check_rate_limit"):
@@ -145,6 +162,73 @@ def test_verify_fact_preserves_diagnostic_result(client):
     assert data["verdict"] == "REFUTED"
 
 
+def test_verify_fact_legacy_object_verified(client):
+    """Cover fact endpoint hasattr(result, 'to_dict') with is_verified=True."""
+    mock_result = MagicMock()
+    mock_result.to_dict.return_value = {"verdict": "SUPPORTED", "confidence": 0.95}
+    mock_result.is_verified = True
+    mock_result.verdict = "SUPPORTED"
+    mock_result.__class__.__module__ = "unittest.mock"
+
+    with patch("qwed_new.core.fact_verifier.FactVerifier.verify_fact", return_value=mock_result), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/fact",
+            json={"claim": "Sky is blue", "context": "Sky is blue"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "VERIFIED"
+
+
+def test_verify_fact_legacy_object_unverified(client):
+    """Cover fact endpoint hasattr(result, 'to_dict') with is_verified=False."""
+    mock_result = MagicMock()
+    mock_result.to_dict.return_value = {"verdict": "NEUTRAL", "confidence": 0.5}
+    mock_result.is_verified = False
+    mock_result.__class__.__module__ = "unittest.mock"
+
+    with patch("qwed_new.core.fact_verifier.FactVerifier.verify_fact", return_value=mock_result), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/fact",
+            json={"claim": "maybe", "context": "uncertain"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+
+
+def test_verify_fact_unknown_result(client):
+    """Cover fact endpoint else branch (bare string result)."""
+    with patch("qwed_new.core.fact_verifier.FactVerifier.verify_fact", return_value="plain string result"), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/fact",
+            json={"claim": "test", "context": "test context"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+
+
+def test_verify_sql_unverified(client):
+    """Cover SQL endpoint is_valid=False -> BLOCKED."""
+    with patch("qwed_new.core.sql_verifier.SQLVerifier.verify_sql", return_value={"is_valid": False, "message": "Invalid syntax"}), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/sql",
+            json={"query": "SELECT *", "schema_ddl": "CREATE TABLE t (id int)", "type": "postgres"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "BLOCKED"
+
+
 def test_verify_code_missing_code_returns_400(client):
     """Cover HTTPException from missing code field in verify_code."""
     with patch("qwed_new.api.main.check_rate_limit"):
@@ -191,10 +275,10 @@ def test_verify_consensus_blocked_status(client):
             json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
         )
 
-        assert response.status_code == 200
-        data = response.json()
-        assert data["diagnostic_status"] == "BLOCKED"
-        assert data["is_authoritative"] is False
+    assert response.status_code == 200
+    data = response.json()
+    assert data["diagnostic_status"] == "BLOCKED"
+    assert data["is_authoritative"] is False
 
 
 def test_verify_consensus_unverifiable_status(client):

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -4,8 +4,9 @@ Targets uncovered code paths reported by SonarQube for #264.
 """
 import os
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock, AsyncMock, sentinel
 from fastapi.testclient import TestClient
+from fastapi import HTTPException
 
 from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
 
@@ -68,6 +69,21 @@ def test_verify_natural_language_legacy_unrecognized(client):
         "verification": {"is_correct": True, "status": "XYZZY"},
     }
     with patch("qwed_new.api.main.control_plane.process_natural_language", new_callable=AsyncMock, return_value=mock_result), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/natural_language",
+            json={"query": "test query"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+    assert data["proof_ref"] is None
+
+
+def test_verify_natural_language_internal_error(client):
+    """Cover process_natural_language exception -> fail-closed UNVERIFIABLE."""
+    with patch("qwed_new.api.main.control_plane.process_natural_language", new_callable=AsyncMock, side_effect=Exception("Engine down")), \
          patch("qwed_new.api.main.check_rate_limit"):
         response = client.post(
             "/verify/natural_language",
@@ -345,3 +361,59 @@ def test_verify_consensus_no_agreement(client):
     assert data["status"] == "UNVERIFIABLE"
     assert data["is_authoritative"] is False
     assert data["proof_ref"] is None
+
+
+# --- Direct unit tests for auth functions (SonarQube uncovered paths) ---
+
+
+def test_get_optional_current_user_success():
+    """Cover get_optional_current_user success path: return user."""
+    from qwed_new.api.main import get_optional_current_user
+
+    mock_user = MagicMock()
+    mock_session = MagicMock()
+    mock_session.get.return_value = mock_user
+
+    with patch("qwed_new.api.main.get_current_user_token", return_value={"sub": "42"}):
+        result = get_optional_current_user(
+            authorization="Bearer my.jwt.token",
+            session=mock_session,
+        )
+
+    assert result is mock_user
+    mock_session.get.assert_called_once()
+
+
+def test_get_optional_api_key_record_success():
+    """Cover get_optional_api_key_record success path: return api_key."""
+    from qwed_new.api.main import get_optional_api_key_record
+
+    mock_api_key = MagicMock()
+    mock_session = MagicMock()
+    mock_session.execute.return_value.scalars.return_value.first.return_value = mock_api_key
+
+    with patch("qwed_new.api.main.hash_api_key", return_value="hashed_value"):
+        result = get_optional_api_key_record(
+            x_api_key="sk-test-key",
+            session=mock_session,
+        )
+
+    assert result is mock_api_key
+    mock_session.execute.assert_called_once()
+
+
+def test_require_metrics_access_authentication_required():
+    """Cover require_metrics_access 401 branch: no user, no api key."""
+    from qwed_new.api.main import require_metrics_access
+
+    mock_session = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_metrics_access(
+            current_user=None,
+            api_key_record=None,
+            session=mock_session,
+        )
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Authentication required"

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -13,7 +13,7 @@ from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
 def client():
     from qwed_new.api.main import app, get_current_tenant, get_session
 
-    mock_tenant = MagicMock(organization_id=1, api_key="QWED_TEST_VALUE", organization_name="Test Org")
+    mock_tenant = MagicMock(organization_id=1, api_key="sk-test-fixture-key-do-not-use-in-production", organization_name="Test Org")
     mock_session = MagicMock(add=MagicMock(), commit=MagicMock())
 
     app.dependency_overrides[get_current_tenant] = lambda: mock_tenant
@@ -39,12 +39,11 @@ def test_verify_natural_language_success_path(client):
 
     assert response.status_code == 200
     data = response.json()
-    assert "proof_ref" in data
-    assert "diagnostic_status" in data
+    assert data["status"] == "UNVERIFIABLE"
 
 
-def test_verify_natural_language_legacy_verified(client):
-    """Cover from_legacy_dict ValueError -> VERIFIED passthrough for VERIFIED legacy."""
+def test_verify_natural_language_legacy_conversion_fails(client):
+    """Cover from_legacy_dict ValueError -> UNVERIFIABLE (fail-closed)."""
     mock_result = {
         "verification": {"is_correct": True, "status": "VERIFIED"},
     }
@@ -57,11 +56,12 @@ def test_verify_natural_language_legacy_verified(client):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["diagnostic_status"] == "VERIFIED"
+    assert data["status"] == "UNVERIFIABLE"
+    assert data["proof_ref"] is None
 
 
 def test_verify_natural_language_legacy_unrecognized(client):
-    """Cover from_legacy_dict ValueError -> BLOCKED for unrecognized legacy."""
+    """Cover from_legacy_dict ValueError -> UNVERIFIABLE for unrecognized legacy."""
     mock_result = {
         "verification": {"is_correct": True, "status": "XYZZY"},
     }
@@ -74,7 +74,7 @@ def test_verify_natural_language_legacy_unrecognized(client):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["diagnostic_status"] == "BLOCKED"
+    assert data["status"] == "UNVERIFIABLE"
     assert data["proof_ref"] is None
 
 
@@ -97,8 +97,8 @@ def test_verify_logic_sat_path(client):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["status"] == "SAT"
-    assert data["diagnostic_status"] == "VERIFIED"
+    assert data["status"] == "VERIFIED"
+    assert data["agent_message"] == "Logic constraints are satisfiable"
 
 
 def test_verify_logic_unsat_path(client):
@@ -120,8 +120,8 @@ def test_verify_logic_unsat_path(client):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["status"] == "UNSAT"
-    assert data["diagnostic_status"] == "UNVERIFIABLE"
+    assert data["status"] == "UNVERIFIABLE"
+    assert data["agent_message"] == "Logic constraints are unsatisfiable"
 
 
 def test_verify_stats_success_unverifiable(client):
@@ -168,7 +168,6 @@ def test_verify_fact_legacy_object_verified(client):
     mock_result.to_dict.return_value = {"verdict": "SUPPORTED", "confidence": 0.95}
     mock_result.is_verified = True
     mock_result.verdict = "SUPPORTED"
-    mock_result.__class__.__module__ = "unittest.mock"
 
     with patch("qwed_new.core.fact_verifier.FactVerifier.verify_fact", return_value=mock_result), \
          patch("qwed_new.api.main.check_rate_limit"):
@@ -187,7 +186,6 @@ def test_verify_fact_legacy_object_unverified(client):
     mock_result = MagicMock()
     mock_result.to_dict.return_value = {"verdict": "NEUTRAL", "confidence": 0.5}
     mock_result.is_verified = False
-    mock_result.__class__.__module__ = "unittest.mock"
 
     with patch("qwed_new.core.fact_verifier.FactVerifier.verify_fact", return_value=mock_result), \
          patch("qwed_new.api.main.check_rate_limit"):
@@ -277,8 +275,9 @@ def test_verify_consensus_blocked_status(client):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["diagnostic_status"] == "BLOCKED"
+    assert data["status"] == "BLOCKED"
     assert data["is_authoritative"] is False
+    assert data["final_answer"] is None
 
 
 def test_verify_consensus_unverifiable_status(client):
@@ -303,8 +302,9 @@ def test_verify_consensus_unverifiable_status(client):
 
         assert response.status_code == 200
         data = response.json()
-        assert data["diagnostic_status"] == "UNVERIFIABLE"
+        assert data["status"] == "UNVERIFIABLE"
         assert data["is_authoritative"] is False
+        assert data["final_answer"] == "maybe"
 
 
 def test_verify_consensus_no_agreement(client):
@@ -329,5 +329,5 @@ def test_verify_consensus_no_agreement(client):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["diagnostic_status"] == "UNVERIFIABLE"
+    assert data["status"] == "UNVERIFIABLE"
     assert data["is_authoritative"] is False

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -82,7 +82,7 @@ def test_verify_natural_language_legacy_unrecognized(client):
 
 
 def test_verify_natural_language_internal_error(client):
-    """Cover process_natural_language exception -> fail-closed UNVERIFIABLE."""
+    """Cover process_natural_language exception -> BLOCKED."""
     with patch("qwed_new.api.main.control_plane.process_natural_language", new_callable=AsyncMock, side_effect=Exception("Engine down")), \
          patch("qwed_new.api.main.check_rate_limit"):
         response = client.post(
@@ -92,7 +92,8 @@ def test_verify_natural_language_internal_error(client):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["status"] == "UNVERIFIABLE"
+    assert data["status"] == "BLOCKED"
+    assert data["agent_message"] == "Internal verification error"
     assert data["proof_ref"] is None
     assert "Engine down" not in response.text
 
@@ -393,9 +394,9 @@ def test_get_optional_api_key_record_success():
     mock_session = MagicMock()
     mock_session.execute.return_value.scalars.return_value.first.return_value = mock_api_key
 
-    with patch("qwed_new.api.main.hash_api_key", return_value="QWED_TEST_VALUE"):
+    with patch("qwed_new.api.main.hash_api_key", return_value="test-hash-0000"):
         result = get_optional_api_key_record(
-            x_api_key="QWED_TEST_VALUE",
+            x_api_key="test-key-0000",
             session=mock_session,
         )
 

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -149,8 +149,8 @@ def test_verify_logic_unsat_path(client):
 
 
 def test_verify_stats_success_verified(client):
-    """Cover stats SUCCESS -> VERIFIED (execution result IS the evidence)."""
-    with patch("qwed_new.core.stats_verifier.StatsVerifier.verify_stats", return_value={"status": "SUCCESS", "analysis": "mean=2.0"}), \
+    """Cover stats SUCCESS + claim_supported -> VERIFIED."""
+    with patch("qwed_new.core.stats_verifier.StatsVerifier.verify_stats", return_value={"status": "SUCCESS", "claim_supported": True, "analysis": "mean=2.0"}), \
          patch("qwed_new.api.main.check_rate_limit"):
         response = client.post(
             "/verify/stats",
@@ -163,6 +163,21 @@ def test_verify_stats_success_verified(client):
     assert data["status"] == "VERIFIED"
     assert data["is_authoritative"] is True
     assert data["proof_ref"]
+
+
+def test_verify_stats_success_without_claim_supported_is_unverifiable(client):
+    """Cover stats SUCCESS without claim_supported -> UNVERIFIABLE (execution ≠ proof)."""
+    with patch("qwed_new.core.stats_verifier.StatsVerifier.verify_stats", return_value={"status": "SUCCESS", "analysis": "mean=2.0"}), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/stats",
+            files={"file": ("data.csv", b"value\n1\n2\n3\n", "text/csv")},
+            data={"query": "What is the mean?"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
 
 
 def test_verify_fact_preserves_diagnostic_result(client):
@@ -339,6 +354,33 @@ def test_verify_consensus_unverifiable_status(client):
     assert data["is_authoritative"] is False
     assert data["final_answer"] == "maybe"
 
+
+
+
+def test_verify_consensus_all_engines_blocked(client):
+    """Cover consensus agreement_status=blocked -> BLOCKED (fail-closed)."""
+    from qwed_new.core.consensus_verifier import ConsensusResult
+
+    fake = MagicMock(spec=ConsensusResult)
+    fake.final_answer = None
+    fake.confidence = 0.0
+    fake.engines_used = 2
+    fake.agreement_status = "blocked"
+    fake.status = "BLOCKED"
+    fake.verification_chain = []
+    fake.total_latency_ms = 5.0
+
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake),          patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "BLOCKED"
+    assert data["is_authoritative"] is False
+    assert data["proof_ref"] is None
 
 def test_verify_consensus_no_agreement(client):
     """Cover else branch (no_consensus/split) -> UNVERIFIABLE."""

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -3,6 +3,7 @@
 Targets uncovered code paths reported by SonarQube for #264.
 """
 import os
+import secrets
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 from fastapi.testclient import TestClient
@@ -23,7 +24,8 @@ def client():
 
     yield TestClient(app)
 
-    app.dependency_overrides.clear()
+    del app.dependency_overrides[get_current_tenant]
+    del app.dependency_overrides[get_session]
 
 
 def test_verify_natural_language_success_path(client):
@@ -394,9 +396,11 @@ def test_get_optional_api_key_record_success():
     mock_session = MagicMock()
     mock_session.execute.return_value.scalars.return_value.first.return_value = mock_api_key
 
-    with patch("qwed_new.api.main.hash_api_key", return_value="test_hash"):
+    fake_hash = secrets.token_hex(8)
+    fake_key = secrets.token_hex(8)
+    with patch("qwed_new.api.main.hash_api_key", return_value=fake_hash):
         result = get_optional_api_key_record(
-            x_api_key="test_value",
+            x_api_key=fake_key,
             session=mock_session,
         )
 

--- a/tests/test_logic_exceptions.py
+++ b/tests/test_logic_exceptions.py
@@ -32,8 +32,8 @@ async def test_verify_logic_exception_handling(client):
 
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "ERROR"
-        assert data["error"] == "Internal verification error"
+        assert data["status"] == "BLOCKED"
+        assert data["agent_message"] == "Internal verification error"
         assert data["provider_used"] == "openai"
         assert "SENSITIVE_LOGIC_ERROR" not in str(data)
 
@@ -52,8 +52,8 @@ def test_verify_logic_exception_integration(client):
 
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "ERROR"
-        assert data["error"] == "Internal verification error"
+        assert data["status"] == "BLOCKED"
+        assert data["agent_message"] == "Internal verification error"
         assert data["provider_used"] == "openai"
         assert "SENSITIVE_FAILURE" not in str(data)
 

--- a/tests/test_logic_provider_reporting.py
+++ b/tests/test_logic_provider_reporting.py
@@ -31,8 +31,8 @@ async def test_verify_logic_error_uses_routed_provider(monkeypatch):
         session=session,
     )
 
-    assert result["status"] == "ERROR"
-    assert result["error"] == "Internal verification error"
+    assert result["status"] == "BLOCKED"
+    assert result["agent_message"] == "Internal verification error"
     assert result["provider_used"] == "openai_compat"
 
 

--- a/tests/test_pr117_regressions.py
+++ b/tests/test_pr117_regressions.py
@@ -118,8 +118,10 @@ def test_stats_api_masks_secure_runtime_unavailability(client):
             headers={"x-api-key": "fake-key"},
         )
 
-    assert response.status_code == 503
-    assert response.json()["detail"] == "Service temporarily unavailable"
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "BLOCKED"
+    assert data["agent_message"] == "Service temporarily unavailable"
 
 
 def test_stats_api_preserves_security_policy_blocks(client):
@@ -135,8 +137,10 @@ def test_stats_api_preserves_security_policy_blocks(client):
             headers={"x-api-key": "fake-key"},
         )
 
-    assert response.status_code == 403
-    assert response.json()["detail"] == "Verification blocked by security policy"
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "BLOCKED"
+    assert data["agent_message"] == "Verification blocked by security policy"
 
 
 def test_consensus_code_engine_requires_secure_executor():

--- a/tests/test_pr117_regressions.py
+++ b/tests/test_pr117_regressions.py
@@ -122,6 +122,7 @@ def test_stats_api_masks_secure_runtime_unavailability(client):
     data = response.json()
     assert data["status"] == "BLOCKED"
     assert data["agent_message"] == "Service temporarily unavailable"
+    assert data["proof_ref"] is None
 
 
 def test_stats_api_preserves_security_policy_blocks(client):
@@ -141,6 +142,7 @@ def test_stats_api_preserves_security_policy_blocks(client):
     data = response.json()
     assert data["status"] == "BLOCKED"
     assert data["agent_message"] == "Verification blocked by security policy"
+    assert data["proof_ref"] is None
 
 
 def test_consensus_code_engine_requires_secure_executor():

--- a/tests/test_pr117_regressions.py
+++ b/tests/test_pr117_regressions.py
@@ -226,8 +226,10 @@ def test_consensus_api_masks_secure_execution_block(client):
             headers={"x-api-key": "fake-key"},
         )
 
-    assert response.status_code == 503
-    assert response.json()["detail"] == "Service temporarily unavailable"
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "BLOCKED"
+    assert data["is_authoritative"] is False
 
 
 def test_stats_verifier_blocks_if_docker_drops_after_selection():


### PR DESCRIPTION
## Summary

All 8 `/verify/*` endpoints in `api/main.py` now construct `DiagnosticResult`
instances and route through `_enforce_trust()` instead of returning raw dicts.
This closes the root cause finding from the adversarial audit:
endpoints were bypassing the trust boundary by returning unstructured dicts
without diagnostic metadata, proof references, or enforcement hooks.

## Changes

- **`src/qwed_new/api/main.py`** (388 insertions, 258 deletions)

### Per-endpoint migration

| Endpoint | Before | After |
|----------|--------|-------|
| `/verify/math` | Raw dict from `MathVerifier` | `DiagnosticResult.verified()` / `.blocked()` per result status |
| `/verify/code` | Raw `{"is_safe": bool}` | `DiagnosticResult.verified()` if safe, `.blocked()` otherwise |
| `/verify/sql` | Raw `{"is_valid": bool}` | `DiagnosticResult.verified()` if valid, `.blocked()` otherwise |
| `/verify/natural_language` | Raw dict from `ControlPlane` | `from_legacy_dict()` / `.verified()` with proof_ref |
| `/verify/logic` | Raw `{"status": "SAT"/"UNSAT"/...}` | SAT→`.verified()`, UNSAT→`.unverifiable()`, ERROR→`.blocked()` |
| `/verify/consensus` | Raw `{"agreement_status": ...}` | unanimous→`.verified()`, else→`.unverifiable()` |
| `/verify/fact` | Raw `FactCheckResult.to_dict()` | `DiagnosticResult` from `FactCheckResult`, with enforce_trust |
| `/verify/image` | Raw dict from `ImageVerifier` | `DiagnosticResult` from result, with enforce_trust |
| `/verify/stats` | Raw dict from `StatsVerifier` | SUCCESS→`.verified()`, BLOCKED→`.blocked()`, exception→`.blocked()` |

### Key patterns introduced

1. **`_enforce_trust(dr, query)` helper** — wraps `enforce_trust_decision` in
   advisory mode so trust decisions are logged but the API response still flows.
   To be tightened to hard-fail in a follow-up (#265).

2. **`dr.to_dict() | dr.developer_fields`** — merges the canonical diagnostic
   payload with backward-compatible developer fields so existing clients see no
   breaking changes.

3. **`DiagnosticResult.verified(evidence=...)`** — used instead of
   `from_legacy_dict()` for branches with no legacy dict to convert; requires
   explicit evidence dict ensuring proof-bearing results always carry context.

## Testing

- All 85 logic/security tests pass (`test_logic_verifier_coverage.py`,
  `test_injection.py`, `test_cli_test_command.py`)
- CLI verify tests (`test_cli_verify.py`) fail pre-existing — require
  `API_KEY_SECRET` env var in CI
- Import verified: no syntax or import errors

## Related

- Closes #264
- Part of epic #263 (Trust Boundary Completion)
- Follow-up: #265 (control plane advisory mode → hard enforcement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit
- **New Features**
  - Verification and logic endpoints now return consistent diagnostic payloads (`status`, `agent_message`, `provider_used`, `is_authoritative`, and `proof_ref` where applicable).
  - Consensus responses now include clearer verified/blocked/unverifiable mapping plus per-item `success` and `meets_requirement`.
- **Bug Fixes**
  - Internal verifier errors now fail closed to `BLOCKED` with sanitized `agent_message`.
  - Legacy natural-language conversion failures now fail closed to `UNVERIFIABLE` with `proof_ref: null`.
  - `/verify/rag` now returns `UNVERIFIABLE` for configuration issues and `BLOCKED` when secure setup fails (without leaking sensitive details).
- **Documentation**
  - Added a security architecture audit report.
- **Tests**
  - Updated and expanded tests to match the revised response shape and statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Standardize verification responses and fail safely across API endpoints

### What Changed
- Verification endpoints now return consistent diagnostic statuses such as `VERIFIED`, `UNVERIFIABLE`, and `BLOCKED`, with clear user-facing messages and proof references where available
- Internal failures no longer expose sensitive error details and are reported as blocked results with sanitized messages
- Math, code, SQL, logic, fact, image, statistics, consensus, RAG, and process verification now distinguish successful verification from inconclusive or blocked outcomes
- Invalid or incomplete requests continue to return clear validation errors, while engine and policy failures are represented consistently in the response body
- Added coverage for success, failure, conversion, security, authentication, and response-format scenarios

### Impact
`✅ Consistent verification outcomes across endpoints`
`✅ Sanitized internal error messages`
`✅ Fewer false VERIFIED results without proof`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
