### PR TITLE
Fix #267: FactVerifier SUPPORTED verdict now UNVERIFIABLE with heuristic advisory_checks

### DIFF
--- a/src/qwed_new/core/fact_verifier.py
+++ b/src/qwed_new/core/fact_verifier.py
@@ -219,13 +219,31 @@ class FactVerifier:
         if advisory_checks:
             developer_fields["advisory_checks"] = advisory_checks
 
-        # Map deterministic verdict to DiagnosticResult
+        # Map deterministic verdict to DiagnosticResult.
+        # NOTE (#267): Heuristic analysis (TF-IDF cosine, keyword overlap,
+        # entity matching, negation detection) cannot produce VERIFIED.
+        # Two different claims with similar token distributions can yield
+        # the same heuristic verdict — advisory-only per QWED fail-closed contract.
         if verdict == "SUPPORTED":
-            evidence = {"citations": developer_fields["citations"], "reasoning": reasoning}
-            return DiagnosticResult.verified(
-                "Fact claim verified by deterministic analysis",
+            developer_fields["constraint_id"] = "fact_verifier.heuristic_supported"
+            advisory_checks.append(
+                AdvisoryCheck(
+                    name="heuristic_supported",
+                    advisory_only=True,
+                    constraint_id="fact_verifier.tfidf_cosine_similarity",
+                    details={
+                        "deterministic_verdict": verdict,
+                        "confidence": round(confidence, 3),
+                        "reasoning": reasoning,
+                        "citations": developer_fields["citations"],
+                        "scores": developer_fields["scores"],
+                    },
+                )
+            )
+            developer_fields["advisory_checks"] = advisory_checks
+            return DiagnosticResult.unverifiable(
+                "Fact claim supported by heuristic analysis — not a deterministic proof",
                 developer_fields,
-                evidence,
             )
 
         if verdict == "REFUTED":

--- a/src/qwed_new/core/fact_verifier.py
+++ b/src/qwed_new/core/fact_verifier.py
@@ -233,7 +233,9 @@ class FactVerifier:
                     constraint_id="fact_verifier.tfidf_cosine_similarity",
                     details={
                         "deterministic_verdict": verdict,
-                        "confidence": round(confidence, 3),
+                        # Reuse deterministic_confidence computed once upstream —
+                        # never re-round in detail blocks (avoids binary float drift).
+                        "confidence": str(developer_fields["deterministic_confidence"]),
                         "reasoning": reasoning,
                         "citations": developer_fields["citations"],
                         "scores": developer_fields["scores"],

--- a/tests/security/test_hybrid_advisory_only.py
+++ b/tests/security/test_hybrid_advisory_only.py
@@ -502,11 +502,16 @@ class TestFactVerifierAdvisoryOnly:
     def setup_method(self):
         self.verifier = FactVerifier(use_llm_fallback=False)
 
-    def test_supported_verified(self):
-        """Deterministic SUPPORTED → VERIFIED with proof_ref."""
+    def test_supported_unverifiable_heuristic_only(self):
+        """Heuristic SUPPORTED → UNVERIFIABLE, never VERIFIED #267."""
         result = self.verifier.verify_fact("The sky is blue", "The sky is blue today")
-        assert result.is_verified
-        assert result.proof_ref is not None
+        assert result.status.value == "UNVERIFIABLE"
+        assert result.is_verified is False
+        assert result.proof_ref is None
+        assert result.developer_fields["deterministic_verdict"] == "SUPPORTED"
+        assert result.developer_fields["constraint_id"] == "fact_verifier.heuristic_supported"
+        # Heuristic verdict must live in advisory_checks, not in status (#267)
+        assert result.developer_fields["advisory_checks"][0].constraint_id == "fact_verifier.tfidf_cosine_similarity"
 
     def test_refuted_blocked(self):
         """REFUTED (negation conflict) → BLOCKED."""

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -181,26 +181,15 @@ def test_verify_stats_success_without_claim_supported_is_unverifiable(client):
 
 
 def test_verify_fact_heuristic_supported_never_returns_verified(client):
-    """Cover that TF-IDF SUPPORTED verdict cannot produce VERIFIED #267."""
-    with patch("qwed_new.core.fact_verifier.FactVerifier.verify_fact", return_value=DiagnosticResult(
-        status=DiagnosticStatus.UNVERIFIABLE,
-        agent_message="Fact claim supported by heuristic analysis — not a deterministic proof",
-        developer_fields={
-            "constraint_id": "fact_verifier.heuristic_supported",
-            "deterministic_verdict": "SUPPORTED",
-            "advisory_checks": [{
-                "name": "heuristic_supported",
-                "advisory_only": True,
-                "constraint_id": "fact_verifier.tfidf_cosine_similarity",
-                "details": {"verdict": "SUPPORTED"},
-            }],
-        },
-        proof_ref=None,
-    )), \
-         patch("qwed_new.api.main.check_rate_limit"):
+    """Cover that real FactVerifier SUPPORTED verdict cannot produce VERIFIED #267.
+    Uses a claim-context pair that reliably triggers the SUPPORTED heuristic path — never mocks the engine."""
+    with patch("qwed_new.api.main.check_rate_limit"):
         response = client.post(
             "/verify/fact",
-            json={"claim": "Rayleigh scattering causes the sky to be blue.", "context": "The sky appears blue because Rayleigh scattering scatters short-wavelength blue light more than other colors."},
+            json={
+                "claim": "Rayleigh scattering causes the sky to appear blue during the daytime.",
+                "context": "The sky appears blue because Rayleigh scattering scatters short-wavelength blue light more than other colors.",
+            },
         )
 
     assert response.status_code == 200

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -194,9 +194,13 @@ def test_verify_fact_heuristic_supported_never_returns_verified(client):
 
     assert response.status_code == 200
     data = response.json()
+    # Assert #267 SUPPORTED heuristic branch was exercised (not insufficient-evidence / neutral fallthrough)
     assert data["status"] == "UNVERIFIABLE"
     assert data["proof_ref"] is None
     assert data["is_authoritative"] is False
+    assert data["deterministic_verdict"] == "SUPPORTED"  # reached the changed branch
+    assert data["constraint_id"] == "fact_verifier.heuristic_supported"
+    assert any(c["name"] == "heuristic_supported" for c in data["advisory_checks"])  # advisory present
     assert data["status"] != "VERIFIED"  # Never verified for heuristic work (#267)
 
 

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -180,6 +180,37 @@ def test_verify_stats_success_without_claim_supported_is_unverifiable(client):
     assert data["status"] == "UNVERIFIABLE"
 
 
+def test_verify_fact_heuristic_supported_never_returns_verified(client):
+    """Cover that TF-IDF SUPPORTED verdict cannot produce VERIFIED #267."""
+    with patch("qwed_new.core.fact_verifier.FactVerifier.verify_fact", return_value=DiagnosticResult(
+        status=DiagnosticStatus.UNVERIFIABLE,
+        agent_message="Fact claim supported by heuristic analysis — not a deterministic proof",
+        developer_fields={
+            "constraint_id": "fact_verifier.heuristic_supported",
+            "deterministic_verdict": "SUPPORTED",
+            "advisory_checks": [{
+                "name": "heuristic_supported",
+                "advisory_only": True,
+                "constraint_id": "fact_verifier.tfidf_cosine_similarity",
+                "details": {"verdict": "SUPPORTED"},
+            }],
+        },
+        proof_ref=None,
+    )), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/fact",
+            json={"claim": "Rayleigh scattering causes the sky to be blue.", "context": "The sky appears blue because Rayleigh scattering scatters short-wavelength blue light more than other colors."},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNVERIFIABLE"
+    assert data["proof_ref"] is None
+    assert data["is_authoritative"] is False
+    assert data["status"] != "VERIFIED"  # Never verified for heuristic work (#267)
+
+
 def test_verify_fact_preserves_diagnostic_result(client):
     """Cover isinstance(result, DiagnosticResult) pass-through in fact endpoint."""
     dr = DiagnosticResult(


### PR DESCRIPTION
## Summary

Fixes #267

`FactVerifier` returned `DiagnosticResult.verified()` for a `SUPPORTED` verdict derived entirely from TF-IDF cosine similarity, keyword overlap, entity matching, and negation detection — heuristic methods, not deterministic proof. Two different claims with similar token distributions could both reach SUPPORTED, violating the invariant that VERIFIED requires deterministic proof.

## Changes

- **`fact_verifier.py`**: `SUPPORTED` branch no longer calls `DiagnosticResult.verified()`. Returns `unverifiable()` with `developer_fields["advisory_checks"]` carrying the full heuristic metadata (citations, scores, reasoning, confidence) as an `AdvisoryCheck`.
- **`tests/security/test_hybrid_advisory_only.py`**: `test_supported_verified` updated from `is_verified/proof_ref` assertion to UNVERIFIABLE with advisory metadata.
- **`tests/test_diagnostic_coverage.py`** Added regression test ensuring SUPPORTED inputs land on the UNVERIFIABLE path.
- **constraint_id moved**: from `deterministic_analysis` to `fact_verifier.heuristic_supported` (accurately signals heuristic, not deterministic).

## Verification

- [x] All 112 tests pass
- [x] Test expectation now matches new UNVERIFIABLE contract (CI green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Heuristic fact-check results are no longer presented as verified.
  * Heuristic support findings now appear as advisory, unverifiable results without proof references.
  * Added safeguards to ensure heuristic verification responses remain non-authoritative.

* **Tests**
  * Added regression coverage for heuristic fact-checking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent heuristic fact matches from being reported as verified

### What Changed
- Fact claims supported only by similarity, keyword, entity, or negation heuristics now return `UNVERIFIABLE` instead of `VERIFIED`
- Heuristic evidence remains available as advisory information, including confidence, reasoning, citations, and scores
- These results no longer include proof references or authoritative verification status
- Added regression coverage to ensure heuristic-supported claims remain unverifiable

### Impact
`✅ Prevents unsupported fact claims from being treated as verified`
`✅ Preserves heuristic evidence for review`
`✅ Avoids authoritative proof references for heuristic results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
