### PR TITLE
Fix #266: ConsensusResult DiagnosticStatus enum + proof_ref + verified_evidence

### DIFF
--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -1571,33 +1571,9 @@ async def verify_with_consensus(
         _safe_commit_log(session, log)
         return _merge_response(dr)
 
-    if result.agreement_status == "unanimous":
-        if hasattr(result, "status") and result.status == "BLOCKED":
-            dr = DiagnosticResult.blocked(
-                "Consensus verification: blocked",
-                developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
-            )
-        elif hasattr(result, "status") and result.status == "UNVERIFIABLE":
-            dr = DiagnosticResult.unverifiable(
-                "Consensus verification: incomplete — some engines blocked",
-                developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
-            )
-        else:
-            dr = DiagnosticResult.verified(
-                "Consensus verification: unanimous",
-                developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
-                evidence={"agreement_status": result.agreement_status, "confidence": result.confidence},
-            )
-    elif result.agreement_status == "majority":
-        dr = DiagnosticResult.unverifiable(
-            "Consensus verification: majority agreement",
-            developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
-        )
-    else:
-        dr = DiagnosticResult.unverifiable(
-            "Consensus verification: no agreement",
-            developer_fields={"agreement_status": result.agreement_status, "confidence": result.confidence, "engines_used": result.engines_used},
-        )
+    # Convert consensus result via its own to_diagnostic_result() method —
+    # it handles proof_ref, attestation evidence, and DiagnosticStatus mapping.
+    dr = result.to_diagnostic_result()
     dr = _enforce_trust(dr, query=request.query)
 
     log = VerificationLog(

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -79,7 +79,8 @@ class ConsensusResult:
             "confidence": self.confidence,
             "engines_used": self.engines_used,
         }
-        if self.status is DiagnosticStatus.VERIFIED:
+        status_val = self.status.value if isinstance(self.status, DiagnosticStatus) else str(self.status)
+        if status_val == DiagnosticStatus.VERIFIED.value:
             return DiagnosticResult.verified(
                 "Consensus verification: unanimous",
                 developer_fields=developer_fields,
@@ -88,17 +89,20 @@ class ConsensusResult:
                     "confidence": self.confidence,
                 },
             )
-        elif self.status is DiagnosticStatus.BLOCKED:
+        elif status_val == DiagnosticStatus.BLOCKED.value:
             return DiagnosticResult.blocked(
                 "Consensus verification: blocked",
                 developer_fields=developer_fields,
             )
         else:
-            msg = "Consensus verification: no agreement"
             if self.agreement_status == "majority":
                 msg = "Consensus verification: majority agreement"
-            elif self.status is DiagnosticStatus.UNVERIFIABLE:
+            elif self.agreement_status == "split":
+                msg = "Consensus verification: no agreement"
+            elif status_val == DiagnosticStatus.UNVERIFIABLE.value:
                 msg = "Consensus verification: incomplete — some engines blocked"
