### PR TITLE
Fix 272: NFC-normalize AgentStateGuard canonicalization

### DIFF
--- a/src/qwed_new/guards/agent_state_guard.py
+++ b/src/qwed_new/guards/agent_state_guard.py
@@ -69,12 +69,18 @@ class AgentStateGuard:
         # Canonicalize schema field names (property keys, required lists, enum
         # values) and transition-rule paths to NFC so validation matches payload
         # keys canonically regardless of precomposed/decomposed spelling.
-        self.required_schema = self._freeze_config(
-            self._canonicalize(validated_schema)
-        )
-        self.transition_rules = self._freeze_config(
-            self._canonicalize(validated_transition_rules)
-        )
+        try:
+            canonical_schema = self._canonicalize(validated_schema)
+            canonical_transition_rules = self._canonicalize(
+                validated_transition_rules
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid schema: {exc} Define property names, required lists, "
+                "and enum values in a consistent Unicode normalization form."
+            ) from exc
+        self.required_schema = self._freeze_config(canonical_schema)
+        self.transition_rules = self._freeze_config(canonical_transition_rules)
         self._transition_rules_configured = self._has_effective_transition_rules(
             self.transition_rules
         )

--- a/src/qwed_new/guards/agent_state_guard.py
+++ b/src/qwed_new/guards/agent_state_guard.py
@@ -66,8 +66,15 @@ class AgentStateGuard:
         validated_transition_rules = self._validate_transition_rules_definition(
             transition_rules or {}
         )
-        self.required_schema = self._freeze_config(validated_schema)
-        self.transition_rules = self._freeze_config(validated_transition_rules)
+        # Canonicalize schema field names (property keys, required lists, enum
+        # values) and transition-rule paths to NFC so validation matches payload
+        # keys canonically regardless of precomposed/decomposed spelling.
+        self.required_schema = self._freeze_config(
+            self._canonicalize(validated_schema)
+        )
+        self.transition_rules = self._freeze_config(
+            self._canonicalize(validated_transition_rules)
+        )
         self._transition_rules_configured = self._has_effective_transition_rules(
             self.transition_rules
         )
@@ -106,9 +113,20 @@ class AgentStateGuard:
                 message=f"Blocked: invalid or non-deterministic JSON state payload. {exc}",
             )
 
+        try:
+            normalized_state = self._canonicalize(state_data)
+        except ValueError as exc:
+            return self._blocked(
+                error_code="QWED-AGENT-STATE-102",
+                message=(
+                    "Blocked: invalid or non-deterministic JSON state payload. "
+                    f"{exc}"
+                ),
+            )
+
         validation_error = self._validate_value(
             schema=self.required_schema,
-            value=state_data,
+            value=normalized_state,
             path="$",
         )
         if validation_error is not None:
@@ -117,7 +135,6 @@ class AgentStateGuard:
                 message=f"Blocked: {validation_error}",
             )
 
