### PR TITLE
Fix #279: Attest translated expression, not natural language query — align attestation scope with verification scope

### DIFF
--- a/src/qwed_new/core/control_plane.py
+++ b/src/qwed_new/core/control_plane.py
@@ -168,7 +168,7 @@ class ControlPlane:
                 if att_result.status is not AttestationStatus.ISSUED:
                     logger.warning(
                         "trust_boundary.attestation_failed query_hash=%s status=%s",
-                        hashlib.sha256(query.encode()).hexdigest()[:16] if query else "unknown",
+                        hashlib.sha256(task.expression.encode()).hexdigest()[:16] if task.expression else "unknown",
                         att_result.status.value,
                     )
                     dr = DiagnosticResult.blocked(

--- a/src/qwed_new/core/control_plane.py
+++ b/src/qwed_new/core/control_plane.py
@@ -153,12 +153,15 @@ class ControlPlane:
                     evidence=evidence,
                     proof_data=str(evidence),
                 )
-                # Issue attestation for the VERIFIED result
+                # Issue attestation for the VERIFIED result.
+                # (#279) Attest the translated formula — not the natural-language
+                # query — so qwed.query_hash binds to task.expression (what the
+                # deterministic engine actually verified), not the user's prose.
                 att_result = create_verification_attestation(
                     status="VERIFIED",
                     verified=True,
                     engine="math",
-                    query=query,
+                    query=task.expression,
                     confidence=1.0,
                     proof_data=str(evidence),
                 )
@@ -179,7 +182,7 @@ class ControlPlane:
                         dr,
                         require_attestation=True,
                         attestation_token=att_result.token,
-                        query=query,
+                        query=task.expression,  # #279 — must match qwed.query_hash in the attestation
                     )
             else:
                 # Non-VERIFIED path: convert legacy dict and enforce.
@@ -189,7 +192,7 @@ class ControlPlane:
                 enforced = enforce_trust_decision(
                     dr,
                     require_attestation=True,
-                    query=query,
+                    query=task.expression,  # #279 — consistent log-side hash attribution to expression
                 )
             trust_boundary["trust_enforced"] = enforced.status.value
             trust_boundary["attestation_policy"] = "mandatory"

--- a/tests/test_pr5_determinism_alignment.py
+++ b/tests/test_pr5_determinism_alignment.py
@@ -64,14 +64,18 @@ async def test_control_plane_marks_translated_math_as_verified(monkeypatch):
     # not control plane orchestration behavior.
     from qwed_new.core.attestation import AttestationResult, AttestationStatus
     from qwed_new.core.diagnostics import DiagnosticResult
-    monkeypatch.setattr(
-        "qwed_new.core.control_plane.create_verification_attestation",
-        lambda **kwargs: AttestationResult(
+    captured_attestation_kwargs: dict = {}
+    def _mock_create_attestation(**kwargs):
+        captured_attestation_kwargs.update(kwargs)
+        return AttestationResult(
             status=AttestationStatus.ISSUED,
             token="test-sentinel-token",
             error_code=None,
             error=None,
-        ),
+        )
+    monkeypatch.setattr(
+        "qwed_new.core.control_plane.create_verification_attestation",
+        _mock_create_attestation,
     )
 
     captured_enforce_kwargs: dict = {}
@@ -100,6 +104,10 @@ async def test_control_plane_marks_translated_math_as_verified(monkeypatch):
     # Assert enforce_trust_decision was called with mandatory attestation args
     assert captured_enforce_kwargs["require_attestation"] is True
     assert captured_enforce_kwargs["attestation_token"] == "test-sentinel-token"
+    # #279 regression: attestation and enforcement both bind to task.expression,
+    # not the natural-language query (semantic scope must match)
+    assert captured_attestation_kwargs["query"] == "0.15 * 200"
+    assert captured_enforce_kwargs["query"] == "0.15 * 200"
     assert captured["organization_id"] == 42
     assert captured["status"] == "VERIFIED"
     assert captured["provider"] == "openai_compat"


### PR DESCRIPTION
## Summary

Fixes #279

When the control plane verified an LLM-translated query and returned VERIFIED, the resulting `qwed.query_hash` in attestation was hashing the **natural language query** instead of the **translated expression** that the engine actually verified. This created a semantic scope mismatch: consumers might read the attestation as "the question was answered" (strong, wrapping claim) instead of "the arithmetic is right" (weak, targeted claim).

## Changes

- **`control_plane.py:161`**: `create_verification_attestation(query=task.expression)` — attestation query_hash now binds to the translated expression (deterministic input), not natural language query (ambiguous scope)
- **`control_plane.py:182-183`**: `enforce_trust_decision(..., query=task.expression)` — signature validation during trust enforcement matches the new attestation binding (line 183 uses task.expression so qwed.query_hash check passes)
- **`control_plane.py:192-193`**: `enforce_trust_decision(..., query=task.expression)` — log-side hash attribution also uses expression for consistent forensic record across all verify paths

## What This Does NOT Change

- `response["user_query"]` still contains original natural language query for consumer display
- `trust_boundary["verification_scope"] = "translated_expression_only"` already discloses the narrowed scope at trust boundary
- No API response schema change at all

## Acceptance Criteria

- [x] Attestation binds to what was actually verified (translated expression), not to ambiguous user intent (natural language)
- [x] Response schema is unchanged — existing consumers continue to work
- [x] 119 existing tests pass, no regression

## Related

- #265: PR #278 implemented mandatory attestation issuance + validation on VERIFIED results
- #278: Follows directly from this design decision flagged during the PR #278 review


___

## **CodeAnt-AI Description**
Bind verification attestations to the translated expression

### What Changed
- VERIFIED results now attest the translated expression that the calculation engine actually checked, instead of the user's natural-language query
- Attestation validation and trust records use the same expression, preventing scope and signature mismatches
- The original natural-language query remains available for user-facing responses

### Impact
`✅ Attestations match the verified calculation`
`✅ Fewer trust-validation mismatches`
`✅ Clearer verification scope`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved math verification consistency by basing attestations and trust decisions on the translated expression used for evaluation.
  * Reduced the risk of mismatches between natural-language queries and their evaluated mathematical forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->