+            else:
+                msg = "Consensus verification: no agreement"
             return DiagnosticResult.unverifiable(
                 msg,
                 developer_fields=developer_fields,
@@ -847,6 +851,7 @@ class ConsensusVerifier:
                 "agreement_status": status,
                 "confidence": confidence,
                 "engines_used": len(successful),
+                "answer": str(answer_values[best_answer]),
                 "chain": [
                     {"engine": r.engine_name, "method": r.method, "confidence": r.confidence}
                     for r in successful

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -19,6 +19,8 @@ import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import threading
 
+from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
+
 
 logger = logging.getLogger(__name__)
 SECURE_EXECUTION_REQUIRED = "SECURE_EXECUTION_REQUIRED"
@@ -62,7 +64,45 @@ class ConsensusResult:
     verification_chain: List[EngineResult]
     total_latency_ms: float
     parallel_execution: bool = False
-    status: Optional[str] = None  # DiagnosticStatus — preserved from engines
+    status: Optional[DiagnosticStatus] = None  # from _calculate_consensus
+    proof_ref: Optional[str] = None  # Populated for VERIFIED consensus results
+    verified_evidence: Optional[Dict[str, Any]] = None  # evidence used for proof_ref, equals verification_chain at VERIFIED
+
+    def to_diagnostic_result(self) -> DiagnosticResult:
+        """Convert this ConsensusResult to a DiagnosticResult.
+
+        This is the canonical path for the /verify/consensus endpoint —
+        the conversion logic lives here so the endpoint is a thin wrapper.
+        """
+        developer_fields: Dict[str, Any] = {
+            "agreement_status": self.agreement_status,
+            "confidence": self.confidence,
+            "engines_used": self.engines_used,
+        }
+        if self.status is DiagnosticStatus.VERIFIED:
+            return DiagnosticResult.verified(
+                "Consensus verification: unanimous",
+                developer_fields=developer_fields,
+                evidence=self.verified_evidence or {
+                    "agreement_status": self.agreement_status,
+                    "confidence": self.confidence,
+                },
+            )
+        elif self.status is DiagnosticStatus.BLOCKED:
+            return DiagnosticResult.blocked(
+                "Consensus verification: blocked",
+                developer_fields=developer_fields,
+            )
+        else:
+            msg = "Consensus verification: no agreement"
+            if self.agreement_status == "majority":
+                msg = "Consensus verification: majority agreement"
+            elif self.status is DiagnosticStatus.UNVERIFIABLE:
+                msg = "Consensus verification: incomplete — some engines blocked"
+            return DiagnosticResult.unverifiable(
+                msg,
+                developer_fields=developer_fields,
+            )
 
 
 @dataclass
@@ -380,6 +420,8 @@ class ConsensusVerifier:
             total_latency_ms=total_latency,
             parallel_execution=parallel and len(engine_methods) > 1,
             status=consensus.get("diagnostic_status"),
+            proof_ref=consensus.get("proof_ref"),
+            verified_evidence=consensus.get("verified_evidence"),
         )
     
     # =========================================================================
@@ -467,12 +509,14 @@ class ConsensusVerifier:
             total_latency_ms=total_latency,
             parallel_execution=True,
             status=consensus.get("diagnostic_status"),
+            proof_ref=consensus.get("proof_ref"),
+            verified_evidence=consensus.get("verified_evidence"),
         )
-    
+
     # =========================================================================
     # Engine Selection
     # =========================================================================
-    
+
     def _select_engines(self, query: str, mode: VerificationMode) -> List[Tuple[str, Callable]]:
         """Select engines based on mode and query type."""
         engines = []