-        normalized_state = self._canonicalize(state_data)
         return {
             "verified": True,
             "status": "VERIFIED",
@@ -948,12 +965,24 @@ class AgentStateGuard:
         - lists keep their order and are processed recursively.
         - non-string scalars (int, float, Decimal, bool, None) are returned
           unchanged.
+
+        Raises:
+            ValueError: if two distinct keys normalize to the same NFC key
+            (e.g. ``"\u00C9"`` and ``"E\u0301"`` in the same object). Such
+            input is ambiguous and cannot be canonicalized without silent
+            data loss, so it is rejected deterministically.
         """
         if isinstance(value, dict):
-            return {
-                cls._canonicalize(key): cls._canonicalize(value[key])
-                for key in sorted(value, key=lambda k: unicodedata.normalize("NFC", k))
-            }
+            normalized: Dict[str, Any] = {}
+            for key in sorted(value, key=lambda k: unicodedata.normalize("NFC", k)):
+                normalized_key = cls._canonicalize(key)
+                if normalized_key in normalized:
+                    raise ValueError(
+                        f"Duplicate object key after Unicode NFC normalization: "
+                        f"{normalized_key!r}."
+                    )
+                normalized[normalized_key] = cls._canonicalize(value[key])
+            return normalized
         if isinstance(value, list):
             return [cls._canonicalize(item) for item in value]
         if isinstance(value, str):

--- a/src/qwed_new/guards/agent_state_guard.py
+++ b/src/qwed_new/guards/agent_state_guard.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import unicodedata
 from decimal import Decimal
 from pathlib import Path
 from types import MappingProxyType
@@ -31,6 +32,15 @@ class AgentStateGuard:
 
     Phase 1 validates structure, Phase 2 adds bounded semantic transition
     proof, and Phase 3 adds governed atomic commit.
+
+    Contract:
+    - Verification is a pure function of the payload; no side effects occur
+      before verification completes.
+    - State is canonicalized with `_canonicalize`: dict keys are sorted and
+      all string keys/values are normalized to Unicode normalization form C
+      (NFC). Logically equivalent text (e.g. precomposed ``"\u00C9"`` vs
+      decomposed ``"E\u0301"``) therefore produces identical canonical output
+      and identical verification results and proof references.
     """
 
     _VALID_SCHEMA_TYPES = frozenset(
@@ -107,14 +117,15 @@ class AgentStateGuard:
                 message=f"Blocked: {validation_error}",
             )
 
+        normalized_state = self._canonicalize(state_data)
         return {
             "verified": True,
             "status": "VERIFIED",
             "proof_ref": self._proof_ref(
-                self._serialize_json_deterministically({"normalized_state": state_data})
+                self._serialize_json_deterministically({"normalized_state": normalized_state})
             ),
             "developer_fields": {"proof_reason": "State payload matched the configured strict schema."},
-            "normalized_state": self._canonicalize(state_data),
+            "normalized_state": normalized_state,
         }
 
     def verify_state_transition(
@@ -925,13 +936,28 @@ class AgentStateGuard:
 
     @classmethod
     def _canonicalize(cls, value: Any) -> Any:
+        """Recursively normalize a parsed JSON value into canonical form.
+
+        Normalization policy:
+        - dict keys are sorted by their NFC-normalized form (Unicode
+          normalization form C) so precomposed and decomposed equivalents
+          sort identically.
+        - string keys and string values are normalized to NFC, so logically
+          equivalent text (e.g. ``"\u00C9"`` vs ``"E\u0301"``) canonicalizes
+          to the same output and produces identical verification results.
+        - lists keep their order and are processed recursively.
+        - non-string scalars (int, float, Decimal, bool, None) are returned
+          unchanged.
+        """
         if isinstance(value, dict):
             return {
-                key: cls._canonicalize(value[key])
-                for key in sorted(value)
+                cls._canonicalize(key): cls._canonicalize(value[key])
+                for key in sorted(value, key=lambda k: unicodedata.normalize("NFC", k))
             }
         if isinstance(value, list):
             return [cls._canonicalize(item) for item in value]
+        if isinstance(value, str):
+            return unicodedata.normalize("NFC", value)
         return value
 
 

--- a/tests/test_agent_state_guard.py
+++ b/tests/test_agent_state_guard.py
@@ -1230,8 +1230,6 @@ def test_rejects_excessive_validation_depth():
 
 
 def test_canonicalize_normalizes_unicode_values_to_nfc():
-    guard = _build_guard()
-
     precomposed = AgentStateGuard._canonicalize({"label": "\u00C9"})
     decomposed = AgentStateGuard._canonicalize({"label": "E\u0301"})
 
@@ -1240,8 +1238,6 @@ def test_canonicalize_normalizes_unicode_values_to_nfc():
 
 
 def test_canonicalize_normalizes_unicode_keys_to_nfc():
-    guard = _build_guard()
-
     precomposed = AgentStateGuard._canonicalize({"\u00C9": "value"})
     decomposed = AgentStateGuard._canonicalize({"E\u0301": "value"})
 
@@ -1305,3 +1301,78 @@ def test_canonicalize_leaves_non_string_scalars_unchanged():
     assert AgentStateGuard._canonicalize(True) is True
     assert AgentStateGuard._canonicalize(3) == 3
     assert AgentStateGuard._canonicalize(Decimal("7.5")) == Decimal("7.5")
+
+
+def test_canonicalize_rejects_nfc_key_collision():
+    with pytest.raises(ValueError, match="Duplicate object key"):
+        AgentStateGuard._canonicalize({"\u00C9": 1, "E\u0301": 2})
+
+
+def test_verify_state_payload_blocks_nfc_key_collision():
+    guard = AgentStateGuard(
+        {
+            "type": "object",
+            "properties": {"agent_id": {"type": "string"}},
+            "required": ["agent_id"],
+            "additionalProperties": False,
+        }
+    )
+
+    result = guard.verify_state_payload('{"agent_id": "a1", "\\u00C9": 1, "E\\u0301": 2}')
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-102"
+    assert "Duplicate object key" in result["message"]
+
+
+def test_verify_state_payload_blocks_nfc_key_collision_reversed_order():
+    guard = AgentStateGuard(
+        {
+            "type": "object",
+            "properties": {"agent_id": {"type": "string"}},
+            "required": ["agent_id"],
+            "additionalProperties": False,
+        }
+    )
+
+    result = guard.verify_state_payload('{"E\\u0301": 2, "\\u00C9": 1, "agent_id": "a1"}')
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-102"
+    assert "Duplicate object key" in result["message"]
+
+
+def test_verify_state_payload_unicode_required_key_equivalence():
+    guard = AgentStateGuard(
+        {
+            "type": "object",
+            "properties": {"\u00C9tat": {"type": "string"}},
+            "required": ["\u00C9tat"],
+            "additionalProperties": False,
+        }
+    )
+
+    precomposed = guard.verify_state_payload('{"\\u00C9tat": "ok"}')
+    decomposed = guard.verify_state_payload('{"E\\u0301tat": "ok"}')
+
+    assert precomposed["verified"] is True
+    assert decomposed["verified"] is True
+    assert precomposed["normalized_state"] == decomposed["normalized_state"]
+    assert precomposed["proof_ref"] == decomposed["proof_ref"]
+
+
+def test_verify_state_payload_rejects_unicode_mismatch_when_required():
+    guard = AgentStateGuard(
+        {
+            "type": "object",
+            "properties": {"\u00C9tat": {"type": "string"}},
+            "required": ["\u00C9tat"],
+            "additionalProperties": False,
+        }
+    )
+
+    result = guard.verify_state_payload('{"wrong_key": "ok"}')
+
+    assert result["verified"] is False
+    assert result["error_code"] == "QWED-AGENT-STATE-103"
+    assert "missing required keys" in result["message"]

--- a/tests/test_agent_state_guard.py
+++ b/tests/test_agent_state_guard.py
@@ -1227,3 +1227,81 @@ def test_rejects_excessive_validation_depth():
     assert error.endswith(
         f"exceeds maximum validation depth ({AgentStateGuard.MAX_VALIDATION_DEPTH})."
     )
+
+
+def test_canonicalize_normalizes_unicode_values_to_nfc():
+    guard = _build_guard()
+
+    precomposed = AgentStateGuard._canonicalize({"label": "\u00C9"})
+    decomposed = AgentStateGuard._canonicalize({"label": "E\u0301"})
+
+    assert precomposed == {"label": "\u00C9"}
+    assert precomposed == decomposed
+
+
+def test_canonicalize_normalizes_unicode_keys_to_nfc():
+    guard = _build_guard()
+
+    precomposed = AgentStateGuard._canonicalize({"\u00C9": "value"})
+    decomposed = AgentStateGuard._canonicalize({"E\u0301": "value"})
+
+    assert precomposed == decomposed
+    assert list(precomposed.keys()) == ["\u00C9"]
+
+
+def test_canonicalize_normalizes_nested_unicode_structures():
+    precomposed = AgentStateGuard._canonicalize(
+        {
+            "items": [
+                {"name": "caf\u00E9"},
+                {"name": "cafe\u0301"},
+            ],
+            "\u00C9tat": {"\u00E9lan": "r\u00E9sum\u00E9"},
+        }
+    )
+    decomposed = AgentStateGuard._canonicalize(
+        {
+            "items": [
+                {"name": "cafe\u0301"},
+                {"name": "caf\u00E9"},
+            ],
+            "E\u0301tat": {"e\u0301lan": "re\u0301sume\u0301"},
+        }
+    )
+
+    assert precomposed == decomposed
+    assert precomposed == {
+        "\u00C9tat": {"\u00E9lan": "r\u00E9sum\u00E9"},
+        "items": [
+            {"name": "caf\u00E9"},
+            {"name": "caf\u00E9"},
+        ],
+    }
+
+
+def test_verify_state_payload_unicode_equivalence_consistent():
+    guard = AgentStateGuard(
+        {
+            "type": "object",
+            "properties": {
+                "agent_id": {"type": "string"},
+                "label": {"type": "string"},
+            },
+            "required": ["agent_id", "label"],
+            "additionalProperties": False,
+        }
+    )
+
+    precomposed = guard.verify_state_payload('{"agent_id": "a1", "label": "\\u00C9"}')
+    decomposed = guard.verify_state_payload('{"agent_id": "a1", "label": "E\\u0301"}')
+
+    assert precomposed["verified"] is True
+    assert precomposed["normalized_state"] == decomposed["normalized_state"]
+    assert precomposed["proof_ref"] == decomposed["proof_ref"]
+
+
+def test_canonicalize_leaves_non_string_scalars_unchanged():
+    assert AgentStateGuard._canonicalize(None) is None
+    assert AgentStateGuard._canonicalize(True) is True
+    assert AgentStateGuard._canonicalize(3) == 3
+    assert AgentStateGuard._canonicalize(Decimal("7.5")) == Decimal("7.5")

--- a/tests/test_agent_state_guard.py
+++ b/tests/test_agent_state_guard.py
@@ -1245,6 +1245,21 @@ def test_canonicalize_normalizes_unicode_keys_to_nfc():
     assert list(precomposed.keys()) == ["\u00C9"]
 
 
+def test_constructor_rejects_schema_with_nfc_equivalent_property_names():
+    with pytest.raises(ValueError, match="Invalid schema"):
+        AgentStateGuard(
+            {
+                "type": "object",
+                "properties": {
+                    "\u00C9tat": {"type": "string"},
+                    "E\u0301tat": {"type": "string"},
+                },
+                "required": ["\u00C9tat"],
+                "additionalProperties": False,
+            }
+        )
+
+
 def test_canonicalize_normalizes_nested_unicode_structures():
     precomposed = AgentStateGuard._canonicalize(
         {


### PR DESCRIPTION
## Fixes #272

`AgentStateGuard._canonicalize` now normalizes all string keys and values to Unicode normalization form C (NFC), so logically equivalent text (e.g. precomposed `"\u00C9"` vs decomposed `"E\u0301"`) produces identical canonical output and identical verification results.

## Changes
- Import `unicodedata`
- `_canonicalize`: sort dict keys by NFC-normalized form; normalize string keys and values to NFC
- Bind `verify_state_payload` proof_ref to the canonicalized state (consistent with the commit path, which already bound `normalized_state`)
- Document the normalization policy in the guard's contract

## Tests
5 new regression tests:
- values normalized to NFC
- keys normalized to NFC
- nested structures normalize identically regardless of precomposed/decomposed form
- end-to-end `verify_state_payload` produces identical `normalized_state` and `proof_ref` for equivalent payloads
- non-string scalars unchanged

Full suite: 1644 passed, 102 skipped.


___

## **CodeAnt-AI Description**
Make equivalent Unicode text produce consistent agent state verification results

### What Changed
- Agent state keys and values are now normalized to Unicode NFC, including nested objects and lists
- Payloads using precomposed or decomposed forms of the same text now produce identical normalized state and proof references
- Non-string values remain unchanged
- Added regression coverage for Unicode keys, values, nested structures, and verification results

### Impact
`✅ Consistent verification for equivalent Unicode text`
`✅ Matching proof references across Unicode representations`
`✅ Stable handling of nested agent state`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
