### PR TITLE
Fix CI: mock network in secret redaction tests

### DIFF
--- a/tests/test_secret_redaction.py
+++ b/tests/test_secret_redaction.py
@@ -95,20 +95,41 @@ class TestKeyFormatValidation:
 class TestSecretRedactionInExceptions:
     """Ensure exceptions from providers never contain API keys."""
 
-    def test_openai_direct_exception_no_key(self):
+    def test_openai_direct_exception_no_key(self, monkeypatch):
         """OpenAI provider ValueError must not contain the API key."""
         from qwed_new.providers.openai_direct import OpenAIDirectProvider
 
         fake_key = "sk-proj-" + "TOPSECRET" * 4
+        provider = OpenAIDirectProvider(api_key=fake_key, model="gpt-fake")
+
+        class _FakeCompletions:
+            def create(self, *args, **kwargs):
+                raise Exception("simulated upstream API failure")
+
+        class _FakeChat:
+            completions = _FakeCompletions()
+
+        # Replace the real SDK client so no network call is made; the test
+        # only verifies key redaction in the resulting exception.
+        monkeypatch.setattr(provider.client, "chat", _FakeChat())
+
         with pytest.raises(Exception) as exc_info:
-            provider = OpenAIDirectProvider(api_key=fake_key, model="gpt-fake")
             provider.translate("test query")
 
         error_msg = str(exc_info.value)
         assert "TOPSECRET" not in error_msg, f"API key leaked in exception: {error_msg}"
 
-    def test_connection_test_exception_no_key(self):
+    def test_connection_test_exception_no_key(self, monkeypatch):
         """Connection test errors must not contain API key."""
+        import httpx
+
+        def _raise_connect_error(*args, **kwargs):
+            raise httpx.ConnectError("simulated no network")
+
+        # key_validator imports httpx inside the handler; patch the shared
+        # module so the connection test fails deterministically without I/O.
+        monkeypatch.setattr(httpx, "get", _raise_connect_error)
+
         fake_key = "sk-proj-" + "SUPERSECRET" * 3
         success, msg = check_connection(
             provider_slug="openai",

--- a/tests/test_secret_redaction.py
+++ b/tests/test_secret_redaction.py
@@ -119,7 +119,14 @@ class TestSecretRedactionInExceptions:
             provider.translate("test query")
 
         error_msg = str(exc_info.value)
+        # The upstream exception carried the credential; the surfaced message
+        # must be the documented contract string with NO key and NO chained
+        # exception (from None), so a regression that leaks the raw upstream
+        # error into the surfaced message fails this test.
+        assert error_msg == "OpenAI translation failed."
         assert "TOPSECRET" not in error_msg, f"API key leaked in exception: {error_msg}"
+        assert exc_info.value.__cause__ is None
+        assert exc_info.value.__suppress_context__ is True
 
     def test_connection_test_exception_no_key(self, monkeypatch):
         """Connection test errors must not contain API key."""
@@ -142,7 +149,10 @@ class TestSecretRedactionInExceptions:
             base_url=None,
         )
         assert not success, f"injected connection failure must not report success: {msg}"
-        # Whether success or failure, message must not contain full key
+        # The upstream ConnectError carried the credential; the surfaced
+        # message must be the fixed contract string with NO key, so a
+        # regression that leaks the raw httpx error fails this test.
+        assert msg == "Cannot connect to endpoint. Check URL and network."
         assert "SUPERSECRET" not in msg
 
 

--- a/tests/test_secret_redaction.py
+++ b/tests/test_secret_redaction.py
@@ -104,7 +104,9 @@ class TestSecretRedactionInExceptions:
 
         class _FakeCompletions:
             def create(self, *args, **kwargs):
-                raise Exception("simulated upstream API failure")
+                # Carry the credential so the redaction assertion is real:
+                # a regression that leaks the key here must fail the test.
+                raise Exception(f"simulated upstream API failure: {fake_key}")
 
         class _FakeChat:
             completions = _FakeCompletions()
@@ -113,7 +115,7 @@ class TestSecretRedactionInExceptions:
         # only verifies key redaction in the resulting exception.
         monkeypatch.setattr(provider.client, "chat", _FakeChat())
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             provider.translate("test query")
 
         error_msg = str(exc_info.value)
@@ -123,19 +125,23 @@ class TestSecretRedactionInExceptions:
         """Connection test errors must not contain API key."""
         import httpx
 
+        fake_key = "sk-proj-" + "SUPERSECRET" * 3
+
         def _raise_connect_error(*args, **kwargs):
-            raise httpx.ConnectError("simulated no network")
+            # Carry the credential so the redaction assertion is real:
+            # a regression that leaks the key here must fail the test.
+            raise httpx.ConnectError(f"simulated no network: {fake_key}")
 
         # key_validator imports httpx inside the handler; patch the shared
         # module so the connection test fails deterministically without I/O.
         monkeypatch.setattr(httpx, "get", _raise_connect_error)
 
-        fake_key = "sk-proj-" + "SUPERSECRET" * 3
         success, msg = check_connection(
             provider_slug="openai",
             api_key=fake_key,
             base_url=None,
         )
+        assert not success, f"injected connection failure must not report success: {msg}"
         # Whether success or failure, message must not contain full key
         assert "SUPERSECRET" not in msg
 


### PR DESCRIPTION
## Fix failing Buildkite CI on network-dependent redaction tests

Build #684 failed on `tests/test_secret_redaction.py::TestSecretRedactionInExceptions::test_openai_direct_exception_no_key`:

```
sock.connect(sa)
E  Failed: Timeout (>30.0s) from pytest-timeout.
```

## Root cause
`test_openai_direct_exception_no_key` constructs `OpenAIDirectProvider` and calls `translate()`, which performs a **real network call to the OpenAI API** via the SDK. In sandboxed Buildkite CI, outbound sockets hang, so the connect exceeds the 30s `pytest-timeout` and the build fails. The test's intent is key **redaction**, not connectivity.

## Changes
- `test_openai_direct_exception_no_key`: replace the SDK client's `chat` object with a stub whose `completions.create` raises immediately — no network I/O, same redaction assertion.
- `test_connection_test_exception_no_key`: patch `httpx.get` (in the `key_validator` handler) to raise `ConnectError` deterministically — no I/O, same redaction assertion.

Both tests now finish in ~1.5s under the CI flags (`--timeout=30`) instead of hanging.

## Verification
- `pytest tests/test_secret_redaction.py` — 19 passed
- `pytest tests/test_secret_redaction.py::TestSecretRedactionInExceptions --timeout=30 -p no:cacheprovider` — 2 passed in 1.46s


___

## **CodeAnt-AI Description**
Make secret-redaction tests reliable in network-restricted CI

### What Changed
- Secret-redaction tests now simulate provider and connection failures instead of making real network requests
- Tests continue verifying that API keys are excluded from exception and connection-error messages
- Network-dependent tests finish without waiting for connection timeouts

### Impact
`✅ Fewer CI timeouts`
`✅ Reliable redaction test results in sandboxed environments`
`✅ API keys remain hidden in failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded exception-handling coverage to verify that API keys remain redacted in error messages.
  * Added deterministic simulations for upstream service and connection failures, eliminating reliance on live network requests.
  * Strengthened validation of failure scenarios to help protect sensitive credentials from accidental exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->