### PR TITLE
Fix #274: VerificationCache + cached_verify support tenant isolation via optional tenant_id

### DIFF
--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -105,6 +105,9 @@ class VerificationCache:
     - LRU eviction
     - TTL (time-to-live) support
     - Hit rate tracking
+
+    #274 tenant isolation: pass tenant_id to get/set/invalidate to isolate
+    cache keyspace per tenant. tenant_id=None preserves pre-#274 single-tenant hash.
     """
 
     def __init__(
@@ -124,21 +127,37 @@ class VerificationCache:
         self._hits = 0
         self._misses = 0
 
-    def _generate_key(self, dsl_code: str, variables: Optional[list] = None) -> str:
-        """Generate an unambiguous cache key from DSL code and optional variables."""
+    def _generate_key(self, dsl_code: str, variables: Optional[list] = None,
+                      tenant_id: Optional[str] = None) -> str:
+        """Generate an unambiguous cache key from DSL code and optional variables.
+
+        (#274) When tenant_id is None: uses the pre-#274 hash format ({"dsl":...,"vars":...}, no tenant marker) — same key as today. Explicit tenant_id adds "tenant" to the hash material, isolating keyspace per tenant.
+        """
         normalized = ' '.join(dsl_code.split())
         # Use a structured JSON object so "foo" + vars=[1] never collides with
-        # "foo[1]" + vars=None (plain string concatenation would cause that).
-        key_material = json.dumps(
-            {"dsl": normalized, "vars": variables},
-            sort_keys=True,
-            separators=(",", ":"),
-        )
+        if tenant_id is not None:
+            key_material = json.dumps(
+                {"tenant": tenant_id, "dsl": normalized, "vars": variables},
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        else:
+            key_material = json.dumps(
+                {"dsl": normalized, "vars": variables},
+                sort_keys=True,
+                separators=(",", ":"),
+            )
         return hashlib.sha256(key_material.encode()).hexdigest()[:32]
 
-    def get(self, dsl_code: str, variables: Optional[list] = None) -> Optional[Dict[str, Any]]:
+    def get(self, dsl_code: str, variables: Optional[list] = None,
+            tenant_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """
         Get cached result for DSL code.
+
+        Args:
+            dsl_code: QWED-DSL expression
+            variables: Variable declarations
+            tenant_id: Optional tenant identifier for multi-tenant key isolation (#274)
 
         Returns:
             Cached result dict or None if not found/expired
@@ -146,7 +165,7 @@ class VerificationCache:
         if not self.enabled:
             return None
 
-        key = self._generate_key(dsl_code, variables)
+        key = self._generate_key(dsl_code, variables, tenant_id)
 
         with self._lock:
             if key not in self._cache:
@@ -174,13 +193,21 @@ class VerificationCache:
         self,
         dsl_code: str,
         result: Dict[str, Any],
-        variables: Optional[list] = None
+        variables: Optional[list] = None,
+        tenant_id: Optional[str] = None,
     ) -> None:
-        """Cache a verification result."""
+        """Cache a verification result.
+
+        Args:
+            dsl_code: QWED-DSL expression
+            result: Verification result dict
+            variables: Variable declarations
+            tenant_id: Optional tenant identifier for multi-tenant key isolation (#274)
+        """
         if not self.enabled:
             return
 
-        key = self._generate_key(dsl_code, variables)
+        key = self._generate_key(dsl_code, variables, tenant_id)
 
         with self._lock:
             # If the key already exists, remove it first so the size
@@ -197,9 +224,10 @@ class VerificationCache:
                 created_at=time.time()
             )
 
-    def invalidate(self, dsl_code: str, variables: Optional[list] = None) -> bool:
+    def invalidate(self, dsl_code: str, variables: Optional[list] = None,
+                   tenant_id: Optional[str] = None) -> bool:
         """Remove a specific entry from cache."""
-        key = self._generate_key(dsl_code, variables)
+        key = self._generate_key(dsl_code, variables, tenant_id)
 
         with self._lock:
             if key in self._cache:
@@ -683,6 +711,11 @@ _cache_factory_lock = Lock()
 
 
 def _get_or_create_local_cache(tenant_id: Optional[int]) -> VerificationCache:
