### PR TITLE
Fix #269: Consensus code execution advisory-only · VERIFIED → UNVERIFIABLE

### DIFF
--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -1599,6 +1599,7 @@ async def verify_with_consensus(
                 "confidence": round(r.confidence, 4),
                 "latency_ms": round(r.latency_ms, 2),
                 "success": r.success,
+                "status": r.status,
             }
             for r in result.verification_chain
         ],

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -1604,7 +1604,9 @@ async def verify_with_consensus(
             for r in result.verification_chain
         ],
         "total_latency_ms": round(result.total_latency_ms, 2),
-        "meets_requirement": result.confidence >= request.min_confidence,
+        # TRUE only when consensus is both VERIFIED at the trust boundary AND
+        # confidence meets the threshold — never confidence alone (#269).
+        "meets_requirement": dr.is_verified and result.confidence >= request.min_confidence,
     }
     return _merge_response(dr) | response
 # --- Enterprise Security Endpoints (Week 2) ---

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -697,11 +697,15 @@ class ConsensusVerifier:
                     error=error, status="BLOCKED",
                 )
 
+            # Code execution is advisory-only — the code ran without runtime
+            # errors, but executing an expression is not proving its result
+            # matches an expected answer or satisfies the query's semantics.
+            # Empirical runtime success disproves (by crashing); it cannot prove (#269).
             return EngineResult(
                 engine_name="Python", method="code_execution",
                 result=output, confidence=0.99,
                 latency_ms=(time.time() - start) * 1000, success=True,
-                status="VERIFIED",
+                status="UNVERIFIABLE",
             )
         except Exception as e:
             return EngineResult(

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -415,6 +415,34 @@ def test_verify_consensus_all_engines_blocked(client):
     assert data["proof_ref"] is None
 
 
+def test_verify_consensus_unverifiable_with_high_confidence_not_requirements_met(client):
+    """Cover that high confidence alone cannot flip UNVERIFIABLE consensus to meets_requirement (#269)."""
+    from qwed_new.core.consensus_verifier import ConsensusResult
+
+    fake = ConsensusResult(
+        final_answer="2",
+        confidence=0.99,
+        engines_used=2,
+        agreement_status="unanimous",
+        verification_chain=[],
+        total_latency_ms=5.0,
+        status=DiagnosticStatus.UNVERIFIABLE,
+    )
+
+    with patch("qwed_new.api.main.consensus_verifier.verify_with_consensus", return_value=fake), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/consensus",
+            json={"query": "test", "verification_mode": "high", "min_confidence": 0.95},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+    assert data["meets_requirement"] is False
+    assert data["is_authoritative"] is False
+
+
 def test_verify_consensus_unverifiable_no_blocked_engines_message(client):
     """Cover unanimous + UNVERIFIABLE with zero blocked engines (#266) — message reflects source, not blocked fallback."""
     from qwed_new.core.consensus_verifier import ConsensusResult, EngineResult

--- a/tests/test_pr117_regressions.py
+++ b/tests/test_pr117_regressions.py
@@ -183,6 +183,7 @@ def test_consensus_code_engine_uses_secure_executor_output():
     assert result.success is True
     assert result.result == "4"
     assert result.engine_name == "Python"
+    assert result.status == "UNVERIFIABLE"  # Code execution is advisory-only (#269)
 
 
 def test_consensus_codegen_assigns_result_variable():


### PR DESCRIPTION
## Summary

Fixes #269

`_verify_with_code` returned `status="VERIFIED"` when generated code executed successfully. But executing an expression is not proving its result matches any expected answer — just that it ran. Mirrored fix from #270 (Stats advisory-only).

## Changes

- **`consensus_verifier.py:700-705`**: Status changed from `"VERIFIED"` to `"UNVERIFIABLE"`. Kept full output intact — output is still available as advisory evidence but no longer produces a VERIFIED vote in consensus.

## Verification

- [x] All 78 existing tests pass


___

## **CodeAnt-AI Description**
Prevent successful code execution from being treated as verified consensus

### What Changed
- Code that runs without errors is now reported as unverifiable instead of verified
- Execution output remains available as advisory evidence
- Code failures continue to be reported as blocked

### Impact
`✅ Fewer false VERIFIED results`
`✅ More reliable consensus decisions`
`✅ Advisory code output remains available`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated code-execution verification results to be treated as advisory rather than definitive.
  * Successful execution no longer marks a result as verified, preventing runtime success from being interpreted as proof of semantic correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->