@@ -741,10 +785,10 @@ class ConsensusVerifier:
         - No BLOCKED, unanimous → VERIFIED
         """
         if not results:
-            return {"answer": None, "confidence": 0.0, "status": "no_results", "diagnostic_status": "UNVERIFIABLE"}
+            return {"answer": None, "confidence": 0.0, "status": "no_results", "diagnostic_status": DiagnosticStatus.UNVERIFIABLE}
 
         if any(r.error == SECURE_EXECUTION_REQUIRED for r in results):
-            return {"answer": None, "confidence": 0.0, "status": "blocked_secure_execution", "diagnostic_status": "BLOCKED"}
+            return {"answer": None, "confidence": 0.0, "status": "blocked_secure_execution", "diagnostic_status": DiagnosticStatus.BLOCKED}
 
         blocked = [r for r in results if r.status == "BLOCKED"]
         active = [r for r in results if r.status != "BLOCKED"]
@@ -755,14 +799,14 @@ class ConsensusVerifier:
                 "answer": None,
                 "confidence": 0.0,
                 "status": "blocked",
-                "diagnostic_status": "BLOCKED",
+                "diagnostic_status": DiagnosticStatus.BLOCKED,
                 "errors": blocked_errors,
             }
 
         successful = [r for r in active if r.success]
 
         if not successful:
-            return {"answer": None, "confidence": 0.0, "status": "all_failed", "diagnostic_status": "UNVERIFIABLE"}
+            return {"answer": None, "confidence": 0.0, "status": "all_failed", "diagnostic_status": DiagnosticStatus.UNVERIFIABLE}
 
         # Weight answers by engine reliability
         weighted_answers: Dict[str, float] = {}
@@ -793,13 +837,34 @@ class ConsensusVerifier:
         # advisory-only results (e.g. Stats computation) cannot contribute
         # to a VERIFIED consensus (#270).
         all_verified = all(r.status == "VERIFIED" for r in successful)
-        diagnostic_status = "VERIFIED" if (status == "unanimous" and not blocked and all_verified) else "UNVERIFIABLE"
+        diagnostic_status = DiagnosticStatus.VERIFIED if (status == "unanimous" and not blocked and all_verified) else DiagnosticStatus.UNVERIFIABLE
+
+        # Bind proof_ref to the VERIFIED consensus: evidence includes the
+        # engine chain details so the attestation can be audited downstream.
+        proof_ref = None
+        if diagnostic_status is DiagnosticStatus.VERIFIED:
+            evidence = {
+                "agreement_status": status,
+                "confidence": confidence,
+                "engines_used": len(successful),
+                "chain": [
+                    {"engine": r.engine_name, "method": r.method, "confidence": r.confidence}
+                    for r in successful
+                ],
+            }
+            proof_ref = DiagnosticResult.verified(
+                "Consensus verification: unanimous",
+                developer_fields={"agreement_status": status, "confidence": confidence},
+                evidence=evidence,
+            ).proof_ref
 
         return {
             "answer": answer_values[best_answer],
             "confidence": confidence,
             "status": status,
             "diagnostic_status": diagnostic_status,
+            "proof_ref": proof_ref,
+            "verified_evidence": evidence if diagnostic_status is DiagnosticStatus.VERIFIED else None,
         }
 
     @staticmethod

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -863,7 +863,8 @@ class ConsensusVerifier:
                 "agreement_status": status,
                 "confidence": confidence,
                 "contributing_engines": len(successful),
-                "answer": str(answer_values[best_answer]),
+                # None stays as JSON null; repr carries type info for non-None (#266).
+                "answer": None if answer_values[best_answer] is None else repr(answer_values[best_answer]),
                 "chain": [
                     {"engine": r.engine_name, "method": r.method, "confidence": r.confidence}
                     for r in successful

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -81,13 +81,17 @@ class ConsensusResult:
         }
         status_val = self.status.value if isinstance(self.status, DiagnosticStatus) else str(self.status)
         if status_val == DiagnosticStatus.VERIFIED.value:
+            if not self.verified_evidence:
+                # A VERIFIED status without its canonical evidence is a contract
+                # violation — fail closed rather than fabricating a weaker proof.
+                return DiagnosticResult.unverifiable(
+                    "Consensus verification: VERIFIED status missing canonical evidence",
+                    developer_fields=developer_fields,
+                )
             return DiagnosticResult.verified(
                 "Consensus verification: unanimous",
                 developer_fields=developer_fields,
-                evidence=self.verified_evidence or {
-                    "agreement_status": self.agreement_status,
-                    "confidence": self.confidence,
-                },
+                evidence=self.verified_evidence,
             )
         elif status_val == DiagnosticStatus.BLOCKED.value:
             return DiagnosticResult.blocked(
@@ -95,12 +99,19 @@ class ConsensusResult:
                 developer_fields=developer_fields,
             )
         else:
+            blocked_count = sum(1 for r in self.verification_chain if r.status in ("BLOCKED", DiagnosticStatus.BLOCKED.value))
             if self.agreement_status == "majority":
                 msg = "Consensus verification: majority agreement"
             elif self.agreement_status == "split":
                 msg = "Consensus verification: no agreement"
-            elif status_val == DiagnosticStatus.UNVERIFIABLE.value:
+            elif self.agreement_status == "no_results":
+                msg = "Consensus verification: no engine results available"
+            elif self.agreement_status == "all_failed":
+                msg = "Consensus verification: all engines failed"
+            elif status_val == DiagnosticStatus.UNVERIFIABLE.value and blocked_count > 0:
                 msg = "Consensus verification: incomplete — some engines blocked"
+            elif status_val == DiagnosticStatus.UNVERIFIABLE.value:
+                msg = "Consensus verification: support conditions unmet — advisory engines cannot verify claims"
             else:
                 msg = "Consensus verification: no agreement"
             return DiagnosticResult.unverifiable(
@@ -846,11 +857,12 @@ class ConsensusVerifier:
         # Bind proof_ref to the VERIFIED consensus: evidence includes the
         # engine chain details so the attestation can be audited downstream.
         proof_ref = None
+        evidence = None
         if diagnostic_status is DiagnosticStatus.VERIFIED:
             evidence = {
                 "agreement_status": status,
                 "confidence": confidence,
-                "engines_used": len(successful),
+                "contributing_engines": len(successful),
                 "answer": str(answer_values[best_answer]),
                 "chain": [
                     {"engine": r.engine_name, "method": r.method, "confidence": r.confidence}

--- a/tests/security/test_hybrid_advisory_only.py
+++ b/tests/security/test_hybrid_advisory_only.py
@@ -327,6 +327,29 @@ class TestConsensusVerifierAdvisoryOnly:
         assert consensus["diagnostic_status"] == "UNVERIFIABLE"
         assert consensus["status"] == "unanimous"
 
+    def test_verified_evidence_answer_none_stays_null_and_type_differs(self):
+        """Verified consensus evidence: answer None→null, repr carries type info (#266)."""
+        from decimal import Decimal
+
+        verifier = ConsensusVerifier(enable_circuit_breaker=False)
+
+        none_result = verifier._calculate_consensus([
+            EngineResult("Logic", "logic", None, 1.0, 1.0, True, status="VERIFIED"),
+            EngineResult("Math", "symbolic_math", None, 1.0, 1.0, True, status="VERIFIED"),
+        ])
+        assert none_result["verified_evidence"]["answer"] is None
+
+        typed_result = verifier._calculate_consensus([
+            EngineResult("Logic", "logic", Decimal("1.0"), 1.0, 1.0, True, status="VERIFIED"),
+            EngineResult("Math", "symbolic_math", Decimal("1.0"), 1.0, 1.0, True, status="VERIFIED"),
+        ])
+        float_result = verifier._calculate_consensus([
+            EngineResult("Logic", "logic", 1.0, 1.0, 1.0, True, status="VERIFIED"),
+            EngineResult("Math", "symbolic_math", 1.0, 1.0, 1.0, True, status="VERIFIED"),
+        ])
+
+        assert typed_result["verified_evidence"]["answer"] != float_result["verified_evidence"]["answer"]
+
 
 # ========================================================================
 # ImageVerifier — deterministic refutation and MultiVLM edge cases

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from fastapi import HTTPException
 
 from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
+from qwed_new.core.consensus_verifier import ConsensusResult
 
 
 @pytest.fixture
@@ -303,14 +304,15 @@ def test_verify_consensus_blocked_status(client):
     """Cover consensus agreement_status=unanimous with result.status=BLOCKED."""
     from qwed_new.core.consensus_verifier import ConsensusResult
 
-    fake = MagicMock(spec=ConsensusResult)
-    fake.final_answer = None
-    fake.confidence = 0.0
-    fake.engines_used = 2
-    fake.agreement_status = "unanimous"
-    fake.status = "BLOCKED"
-    fake.verification_chain = []
-    fake.total_latency_ms = 5.0
+    fake = ConsensusResult(
+        final_answer=None,
+        confidence=0.0,
+        engines_used=2,
+        agreement_status="unanimous",
+        verification_chain=[],
+        total_latency_ms=5.0,
+        status=DiagnosticStatus.BLOCKED,
+    )
 
     with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
          patch("qwed_new.api.main.check_rate_limit"):
@@ -331,14 +333,15 @@ def test_verify_consensus_unverifiable_status(client):
     """Cover consensus agreement_status=unanimous with result.status=UNVERIFIABLE."""
     from qwed_new.core.consensus_verifier import ConsensusResult
 
-    fake = MagicMock(spec=ConsensusResult)
-    fake.final_answer = "maybe"
-    fake.confidence = 0.5
-    fake.engines_used = 2
-    fake.agreement_status = "unanimous"
-    fake.status = "UNVERIFIABLE"
-    fake.verification_chain = []
-    fake.total_latency_ms = 5.0
+    fake = ConsensusResult(
+        final_answer="maybe",
+        confidence=0.5,
+        engines_used=2,
+        agreement_status="unanimous",
+        verification_chain=[],
+        total_latency_ms=5.0,
+        status=DiagnosticStatus.UNVERIFIABLE,
+    )
 
     with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
          patch("qwed_new.api.main.check_rate_limit"):
@@ -355,22 +358,51 @@ def test_verify_consensus_unverifiable_status(client):
     assert data["final_answer"] == "maybe"
 
 
+def test_verify_consensus_verified_with_proof_ref(client):
+    """Cover VERIFIED consensus with proof_ref included in response (#266)."""
+    from qwed_new.core.consensus_verifier import ConsensusResult
+
+    fake = ConsensusResult(
+        final_answer="4",
+        confidence=0.99,
+        engines_used=2,
+        agreement_status="unanimous",
+        verification_chain=[],
+        total_latency_ms=5.0,
+        status=DiagnosticStatus.VERIFIED,
+    )
+
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "VERIFIED"
+    assert data["proof_ref"] is not None
+    assert data["proof_ref"].startswith("sha256:")
+    assert data["is_authoritative"] is True
 
 
 def test_verify_consensus_all_engines_blocked(client):
     """Cover consensus agreement_status=blocked -> BLOCKED (fail-closed)."""
     from qwed_new.core.consensus_verifier import ConsensusResult
 
-    fake = MagicMock(spec=ConsensusResult)
-    fake.final_answer = None
-    fake.confidence = 0.0
-    fake.engines_used = 2
-    fake.agreement_status = "blocked"
-    fake.status = "BLOCKED"
-    fake.verification_chain = []
-    fake.total_latency_ms = 5.0
+    fake = ConsensusResult(
+        final_answer=None,
+        confidence=0.0,
+        engines_used=2,
+        agreement_status="blocked",
+        verification_chain=[],
+        total_latency_ms=5.0,
+        status=DiagnosticStatus.BLOCKED,
+    )
 
-    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake),          patch("qwed_new.api.main.check_rate_limit"):
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
+         patch("qwed_new.api.main.check_rate_limit"):
         response = client.post(
             "/verify/consensus",
             json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
@@ -382,18 +414,20 @@ def test_verify_consensus_all_engines_blocked(client):
     assert data["is_authoritative"] is False
     assert data["proof_ref"] is None
 
+
 def test_verify_consensus_no_agreement(client):
     """Cover else branch (no_consensus/split) -> UNVERIFIABLE."""
     from qwed_new.core.consensus_verifier import ConsensusResult
 
-    fake = MagicMock(spec=ConsensusResult)
-    fake.final_answer = None
-    fake.confidence = 0.3
-    fake.engines_used = 3
-    fake.agreement_status = "split"
-    fake.status = None
-    fake.verification_chain = []
-    fake.total_latency_ms = 10.0
+    fake = ConsensusResult(
+        final_answer=None,
+        confidence=0.3,
+        engines_used=3,
+        agreement_status="split",
+        verification_chain=[],
+        total_latency_ms=10.0,
+        status=None,
+    )
 
     with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
          patch("qwed_new.api.main.check_rate_limit"):

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -10,7 +10,6 @@ from fastapi.testclient import TestClient
 from fastapi import HTTPException
 
 from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
-from qwed_new.core.consensus_verifier import ConsensusResult
 
 
 @pytest.fixture

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -369,6 +369,7 @@ def test_verify_consensus_verified_with_proof_ref(client):
         verification_chain=[],
         total_latency_ms=5.0,
         status=DiagnosticStatus.VERIFIED,
+        verified_evidence={"agreement_status": "unanimous", "confidence": 0.99},
     )
 
     with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
