### PR TITLE
Fix 273: close TOCTOU in enforce_trust_decision

### DIFF
--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -736,7 +736,25 @@ def enforce_trust_decision(
     # snapshot below is read during validation AND returned, so a concurrent
     # mutation of the caller's object can neither skew the decision nor leak
     # into the returned result.
-    result = replace(result, developer_fields=deepcopy(result.developer_fields))
+    try:
+        result = replace(result, developer_fields=deepcopy(result.developer_fields))
+    except Exception as exc:
+        # developer_fields is Dict[str, Any] — a value that rejects deep-copying
+        # (or a concurrent mutation mid-snapshot) must fail closed, not escape
+        # as an exception. Log only the exception type, never args/message, so
+        # no caller data leaks into the audit trail.
+        logger.warning(
+            "trust_gate.blocked reason=diagnostic_snapshot_failed policy=%s error_type=%s",
+            policy,
+            type(exc).__name__,
+        )
+        return DiagnosticResult.blocked(
+            agent_message="Verification blocked — diagnostic snapshot failed",
+            developer_fields={
+                "constraint_id": "trust_gate.diagnostic_snapshot_failed",
+                "policy": policy,
+            },
+        )
 
     if result.is_fail_closed:
         return result

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -42,7 +42,8 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from dataclasses import dataclass, field
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -726,6 +727,16 @@ def enforce_trust_decision(
         fields: constraint_id, reason, policy, and error where applicable.
     """
     policy = "mandatory" if require_attestation else "optional"
+
+    # Issue #273 — TOCTOU: detach the caller's mutable developer_fields before
+    # any validation reads the result. DiagnosticResult is frozen=True, but
+    # developer_fields is a deeply mutable Dict[str, Any]; returning the
+    # caller's original reference would let out-of-band mutation after
+    # enforcement diverge the returned state from the validated state. The
+    # snapshot below is read during validation AND returned, so a concurrent
+    # mutation of the caller's object can neither skew the decision nor leak
+    # into the returned result.
+    result = replace(result, developer_fields=deepcopy(result.developer_fields))
 
     if result.is_fail_closed:
         return result

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
@@ -691,6 +690,43 @@ def _validate_attestation_claims(
     return None
 
 
+def _snapshot_developer_fields(fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Rebuild developer_fields as a fully detached, trusted snapshot.
+
+    deepcopy() is NOT sufficient here: a nested object may implement
+    __deepcopy__ to return itself, preserving an alias to caller data that
+    remains mutable after enforcement (TOCTOU). Instead, containers are
+    rebuilt from scratch and only immutable scalars, AdvisoryCheck, and
+    JSON-safe containers (dict / list / tuple) are admitted. Any other value
+    type is rejected so the caller's objects can never leak into the enforced
+    result.
+
+    Raises:
+        ValueError: if a value type is not admitted (fail closed by caller).
+    """
+    if isinstance(fields, dict):
+        return {
+            str(key): _snapshot_developer_fields(value)
+            for key, value in fields.items()
+        }
+    if isinstance(fields, list):
+        return [_snapshot_developer_fields(item) for item in fields]
+    if isinstance(fields, tuple):
+        return tuple(_snapshot_developer_fields(item) for item in fields)
+    if isinstance(fields, AdvisoryCheck):
+        return AdvisoryCheck(
+            name=fields.name,
+            advisory_only=fields.advisory_only,
+            constraint_id=fields.constraint_id,
+            details=_snapshot_developer_fields(fields.details),
+        )
+    if fields is None or isinstance(fields, (str, int, float, bool)):
+        return fields
+    raise ValueError(
+        f"developer_fields contains unsupported value type: {type(fields).__name__}"
+    )
+
+
 def enforce_trust_decision(
     result: DiagnosticResult,
     *,
@@ -735,11 +771,16 @@ def enforce_trust_decision(
     # enforcement diverge the returned state from the validated state. The
     # snapshot below is read during validation AND returned, so a concurrent
     # mutation of the caller's object can neither skew the decision nor leak
-    # into the returned result.
+    # into the returned result. The snapshot rebuilds containers recursively
+    # (never deepcopy) so a nested object whose __deepcopy__ returns itself
+    # cannot smuggle a mutable alias into the enforced result.
     try:
-        result = replace(result, developer_fields=deepcopy(result.developer_fields))
+        result = replace(
+            result,
+            developer_fields=_snapshot_developer_fields(result.developer_fields),
+        )
     except Exception as exc:
-        # developer_fields is Dict[str, Any] — a value that rejects deep-copying
+        # developer_fields is Dict[str, Any] — a value that rejects snapshoting
         # (or a concurrent mutation mid-snapshot) must fail closed, not escape
         # as an exception. Log only the exception type, never args/message, so
         # no caller data leaks into the audit trail.

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -895,6 +895,34 @@ class TestEnforceTrustDecision(unittest.TestCase):
         self.assertEqual(r.developer_fields["nested"]["evidence"]["result"], 42)
         self.assertNotIn("tampered", r.developer_fields)
 
+    def test_uncopyable_developer_field_fails_closed(self):
+        """A developer_fields value that raises during deepcopy must BLOCK, not raise."""
+        class Uncopyable:
+            def __deepcopy__(self, memo):
+                raise RuntimeError("cannot copy this object")
+
+        with self.assertLogs("src.qwed_new.core.diagnostics", level="WARNING") as logs:
+            r = enforce_trust_decision(
+                DiagnosticResult.verified(
+                    agent_message="Math check passed",
+                    developer_fields={"constraint_id": "math.identity", "bad": Uncopyable()},
+                    evidence={"result": 42},
+                )
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(
+            r.developer_fields.get("constraint_id"),
+            "trust_gate.diagnostic_snapshot_failed",
+        )
+        self.assertIn("diagnostic snapshot failed", r.agent_message.lower())
+        # The audit log must record a generic reason — never the raw exception
+        # message or args (may embed caller data).
+        log_text = "\n".join(logs.output)
+        self.assertIn("reason=diagnostic_snapshot_failed", log_text)
+        self.assertIn("error_type=RuntimeError", log_text)
+        self.assertNotIn("cannot copy this object", log_text)
+
     # --- Edge cases ---
 
     def test_verified_verification_error_returns_blocked(self):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -855,6 +855,46 @@ class TestEnforceTrustDecision(unittest.TestCase):
         self.assertTrue(r.is_fail_closed)
         self.assertEqual(r.constraint_id, "math.inconclusive")
 
+    # --- Issue #273 — TOCTOU: returned result must be detached ---
+
+    def test_returned_result_does_not_share_developer_fields_with_input(self):
+        """Enforced result must not alias the caller's developer_fields dict.
+
+        frozen=True only blocks attribute reassignment; mutating
+        developer_fields["key"] = value must not leak into the returned result
+        after enforcement (TOCTOU window).
+        """
+        r = enforce_trust_decision(self.unverifiable)
+        self.assertIsNot(r.developer_fields, self.unverifiable.developer_fields)
+        self.unverifiable.developer_fields["injected"] = "post-enforcement mutation"
+        self.assertNotIn("injected", r.developer_fields)
+
+    def test_valid_token_passes_return_detached_developer_fields(self):
+        """The pass-through result must deep-copy nested mutable fields."""
+        nested = {"evidence": {"result": 42}}
+        verified = DiagnosticResult.verified(
+            agent_message="Math check passed",
+            developer_fields={"constraint_id": "math.identity", "nested": nested},
+            evidence={"result": 42},
+        )
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (True, self._verified_claims(), None)
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                verified,
+                attestation_token="QWED_TEST_VALID_TOKEN",
+            )
+
+        self.assertTrue(r.is_verified)
+        self.assertIsNot(r.developer_fields, verified.developer_fields)
+        # Deep mutation of the input's nested dict must not leak into the result
+        verified.developer_fields["nested"]["evidence"]["result"] = 999
+        verified.developer_fields["tampered"] = True
+        self.assertEqual(r.developer_fields["nested"]["evidence"]["result"], 42)
+        self.assertNotIn("tampered", r.developer_fields)
+
     # --- Edge cases ---
 
     def test_verified_verification_error_returns_blocked(self):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -895,17 +895,17 @@ class TestEnforceTrustDecision(unittest.TestCase):
         self.assertEqual(r.developer_fields["nested"]["evidence"]["result"], 42)
         self.assertNotIn("tampered", r.developer_fields)
 
-    def test_uncopyable_developer_field_fails_closed(self):
-        """A developer_fields value that raises during deepcopy must BLOCK, not raise."""
-        class Uncopyable:
+    def test_unsupported_developer_field_type_fails_closed(self):
+        """A developer_fields value outside the allowed schema must BLOCK, not raise."""
+        class Unsupported:
             def __deepcopy__(self, memo):
-                raise RuntimeError("cannot copy this object")
+                return self
 
         with self.assertLogs("src.qwed_new.core.diagnostics", level="WARNING") as logs:
             r = enforce_trust_decision(
                 DiagnosticResult.verified(
                     agent_message="Math check passed",
-                    developer_fields={"constraint_id": "math.identity", "bad": Uncopyable()},
+                    developer_fields={"constraint_id": "math.identity", "bad": Unsupported()},
                     evidence={"result": 42},
                 )
             )
@@ -920,8 +920,52 @@ class TestEnforceTrustDecision(unittest.TestCase):
         # message or args (may embed caller data).
         log_text = "\n".join(logs.output)
         self.assertIn("reason=diagnostic_snapshot_failed", log_text)
-        self.assertIn("error_type=RuntimeError", log_text)
-        self.assertNotIn("cannot copy this object", log_text)
+        self.assertIn("error_type=ValueError", log_text)
+        self.assertNotIn("Unsupported", log_text)
+
+    def test_nested_deepcopy_self_aliasing_cannot_leak_into_result(self):
+        """An object whose __deepcopy__ returns itself must NOT be aliased.
+
+        deepcopy() preserves such a nested reference; the snapshot rebuilds
+        containers from scratch, so the enforced result can never share the
+        caller's mutable object.
+        """
+        class SelfAliasing:
+            def __init__(self):
+                self.value = "original"
+
+            def __deepcopy__(self, memo):
+                return self
+
+        nested = {"evidence": {"result": SelfAliasing()}}
+        verified = DiagnosticResult.verified(
+            agent_message="Math check passed",
+            developer_fields={"constraint_id": "math.identity", "nested": nested},
+            evidence={"result": 42},
+        )
+        with patch("src.qwed_new.core.attestation.get_attestation_service") as mock_get:
+            mock_svc = MagicMock()
+            mock_svc.verify_attestation.return_value = (True, self._verified_claims(), None)
+            mock_get.return_value = mock_svc
+
+            r = enforce_trust_decision(
+                verified,
+                attestation_token="QWED_TEST_VALID_TOKEN",
+            )
+
+        self.assertTrue(r.is_fail_closed)
+        self.assertEqual(
+            r.developer_fields.get("constraint_id"),
+            "trust_gate.diagnostic_snapshot_failed",
+        )
+
+    def test_mutating_returned_result_does_not_affect_source(self):
+        """Mutating the ENFORCED result's developer_fields must not touch the source."""
+        r = enforce_trust_decision(self.unverifiable)
+        r.developer_fields["injected"] = "post-enforcement mutation"
+        self.assertNotIn("injected", self.unverifiable.developer_fields)
+        r.developer_fields["nested_new"] = {"a": 1}
+        self.assertNotIn("nested_new", self.unverifiable.developer_fields)
 
     # --- Edge cases ---
 

--- a/tests/test_pr115_regressions.py
+++ b/tests/test_pr115_regressions.py
@@ -11,6 +11,7 @@ from qwed_new.api.main import (
     _run_agent_security_checks,
 )
 from qwed_new.core.consensus_verifier import ConsensusVerifier, VerificationMode
+from qwed_new.core.diagnostics import DiagnosticResult
 from qwed_new.core.logic_verifier import LogicVerifier
 
 
@@ -58,6 +59,15 @@ def test_consensus_endpoint_checks_rate_limit(client):
         agreement_status="unanimous",
         verification_chain=[],
         total_latency_ms=5.0,
+    )
+    fake_result.to_diagnostic_result.return_value = DiagnosticResult.verified(
+        agent_message="Consensus verification: unanimous",
+        developer_fields={
+            "agreement_status": "unanimous",
+            "confidence": 0.99,
+            "engines_used": 1,
+        },
+        evidence={"result": 4},
     )
 
     with (


### PR DESCRIPTION
## **User description**
Closes #273

## Problem

`enforce_trust_decision` validated the attestation token against the caller's `DiagnosticResult`, then returned the **original reference**. `DiagnosticResult` is `@dataclass(frozen=True)`, but `developer_fields: Dict[str, Any]` is deeply mutable — `frozen=True` only blocks attribute reassignment, not `developer_fields["key"] = value`. Any external code holding the same reference could mutate `developer_fields` after enforcement, creating a TOCTOU window where the validated state diverges from the returned state.

## Fix

Snapshot the result up front:

```python
result = replace(result, developer_fields=deepcopy(result.developer_fields))
```

Because the snapshot is taken before any validation reads and is the object returned, a concurrent mutation of the caller's original can neither skew the decision nor leak into the returned result. This closes the window at every return path (fail-closed pass-through, advisory pass-through, and validated pass).

## Tests

- `test_returned_result_does_not_share_developer_fields_with_input` — enforced result must not alias the input's dict.
- `test_valid_token_passes_return_detached_developer_fields` — nested mutable fields are deep-copied on the pass-through path.
- Fixed the `/verify/consensus` fixture in `test_pr115_regressions.py`, which had been passing an unconfigured `MagicMock` into the trust boundary; it now returns a real `DiagnosticResult`.

## Verification

Full local suite: 1652 passed, 102 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Diagnostic results now return isolated developer data, preventing later caller changes from altering validated results.
  - Nested data is also protected from unintended mutation.
  - Uncopyable diagnostic data now fails safely without exposing internal error details.
  - Improved handling of verified diagnostic results in consensus endpoint scenarios.

- **Tests**
  - Added coverage for detached result data, safe failure handling, and regression scenarios involving verified diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent mutable diagnostic data from changing after trust enforcement

### What Changed
- Trust enforcement now returns a fully detached diagnostic snapshot, preventing changes to the caller’s data from altering the validated result.
- Unsupported or unsafe diagnostic values now fail closed with a blocked result instead of bypassing enforcement through an exception.
- Audit logs report only the failure type, avoiding exposure of caller-provided data.
- Added regression coverage for nested mutations, unsafe values, and consensus verification behavior.

### Impact
`✅ Prevents post-enforcement diagnostic tampering`
`✅ Blocks unsafe diagnostic values`
`✅ Keeps audit logs free of caller data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