+    """Get a tenant-scoped VerificationCache singleton.
+
+    Factory creates one VerificationCache per tenant_id. tenant_id=None marks
+    the global single-tenant shared cache — other tenant IDs get their own
+    keyspace from the factory pool (#274)."""
     with _cache_factory_lock:
         cache = _verification_caches.get(tenant_id)
         if cache is None:
@@ -793,6 +826,7 @@ def cached_verify(
     dsl_code: str,
     variables: Optional[list] = None,
     verify_fn: Optional[Callable[[], Dict[str, Any]]] = None,
+    tenant_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Verify with caching (single-process convenience wrapper).
@@ -805,6 +839,9 @@ def cached_verify(
         dsl_code: The QWED-DSL expression
         variables: Variable declarations
         verify_fn: Function to call on cache miss (should return result dict)
+        tenant_id: Optional tenant identifier. When provided, cache keys are
+            isolated per tenant so different tenants cannot share results
+            (#274). Backward compat: absent tenant_id uses the old global key.
 
     Returns:
         Verification result (from cache or fresh)
@@ -813,7 +850,7 @@ def cached_verify(
     cache = get_cache(use_redis=False, mode=CacheBackendMode.LOCAL_ONLY)
 
     # Check cache first
-    cached_result = cache.get(dsl_code, variables)
+    cached_result = cache.get(dsl_code, variables, tenant_id=tenant_id)
     if cached_result is not None:
         cached_result['_cached'] = True
         return cached_result
@@ -827,7 +864,7 @@ def cached_verify(
 
     # Only cache successful results
     if result.get('status') in ['SAT', 'UNSAT', 'SUCCESS']:
-        cache.set(dsl_code, result, variables)
+        cache.set(dsl_code, result, variables, tenant_id=tenant_id)
 
     return result
 

--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -847,7 +847,8 @@ def cached_verify(
         Verification result (from cache or fresh)
     """
     # LOCAL_ONLY: deterministic, no distributed concerns
-    cache = get_cache(use_redis=False, mode=CacheBackendMode.LOCAL_ONLY)
+    # (#274) Pass tenant_id so factory returns a tenant-scoped singleton (LRU capacity, eviction, lifecycle stay per-tenant).
+    cache = get_cache(use_redis=False, tenant_id=tenant_id, mode=CacheBackendMode.LOCAL_ONLY)
 
     # Check cache first
     cached_result = cache.get(dsl_code, variables, tenant_id=tenant_id)

--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -699,7 +699,7 @@ class RedisCache:
 # _verification_caches is a per-tenant mapping to prevent cross-tenant leakage
 # in LOCAL_ONLY / no-Redis paths: VerificationCache._generate_key has no tenant
 # context, so we maintain separate instances per tenant_id.
-_verification_caches: Dict[Optional[int], VerificationCache] = {}
+_verification_caches: Dict[Optional[str], VerificationCache] = {}
 # Per-(tenant_id, mode) RedisCache map — protected by _cache_factory_lock
 # to prevent concurrent callers racing and crossing tenant boundaries.
 _redis_caches: Dict[tuple, RedisCache] = {}
@@ -707,16 +707,28 @@ _redis_caches: Dict[tuple, RedisCache] = {}
 # lock while hammering a dead Redis connection on every call.
 _redis_cache_retry_after: Dict[tuple, float] = {}
 _constructing_events: Dict[tuple, Event] = {}  # signals when construction completes
+
+
+def _normalize_tenant_key(tenant_id: int | str | None) -> Optional[str]:
+    """Normalize tenant_id to canonical string form for cross-backend singleton identity.
+
+    ( #274 ) Both local (VerificationCache) and distributed (RedisCache) singleton
+    factories must use the same canonical key so tenant_id=42 (int) and tenant_id="42" (str)
+    land in the same tenant singleton (no accidental duplication by type)."""
+    if tenant_id is None:
+        return None
+    return str(tenant_id)
 _cache_factory_lock = Lock()
 
 
-def _get_or_create_local_cache(tenant_id: Optional[Union[int, str]]) -> VerificationCache:
+def _get_or_create_local_cache(tenant_id: Optional[int | str]) -> VerificationCache:
     """Get a tenant-scoped VerificationCache singleton.
 
-    Accepts int or str tenant_id; normalizes to string key for consistency
-    (QWED #274 — cached_verify passes Optional[str], callers pass Optional[int]).
+    Accepts int or str tenant_id; normalizes to string key via _normalize_tenant_key
+    so tenant_id=42 (int) and tenant_id="org-42" (str) land in the same tenant
+    singleton (no duplicate LRU by cast inconsistency). #274
     """
-    tenant_key = None if tenant_id is None else str(tenant_id)
+    tenant_key = _normalize_tenant_key(tenant_id)
     with _cache_factory_lock:
         cache = _verification_caches.get(tenant_key)
         if cache is None:
@@ -767,7 +779,7 @@ def _record_redis_cache_construction_failure(cache_key: tuple) -> None:
 
 def get_cache(
     use_redis: bool = True,
-    tenant_id: Optional[Union[int, str]] = None,
+    tenant_id: int | str | None = None,
     mode: CacheBackendMode = CacheBackendMode.STRICT_DISTRIBUTED,
 ) -> "Union[VerificationCache, RedisCache]":
     """
@@ -791,8 +803,10 @@ def get_cache(
     if not use_redis or mode == CacheBackendMode.LOCAL_ONLY:
         return _get_or_create_local_cache(tenant_id)
 
-    # Redis path — per-(tenant_id, mode) singleton, locked to prevent races
-    cache_key = (tenant_id, mode)
+    # Redis path — per-(tenant, mode) singleton, locked to prevent races
+    # #274: use canonicalized tenant_key so int/str tenant_id resolve to one singleton
+    tenant_key = _normalize_tenant_key(tenant_id)
+    cache_key = (tenant_key, mode)
 
     cache, event = _await_or_claim_redis_cache_construction(cache_key, mode)
     if cache is not None:
@@ -801,7 +815,7 @@ def get_cache(
     # Construct outside the lock -- RedisCache.__init__ calls
     # get_redis_client() which may block on a 5-second network timeout.
     try:
-        new_cache = RedisCache(tenant_id=tenant_id, mode=mode)
+        new_cache = RedisCache(tenant_id=tenant_key, mode=mode)
     except CacheBackendUnavailableError:
         _record_redis_cache_construction_failure(cache_key)
         event.set()  # Wake waiters after state is consistent

--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -136,8 +136,11 @@ class VerificationCache:
         normalized = ' '.join(dsl_code.split())
         # Use a structured JSON object so "foo" + vars=[1] never collides with
         if tenant_id is not None:
+            # #274: hash material uses canonically-normalized tenant key — 42 and "42"
+            # produce the same sha256 digest, never two entries in the same tenant singleton.
+            tenant_key = _normalize_tenant_key(tenant_id)
             key_material = json.dumps(
-                {"tenant": tenant_id, "dsl": normalized, "vars": variables},
+                {"tenant": tenant_key, "dsl": normalized, "vars": variables},
                 sort_keys=True,
                 separators=(",", ":"),
             )

--- a/src/qwed_new/core/cache.py
+++ b/src/qwed_new/core/cache.py
@@ -710,17 +710,18 @@ _constructing_events: Dict[tuple, Event] = {}  # signals when construction compl
 _cache_factory_lock = Lock()
 
 
-def _get_or_create_local_cache(tenant_id: Optional[int]) -> VerificationCache:
+def _get_or_create_local_cache(tenant_id: Optional[Union[int, str]]) -> VerificationCache:
     """Get a tenant-scoped VerificationCache singleton.
 
-    Factory creates one VerificationCache per tenant_id. tenant_id=None marks
-    the global single-tenant shared cache — other tenant IDs get their own
-    keyspace from the factory pool (#274)."""
+    Accepts int or str tenant_id; normalizes to string key for consistency
+    (QWED #274 — cached_verify passes Optional[str], callers pass Optional[int]).
+    """
+    tenant_key = None if tenant_id is None else str(tenant_id)
     with _cache_factory_lock:
-        cache = _verification_caches.get(tenant_id)
+        cache = _verification_caches.get(tenant_key)
         if cache is None:
             cache = VerificationCache()
-            _verification_caches[tenant_id] = cache
+            _verification_caches[tenant_key] = cache
     return cache
 
 
@@ -766,7 +767,7 @@ def _record_redis_cache_construction_failure(cache_key: tuple) -> None:
 
 def get_cache(
     use_redis: bool = True,
-    tenant_id: Optional[int] = None,
+    tenant_id: Optional[Union[int, str]] = None,
     mode: CacheBackendMode = CacheBackendMode.STRICT_DISTRIBUTED,
 ) -> "Union[VerificationCache, RedisCache]":
     """

--- a/tests/test_pr189_redis_failclosed.py
+++ b/tests/test_pr189_redis_failclosed.py
@@ -382,8 +382,9 @@ class TestCachedVerifyBackwardCompat:
         assert r2["_cached"] is False
 
         # tenant-a calls again — cache hit from own cache
+        set_count_before_third_call = set_count
         r3 = cached_verify("(= z 1)", verify_fn=compute, tenant_id="tenant-a")
-        assert set_count == 2  # compute NOT called again
+        assert set_count == set_count_before_third_call  # compute NOT called again
         assert r3["_cached"] is True
 
     def test_verification_cache_tenant_id_parameterized_keys(self):
@@ -391,6 +392,10 @@ class TestCachedVerifyBackwardCompat:
         cache = VerificationCache()
         none_key = cache._generate_key("(= q 1)")
         tenant_key = cache._generate_key("(= q 1)", tenant_id="org-42")
+
+        # #274 contract: tenant_id=None must produce the identical pre-#274 key
+        # from legacy canonical payload {"dsl":"(= q 1)","vars":null}
+        assert none_key == "67236b672611776bedbdf526a1c78c69"
 
         assert tenant_key != none_key     # tenant_id=X changes keyspace
         assert cache._generate_key("(= q 1)", tenant_id="org-42") == tenant_key  # deterministic

--- a/tests/test_pr189_redis_failclosed.py
+++ b/tests/test_pr189_redis_failclosed.py
@@ -343,6 +343,7 @@ class TestGetCacheContract:
 # cached_verify() backward compat
 # ---------------------------------------------------------------------------
 
+
 class TestCachedVerifyBackwardCompat:
 
     def setup_method(self):
@@ -359,6 +360,40 @@ class TestCachedVerifyBackwardCompat:
 
         mock_get.assert_not_called()
         assert result["status"] == "SAT"
+
+    def test_cached_verify_tenant_isolation_prevents_cross_tenant_leak(self):
+        """#274: two tenants calling cached_verify with different tenant_id never
+        share cached results."""
+        cache_mod._verification_caches.clear()
+
+        set_count = 0
+        def compute():
+            nonlocal set_count
+            set_count += 1
+            return {"status": "SAT", "verified": True}
+
+        # tenant-a writes to cache
+        cached_verify("(= z 1)", verify_fn=compute, tenant_id="tenant-a")
+        assert set_count == 1
+
+        # tenant-b calls same query — fresh miss, NOT tenant-a's result
+        r2 = cached_verify("(= z 1)", verify_fn=compute, tenant_id="tenant-b")
+        assert set_count == 2  # compute called again for tenant-b
+        assert r2["_cached"] is False
+
+        # tenant-a calls again — cache hit from own cache
+        r3 = cached_verify("(= z 1)", verify_fn=compute, tenant_id="tenant-a")
+        assert set_count == 2  # compute NOT called again
+        assert r3["_cached"] is True
+
+    def test_verification_cache_tenant_id_parameterized_keys(self):
+        """#274: tenant_id=None preserves pre-#274 hash; tenant_id=X distinct keyspace."""
+        cache = VerificationCache()
+        none_key = cache._generate_key("(= q 1)")
+        tenant_key = cache._generate_key("(= q 1)", tenant_id="org-42")
+
+        assert tenant_key != none_key     # tenant_id=X changes keyspace
+        assert cache._generate_key("(= q 1)", tenant_id="org-42") == tenant_key  # deterministic
 
     def test_cached_verify_caches_on_second_call(self):
         """cached_verify() returns cached result on second call."""


### PR DESCRIPTION
## **User description**
## Summary

Fixes #274

`VerificationCache` and `cached_verify()` were single-tenant-global: every caller
shared the same cache key `sha256({"dsl":..., "vars":...})`, allowing cross-tenant
data leakage via cached results and cross-tenant LRU eviction. `cached_verify()`
never accepted tenant_id, so every call routed to the global fabrication singleton
keyed under `tenant_id=None`.

## Changes

### Core
- **`cache.py`**: `VerificationCache._generate_key(_, _, tenant_id=None)` — `tenant_id=None`
  uses the pre-#274 canonical hash (backward compatible). `tenant_id="X"` adds
  `{"tenant": "X"}` to the hash payload — independently isolated keyspace per tenant.
- **`VerificationCache` methods** (`get`, `set`, `invalidate`): accept optional
  `tenant_id` kwarg and forward to `._generate_key`.

### API / Integration
- **`cached_verify()`**: accepts optional `tenant_id` and passes through end-to-end
  → cache factory → `VerificationCache._generate_key`.
- **`get_cache()`**: now accepts `tenant_id` forwarding (Sentry/Greptile/CodeAnt/CodeRabbit):
  `get_cache(use_redis=False, tenant_id=tenant_id, mode=LOCAL_ONLY)` — routes ONLY FD
  singleton factory returns scoped per-tenant instance.

### Factory lifecycle
- **`_get_or_create_local_cache()`**: normalizes `tenant_id` to string key so
  `tenant_id=42` (int) and `tenant_id="org-42"` (str) land in the same tenant
  singleton (Sentry MEDIUM). Prevents duplicate LRUs from type inconsistency.
- Updated docstring documenting tenant-scoped singleton lifetime.

## Backward Compatibility
- `tenant_id=None` produces hash exactly like pre-#274 — single-tenant behavior
  unchanged today. Existing SDK + test callers untouched.
- `tenant_id` kwarg is optional everywhere.

## Tests
- [x] 56/56 test_pr189_redis_failclosed pass, with **new tenant-isolation regressions**:
    - `test_cached_verify_tenant_isolation_prevents_cross_tenant_leak` — tenant-b cannot read tenant-a's cached value
    - `test_verification_cache_tenant_id_parameterized_keys` — `none_key` matches canonical pre-#274 payload hash `67236b672611776bedbdf526a1c78c69` deterministically
- [x] 144/144 broad caches tests
- [x] 82/82 API-regression breadth

## Adversarial Review Findings Solved
- **Sentry/Greptile/CodeAnt/CodeRabbit (LRU capacity)**: `get_cache()` now receives tenant_id so the singleton factory returns per-tenant instances (LRU capacity strictly scoped per tenant, no cross-tenant eviction pressure)
- **Sentry MEDIUM (type safety)**: `_get_or_create_local_cache` normalizes int/str tenant_id for dict lookup consistency — no more duplicate singletons by ID-type-mismatch
- **CodeQL**: Removed automorphic `assert set_count == 2` tautology in tenant-isolation test
- **CodeRabbit Minor**: Regression test pins legacy pre-#274 key vs known value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification cache isolation so results remain separate across tenants.
  * Added support for string and integer tenant identifiers.
  * Preserved existing cache behavior when no tenant is specified.
  * Ensured cache retrieval, updates, invalidation, and verification reuse operate consistently within the correct tenant scope.

* **Tests**
  * Added coverage for tenant-specific cache hits, separation, and deterministic key generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Isolate verification caches by tenant

### What Changed
- Verification results cached for one tenant are no longer returned to another tenant for the same request.
- Tenant-aware caching now applies to reads, writes, invalidation, local caches, distributed caches, and the `cached_verify` helper.
- Tenant identifiers provided as numbers or strings resolve to the same tenant cache.
- Calls without a tenant identifier keep the existing cache keys and behavior.

### Impact
`✅ Prevented cross-tenant verification result leaks`
`✅ Independent cache eviction and reuse per tenant`
`✅ Preserved single-tenant cache compatibility`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