@@ -412,6 +413,93 @@ def test_verify_consensus_all_engines_blocked(client):
     assert data["status"] == "BLOCKED"
     assert data["is_authoritative"] is False
     assert data["proof_ref"] is None
+
+
+def test_verify_consensus_unverifiable_no_blocked_engines_message(client):
+    """Cover unanimous + UNVERIFIABLE with zero blocked engines (#266) — message reflects source, not blocked fallback."""
+    from qwed_new.core.consensus_verifier import ConsensusResult, EngineResult
+
+    fake = ConsensusResult(
+        final_answer="2",
+        confidence=0.98,
+        engines_used=1,
+        agreement_status="unanimous",
+        verification_chain=[
+            EngineResult(
+                engine_name="Stats", method="statistical_analysis", result=2,
+                confidence=0.98, latency_ms=1.0, success=True, status="UNVERIFIABLE",
+            ),
+        ],
+        total_latency_ms=5.0,
+        status=DiagnosticStatus.UNVERIFIABLE,
+    )
+
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+    assert "blocked" not in data["agent_message"].lower()
+    assert "advisory" in data["agent_message"] or "support conditions unmet" in data["agent_message"]
+
+
+def test_verify_consensus_no_results_gives_specific_message(client):
+    """Cover agreement_status=no_results -> specific message, not blocked-engine one."""
+    from qwed_new.core.consensus_verifier import ConsensusResult
+
+    fake = ConsensusResult(
+        final_answer=None,
+        confidence=0.0,
+        engines_used=0,
+        agreement_status="no_results",
+        verification_chain=[],
+        total_latency_ms=1.0,
+        status=DiagnosticStatus.UNVERIFIABLE,
+    )
+
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+    assert data["agent_message"] == "Consensus verification: no engine results available"
+
+
+def test_verify_consensus_all_failed_gives_specific_message(client):
+    """Cover agreement_status=all_failed -> specific message, not blocked-engine one."""
+    from qwed_new.core.consensus_verifier import ConsensusResult
+
+    fake = ConsensusResult(
+        final_answer=None,
+        confidence=0.0,
+        engines_used=2,
+        agreement_status="all_failed",
+        verification_chain=[],
+        total_latency_ms=5.0,
+        status=DiagnosticStatus.UNVERIFIABLE,
+    )
+
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "test", "verification_mode": "high", "min_confidence": 0.0},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+    assert data["agent_message"] == "Consensus verification: all engines failed"
 
 
 def test_verify_consensus_no_agreement(client):


### PR DESCRIPTION
## Summary

Fixes #266

Aligns ConsensusResult with the DiagnosticResult contract: DiagnosticStatus enums replace bare strings, proof_ref is populated for VERIFIED consensus, and verified_evidence preserves the canonical evidence for attestation hashes (avoiding the hidden duplicate-hash problem where the endpoint recomputes evidence differently).

## Changes

- `consensus_verifier.py`: `ConsensusResult.status` type changed to `Optional[DiagnosticStatus]`, `proof_ref` and `verified_evidence` added, `_calculate_consensus` returns the computed proof reference and its evidence dict, `diagnostic_status` uses `DiagnosticStatus.VERIFIED/.UNVERIFIABLE/.BLOCKED` enums
- `consensus_verifier.py:56`: `@dataclass` decorator restored (accidentally dropped)
- `verify_with_consensus` and `verify_async` pass `proof_ref` and `verified_evidence` through to ConsensusResult
- `/verify/consensus` endpoint: `result.to_diagnostic_result()` converts the whole result automatically (removes ~25 lines of branching from the endpoint)
- `to_diagnostic_result()` on ConsensusResult calls `DiagnosticResult.verified()` using the stored `verified_evidence`, ensuring the same evidence → same hash at every boundary
- Tests updated: consensus mocks use real ConsensusResult + DiagnosticStatus enums, `test_verify_consensus_verified_with_proof_ref` added

## Verification

- [x] All 109 tests pass (consensus / hybrid-advisory / diagnostic-coverage / determinism suites)


___

## **CodeAnt-AI Description**
Preserve verified consensus evidence and expose consistent diagnostic results

### What Changed
- Verified consensus responses now include a proof reference derived from the exact engine evidence used to reach agreement
- Consensus outcomes consistently report typed verified, unverifiable, and blocked statuses
- Blocked or incomplete engine checks remain non-authoritative, even when other engines agree
- Consensus response conversion is centralized so status, authority, and proof details stay aligned
- Added coverage for verified proof references and updated tests to use real consensus results

### Impact
`✅ Auditable verified consensus results`
`✅ Consistent blocked and unverifiable responses`
`✅ Fewer mismatches between consensus status and proof data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verified consensus results now include proof references and verified evidence.
  * Consensus responses provide more consistent diagnostic outcomes for verified, blocked, and unverifiable results.

* **Bug Fixes**
  * Improved handling of empty, failed, split, and secure-execution-required consensus results.
  * Ensured verified responses correctly indicate authoritative results and include proof references.

* **Tests**
  * Expanded coverage for consensus outcomes, fail-closed behavior, and verified responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->