### PR TITLE
release: v6.0.0 — Trust Boundary Completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,72 @@ All notable changes to the QWED Protocol will be documented in this file.
 
 ## [Unreleased]
 
+## [6.0.0] - 2026-08-02
+### Trust Boundary Completion (Epic #263)
+
+Completes the Trust Boundary Completion epic — all 12/12 sub-issues closed. Every verification pathway now produces `DiagnosticResult` and routes through `enforce_trust_decision`. The trust boundary is no longer advisory: the control plane requires and verifies attestation before admitting VERIFIED results, and VERIFIED is a protocol guarantee backed by deterministic `proof_ref`, never by execution, agreement, confidence, or provenance.
+
+> **⚠️ Breaking change:** `/verify/*` API responses now use the unified `DiagnosticResult` schema (status / `agent_message` / `developer_fields` / `proof_ref`). Consumers of the previous ad-hoc dict responses must migrate.
+
+#### Architecture: Observation vs Admission (#264, #265)
+- **All `/verify/*` endpoints return `DiagnosticResult`** (PR #276)
+- **Control plane enforces mandatory attestation** — `require_attestation=True`, attestation issued + verified, enforced status drives HTTP response status (PR #278)
+- **Batch math** routes through `DiagnosticResult` + attestation + `enforce_trust_decision` (PR #282)
+- **Attestation scope alignment** — attest translated expression, not natural-language query, so `query_hash` binds to what was actually verified (#279, PR #285)
+
+#### VERIFIED is a protocol guarantee (#266, #267, #269, #270)
+- **ConsensusResult** uses `DiagnosticStatus` enum with `proof_ref` + `verified_evidence` (PR #280)
+- **FactVerifier** heuristic SUPPORTED verdict → UNVERIFIABLE with `advisory_checks` (PR #283)
+- **Consensus code execution** advisory-only, VERIFIED → UNVERIFIABLE (PR #281)
+- **Consensus stats computation** advisory-only, never VERIFIED (PR #277)
+- **LogicVerifier** migrated to `DiagnosticResult` (PR #262)
+- **AgentStateGuard** `proof_ref` = real sha256 of committed bytes, not a static sentence (#268, PR #284)
+
+#### Engineering & Security Hardening
+- **TOCTOU closure** in `enforce_trust_decision` — `developer_fields` snapshotted via recursive rebuild (no `deepcopy` alias window), fail-closed snapshot (#273, PR #290)
+- **Attestation signature verified before claim decode** — silent generic error for all failure modes (#275, PR #287)
+- **Tenant-isolated verification cache** — `VerificationCache` keys namespaced by normalized `tenant_id` (#274, PR #286)
+- **Unicode normalization** in AgentStateGuard canonicalization — NFC collisions rejected (#272, PR #288)
+- **Mandatory proof artifact** for VERIFIED attestations (issuance + consumption, PR #248)
+- **Credential / JWT / dockerignore security alerts** resolved (PR #249)
+- **Math whitelist injection bypass** removed (PR #251)
+- **Engine classification docs** — Proof / Policy Enforcement / Advisory (PR #247)
+
+#### Rules & Protocol Semantics
+- `QWED_RULES.md` codifies the trust-boundary contract: **#13 Separation of Responsibilities**, **#14 Verification Semantics**, **#15 Truth Before Policy**; rules #7/#8 updated to capture admission-boundary and deterministic-proof semantics
+
+#### Version Propagation
+- `qwed` (PyPI): `5.3.0` -> `6.0.0`
+- `qwed_sdk` (Python): `5.3.0` -> `6.0.0`
+- `@qwed-ai/sdk` (NPM): `5.3.0` -> `6.0.0`
+- `qwed` (crates.io/Rust): `5.3.0` -> `6.0.0`
+- API version marker: `5.3.0` -> `6.0.0`
+- Kubernetes deployment image: `5.3.0` -> `6.0.0`
+- Deployment docs + historical roadmap version references updated
+
+#### Included PRs
+- `#247` docs: engine classification — Proof / Policy Enforcement / Advisory
+- `#248` fix(#191): enforce mandatory proof artifact on VERIFIED attestations (issuance + consumption)
+- `#249` fix: resolve credential / JWT / dockerignore security alerts
+- `#251` fix(#227): remove math whitelist injection bypass
+- `#260` fix(#257): hybrid engine advisory-only — never VERIFIED without proof
+- `#261` fix(#259): FactVerifier advisory-only
+- `#262` feat(#252): LogicVerifier migrated to DiagnosticResult
+- `#276` fix(api): migrate all /verify/* endpoints to return DiagnosticResult (#264)
+- `#277` fix(#270): consensus stats advisory-only, never VERIFIED
+- `#278` fix(#265): control plane trust enforcement mandatory
+- `#280` fix(#266): ConsensusResult DiagnosticStatus enum + proof_ref + verified_evidence
+- `#281` fix(#269): consensus code execution advisory-only
+- `#282` fix(#271): batch math DiagnosticResult → proof_ref + attestation + enforce_trust_decision
+- `#283` fix(#267): FactVerifier SUPPORTED → UNVERIFIABLE with heuristic advisory_checks
+- `#284` fix(#268): AgentStateGuard proof_ref real sha256
+- `#285` fix(#279): attest translated expression, not natural language query
+- `#286` fix(#274): VerificationCache tenant isolation
+- `#287` fix(#275): attestation verify-before-decode + silent generic error
+- `#288` fix(#272): NFC-normalize AgentStateGuard canonicalization
+- `#289` fix: mock network in secret redaction tests (CI)
+- `#290` fix(#273): close TOCTOU in enforce_trust_decision
+
 ## [5.3.0] - 2026-07-25
 ### SymbolicVerifier: DiagnosticResult Reference Implementation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the QWED Protocol will be documented in this file.
 ## [6.0.0] - 2026-08-02
 ### Trust Boundary Completion (Epic #263)
 
-Completes the Trust Boundary Completion epic — all 12/12 sub-issues closed. Every verification pathway now produces `DiagnosticResult` and routes through `enforce_trust_decision`. The trust boundary is no longer advisory: the control plane requires and verifies attestation before admitting VERIFIED results, and VERIFIED is a protocol guarantee backed by deterministic `proof_ref`, never by execution, agreement, confidence, or provenance.
+Completes the Trust Boundary Completion epic — all 12/12 sub-issues closed. Every verification API pathway now returns `DiagnosticResult` and routes through `enforce_trust_decision`. The trust boundary is no longer advisory: the control plane requires and verifies attestation before admitting VERIFIED results, and VERIFIED is a protocol guarantee backed by a non-empty, deterministic `proof_ref`, never by execution, agreement, confidence, or provenance. Engine-level migrations to `DiagnosticResult` remain tracked under META #216.
 
 > **⚠️ Breaking change:** `/verify/*` API responses now use the unified `DiagnosticResult` schema (status / `agent_message` / `developer_fields` / `proof_ref`). Consumers of the previous ad-hoc dict responses must migrate.
 

--- a/QWED_RULES.md
+++ b/QWED_RULES.md
@@ -102,17 +102,21 @@ boundary.
 ### 14. Verification Semantics
 
 VERIFIED is a protocol guarantee, not a confidence level. VERIFIED may only be
-emitted when the required deterministic evidence exists and protocol
-invariants are satisfied. Heuristic, probabilistic, or advisory analysis must
-never be promoted to VERIFIED — it must be reported as UNVERIFIABLE with
-structured advisory evidence.
+emitted when a non-empty `proof_ref` exists and is bound to the deterministic
+evidence that produced the verdict. Heuristic, probabilistic, or advisory
+analysis must never be promoted to VERIFIED — it must be reported as
+UNVERIFIABLE with structured advisory evidence.
 
 ### 15. Truth Before Policy
 
 Verification reports truth. Policy decides action. Evidence must never be
-modified to satisfy policy. Enforcement must consume the verified result as
-produced; it must not reinterpret, downgrade, or upgrade the verdict to fit a
-policy outcome.
+modified to satisfy policy. Admission is a separate decision produced by
+`enforce_trust_decision`, distinct from the `DiagnosticResult` the engine
+emitted: a policy denial is represented by that admission decision, and the
+original `DiagnosticResult` and its evidence remain unchanged. Enforcement must
+consume the verified result as produced; it must not reinterpret, downgrade, or
+upgrade the verdict to fit a policy outcome. The control plane consumes the
+admission decision and the preserved diagnostic separately.
 
 ## Forbidden Suggestions
 

--- a/QWED_RULES.md
+++ b/QWED_RULES.md
@@ -52,7 +52,10 @@ execution in a degraded mode. Silent degradation is a vulnerability in waiting.
 
 Security and verification boundaries are not optional features. They must be
 on by default, server-side, and not configurable or bypassable by user input.
-The user cannot opt out of enforcement.
+The user cannot opt out of enforcement. Admission boundaries must be
+server-side and mandatory. Observation surfaces (e.g., read-only verification
+endpoints) must never silently become admission authorities — the role of each
+surface is an explicit architectural decision.
 
 ### 8. Verify Claims, Not Sources
 
@@ -60,6 +63,8 @@ Claims must be verified by deterministic computation (SymPy, Z3, pgTAP,
 SQLGlot), not by the source of the claim. LLM outputs, confidence scores,
 reasoning chains, and metadata are inputs to the verification pipeline—they
 are not proof. Trust comes from deterministic verification, not from origin.
+Proof is established by deterministic evidence, not by successful execution,
+agreement, confidence, or provenance.
 
 ### 9. Ecosystem Neutrality
 
@@ -85,6 +90,29 @@ Introducing a new boundary or security layer must not reduce the severity of
 existing, unfixed security issues. All existing vulnerabilities retain their
 priority until resolved. New enforcement layers are additive, not
 substitutional.
+
+### 13. Separation of Responsibilities
+
+Verification and enforcement are distinct architectural responsibilities.
+Verification produces deterministic evidence (`DiagnosticResult`). Enforcement
+consumes verified evidence to make admission decisions. Components must not
+combine these responsibilities unless explicitly designed as an admission
+boundary.
+
+### 14. Verification Semantics
+
+VERIFIED is a protocol guarantee, not a confidence level. VERIFIED may only be
+emitted when the required deterministic evidence exists and protocol
+invariants are satisfied. Heuristic, probabilistic, or advisory analysis must
+never be promoted to VERIFIED — it must be reported as UNVERIFIABLE with
+structured advisory evidence.
+
+### 15. Truth Before Policy
+
+Verification reports truth. Policy decides action. Evidence must never be
+modified to satisfy policy. Enforcement must consume the verified result as
+produced; it must not reinterpret, downgrade, or upgrade the verdict to fit a
+policy outcome.
 
 ## Forbidden Suggestions
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@
 
 ## Release Update: v6.0.0 — Trust Boundary Completion
 
-`v6.0.0` completes the **Trust Boundary Completion epic** — every verification pathway now routes through `DiagnosticResult` and `enforce_trust_decision` (12/12 sub-issues, #263).
+`v6.0.0` completes the **Trust Boundary Completion epic** — every verification API pathway now returns `DiagnosticResult` and routes through `enforce_trust_decision` (12/12 sub-issues, #263).
 
 - **All `/verify/*` endpoints return `DiagnosticResult`** — unified 3-layer response contract (status / `agent_message` / `developer_fields` / `proof_ref`) across every verification surface
 - **Mandatory attestation in the control plane** — `require_attestation=True`, attestations issued and verified at the admission boundary; enforcement result drives the response status
-- **VERIFIED is a protocol guarantee** — no engine emits VERIFIED without a deterministic `proof_ref`; heuristic/advisory analysis reports `UNVERIFIABLE` with structured `advisory_checks`
+- **VERIFIED is a protocol guarantee** — VERIFIED requires a non-empty `proof_ref` bound to the deterministic evidence; heuristic/advisory analysis reports `UNVERIFIABLE` with structured `advisory_checks`
 - **Architecture contract** — API = observation surface (honest witness), Control Plane = admission authority (judge); rules now codify this separation (#13-15)
 - **Security hardening** — TOCTOU closure in `enforce_trust_decision`, tenant-isolated verification cache, attestation signature-verified before claim decode, Unicode-normalized agent state
 
@@ -670,11 +670,11 @@ We are building the **Universal Verification Standard** for the agentic web.
 
 - **✔ DiagnosticResult model** — Unified 3-layer diagnostic contract, `proof_ref` authority bit, `AdvisoryCheck` pattern (v5.2.0)
 - **✔ SymbolicVerifier migration** — First fully `DiagnosticResult`-conformant engine; serves as reference implementation (v5.3.0)
-- **✔ Trust Boundary Completion** — All verification pathways route through `DiagnosticResult` + `enforce_trust_decision`; mandatory attestation at the admission boundary; VERIFIED requires deterministic proof_ref (v6.0.0)
+- **✔ Trust Boundary Completion** — All verification API pathways return `DiagnosticResult` + route through `enforce_trust_decision`; mandatory attestation at the admission boundary; VERIFIED requires a non-empty, evidence-bound proof_ref (v6.0.0)
 
 ### In Progress
 
-- **Remaining verification engines (#216)** — Migrating the remaining engines to the `DiagnosticResult` model
+- **Remaining verification engines (#216)** — Migrating the remaining engines to the `DiagnosticResult` model (API surfaces are conformant; engine-internal migration continues under META #216)
 
 ### Planned
 
@@ -967,14 +967,14 @@ If you use QWED in your research or project, please cite our archived paper:
   title = {QWED Protocol: Deterministic Verification for Large Language Models},
   year = {2025},
   publisher = {Zenodo},
-  version = {v6.0.0},
+  version = {v5.3.0},
   doi = {10.5281/zenodo.18111675},
   url = {https://doi.org/10.5281/zenodo.18111675}
 }
 ```
 
 **Plain text:**
-> Dass, R. (2025). QWED Protocol: Deterministic Verification for Large Language Models (Version v6.0.0). Zenodo. https://doi.org/10.5281/zenodo.18111675
+> Dass, R. (2025). QWED Protocol: Deterministic Verification for Large Language Models (Version v5.3.0). Zenodo. https://doi.org/10.5281/zenodo.18111675
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -61,18 +61,19 @@
 
 ---
 
-## Release Update: v5.3.0 — SymbolicVerifier: DiagnosticResult Reference Implementation
+## Release Update: v6.0.0 — Trust Boundary Completion
 
-`v5.3.0` delivers the **first fully `DiagnosticResult`-conformant verification engine** — SymbolicVerifier is the reference implementation for all future engine migrations (META #216).
+`v6.0.0` completes the **Trust Boundary Completion epic** — every verification pathway now routes through `DiagnosticResult` and `enforce_trust_decision` (12/12 sub-issues, #263).
 
-- **Reference implementation complete:** All 6 public methods (`verify_code`, `verify_function_contract`, `verify_safety_properties`, `verify_bounded`, `analyze_complexity`, `get_verification_budget`) return `DiagnosticResult`
-- **`AdvisoryCheck` in production:** Non-proof-bearing analysis paths (budget advisory, complexity analysis, safety property checks) use the `advisory_checks` pattern — see `analyze_complexity`, `verify_safety_properties` in SymbolicVerifier for reference
-- **`verification_mode` field:** Tracks bounded vs. unbounded analysis across every return path
-- **Math fail-closed bugs fixed:** All three budget-exhaustion safety issues resolved (#129-#131)
-- **Key rotation security:** Attestation key rotation with proof chain (#224)
-- **12 engines remaining** — ecosystem-wide conformance tracked under META issue #216
+- **All `/verify/*` endpoints return `DiagnosticResult`** — unified 3-layer response contract (status / `agent_message` / `developer_fields` / `proof_ref`) across every verification surface
+- **Mandatory attestation in the control plane** — `require_attestation=True`, attestations issued and verified at the admission boundary; enforcement result drives the response status
+- **VERIFIED is a protocol guarantee** — no engine emits VERIFIED without a deterministic `proof_ref`; heuristic/advisory analysis reports `UNVERIFIABLE` with structured `advisory_checks`
+- **Architecture contract** — API = observation surface (honest witness), Control Plane = admission authority (judge); rules now codify this separation (#13-15)
+- **Security hardening** — TOCTOU closure in `enforce_trust_decision`, tenant-isolated verification cache, attestation signature-verified before claim decode, Unicode-normalized agent state
 
-If you're upgrading from `v5.2.x`, review the [changelog](CHANGELOG.md) for the full migration notes.
+> ⚠️ **Breaking change:** `/verify/*` responses now use the `DiagnosticResult` schema. Consumers parsing the previous ad-hoc dict format must migrate to the unified contract.
+
+If you're upgrading from `v5.3.x`, review the [changelog](CHANGELOG.md) for the full migration notes.
 
 ---
 
@@ -669,14 +670,15 @@ We are building the **Universal Verification Standard** for the agentic web.
 
 - **✔ DiagnosticResult model** — Unified 3-layer diagnostic contract, `proof_ref` authority bit, `AdvisoryCheck` pattern (v5.2.0)
 - **✔ SymbolicVerifier migration** — First fully `DiagnosticResult`-conformant engine; serves as reference implementation (v5.3.0)
+- **✔ Trust Boundary Completion** — All verification pathways route through `DiagnosticResult` + `enforce_trust_decision`; mandatory attestation at the admission boundary; VERIFIED requires deterministic proof_ref (v6.0.0)
 
 ### In Progress
 
-- **Remaining verification engines (#216)** — Migrating the 12 remaining engines to the `DiagnosticResult` model
+- **Remaining verification engines (#216)** — Migrating the remaining engines to the `DiagnosticResult` model
 
 ### Planned
 
-- **v6.0:** QWED Client-Side (WebAssembly), Distributed Verification Network, cross-ecosystem proof exchange
+- **v6.1+:** QWED Client-Side (WebAssembly), Distributed Verification Network, cross-ecosystem proof exchange
 
 ---
 
@@ -965,14 +967,14 @@ If you use QWED in your research or project, please cite our archived paper:
   title = {QWED Protocol: Deterministic Verification for Large Language Models},
   year = {2025},
   publisher = {Zenodo},
-  version = {v5.3.0},
+  version = {v6.0.0},
   doi = {10.5281/zenodo.18111675},
   url = {https://doi.org/10.5281/zenodo.18111675}
 }
 ```
 
 **Plain text:**
-> Dass, R. (2025). QWED Protocol: Deterministic Verification for Large Language Models (Version v5.3.0). Zenodo. https://doi.org/10.5281/zenodo.18111675
+> Dass, R. (2025). QWED Protocol: Deterministic Verification for Large Language Models (Version v6.0.0). Zenodo. https://doi.org/10.5281/zenodo.18111675
 
 ---
 

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: qwed-core
-          image: docker.io/qwedai/qwed-verification:5.3.0
+          image: docker.io/qwedai/qwed-verification:6.0.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -23,7 +23,7 @@ A `Dockerfile` is provided in the root directory. It builds the QWED core servic
 
 ```bash
 # Build the image manually
-docker build -t qweda/qwed-verification:5.3.0 .
+docker build -t qweda/qwed-verification:6.0.0 .
 ```
 
 ### Docker Compose

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # QWED Roadmap — Historical Archive
 
-> ⚠️ **This document is a historical archive.** The QWED roadmap has moved to [docs.qwedai.com](https://docs.qwedai.com). The information below is preserved for reference only and may not reflect the current (v5.2.0+) ecosystem.
+> ⚠️ **This document is a historical archive.** The QWED roadmap has moved to [docs.qwedai.com](https://docs.qwedai.com). The information below is preserved for reference only and may not reflect the current (v6.0.0+) ecosystem.
 
 **Vision:** The First Open Source Neurosymbolic AI Guardrail
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed"
-version = "5.3.0"
+version = "6.0.0"
 description = "The Deterministic Verification Protocol for AI - 11 verification engines for math, logic, code, SQL, facts, images, and more. Now with Agentic Security Guards."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/qwed_sdk/__init__.py
+++ b/qwed_sdk/__init__.py
@@ -37,7 +37,7 @@ from qwed_sdk.models import (
     VerificationType,
 )
 
-__version__ = "5.3.0"
+__version__ = "6.0.0"
 __all__ = [
     "QWEDClient",
     "QWEDAsyncClient",

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qwed"
-version = "5.3.0"
+version = "6.0.0"
 edition = "2021"
 authors = ["QWED-AI"]
 description = "Rust SDK for QWED Verification Protocol"

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -11,7 +11,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qwed = "5.3.0"
+qwed = "6.0.0"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "5.3.0",
+    "version": "6.0.0",
     "description": "TypeScript SDK for QWED Verification Protocol",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -33,7 +33,7 @@ TenantDependency = Annotated[TenantContext, Depends(get_current_tenant)]
 SessionDependency = Annotated[Session, Depends(get_session)]
 AgentTokenHeader = Annotated[str, Header(...)]
 
-APP_VERSION = "5.3.0"
+APP_VERSION = "6.0.0"
 
 app = FastAPI(
     title="QWED API",


### PR DESCRIPTION
## v6.0.0 — Trust Boundary Completion

Completes the **Trust Boundary Completion epic (#263)** — all 12/12 sub-issues closed. Every verification pathway now produces `DiagnosticResult` and routes through `enforce_trust_decision`. The trust boundary is no longer advisory: the control plane requires and verifies attestation before admitting VERIFIED results, and VERIFIED is a protocol guarantee backed by deterministic `proof_ref` — never by execution, agreement, confidence, or provenance.

> **⚠️ Breaking change:** `/verify/*` API responses now use the unified `DiagnosticResult` schema (status / `agent_message` / `developer_fields` / `proof_ref`). Consumers of the previous ad-hoc dict responses must migrate.

### Architecture: Observation vs Admission (#264, #265)

- **All `/verify/*` endpoints return `DiagnosticResult`** (#276)
- **Control plane enforces mandatory attestation** — `require_attestation=True`, enforced status drives HTTP response status (#278)
- **Batch math** routes through `DiagnosticResult` + attestation + `enforce_trust_decision` (#282)
- **Attestation scope alignment** — attest translated expression, not natural-language query (#285)

### VERIFIED is a protocol guarantee (#266, #267, #269, #270)

- **ConsensusResult** uses `DiagnosticStatus` enum with `proof_ref` + `verified_evidence` (#280)
- **FactVerifier** heuristic SUPPORTED verdict → UNVERIFIABLE with `advisory_checks` (#283)
- **Consensus code execution** advisory-only, VERIFIED → UNVERIFIABLE (#281)
- **Consensus stats computation** advisory-only, never VERIFIED (#277)
- **LogicVerifier** migrated to `DiagnosticResult` (#262)
- **AgentStateGuard** `proof_ref` = real sha256 of committed bytes (#284)

### Engineering & Security Hardening

- **TOCTOU closure** in `enforce_trust_decision` — `developer_fields` snapshotted via recursive rebuild, fail-closed (#273, #290)
- **Attestation signature verified before claim decode** — silent generic error for all failure modes (#275, #287)
- **Tenant-isolated verification cache** (#274, #286)
- **Unicode normalization** in AgentStateGuard canonicalization (#272, #288)
- **Mandatory proof artifact** for VERIFIED attestations (#248)
- **Credential / JWT / dockerignore security alerts** resolved (#249)
- **Math whitelist injection bypass** removed (#251)
- **Engine classification docs** — Proof / Policy Enforcement / Advisory (#247)

### Rules & Protocol Semantics

`QWED_RULES.md` codifies the trust-boundary contract: **#13 Separation of Responsibilities**, **#14 Verification Semantics**, **#15 Truth Before Policy**; rules #7/#8 updated to capture admission-boundary and deterministic-proof semantics.

### Version Propagation

- `qwed` (PyPI): `5.3.0` -> `6.0.0`
- `qwed_sdk` (Python): `5.3.0` -> `6.0.0`
- `@qwed-ai/sdk` (NPM): `5.3.0` -> `6.0.0`
- `qwed` (crates.io/Rust): `5.3.0` -> `6.0.0`
- API version marker: `5.3.0` -> `6.0.0`
- Kubernetes deployment image: `5.3.0` -> `6.0.0`

### Files Changed

- `CHANGELOG.md` — Full v6.0.0 section with all 21 PRs
- `README.md` — Release banner reframed to v6.0.0 Trust Boundary Completion, roadmap updated (v6.0.0 Completed / v6.1+ Planned), citation version bumped
- `QWED_RULES.md` — New rules #13-#15; amended #7/#8
- `pyproject.toml` — `5.3.0` → `6.0.0`
- `qwed_sdk/__init__.py` — `5.3.0` → `6.0.0`
- `src/qwed_new/api/main.py` — `5.3.0` → `6.0.0`
- `sdk-ts/package.json` — `5.3.0` → `6.0.0`
- `sdk-rust/Cargo.toml` — `5.3.0` → `6.0.0`
- `sdk-rust/README.md` — `5.3.0` → `6.0.0`
- `docs/DEPLOYMENT.md` — Docker tag `5.3.0` → `6.0.0`
- `deploy/kubernetes/deployment.yaml` — image tag `5.3.0` → `6.0.0`
- `docs/roadmap.md` — stale `v5.2.0+` reference → `v6.0.0+` (missed in last release)

### Ecosystem Status

- **12/12 trust boundary sub-issues closed** (Epic #263)
- **Remaining work** — verification engine migrations to `DiagnosticResult` (META #216)
- **Full test suite:** 1655 passed, 102 skipped

### Included PRs

- `#247` docs: engine classification — Proof / Policy Enforcement / Advisory
- `#248` fix(#191): enforce mandatory proof artifact on VERIFIED attestations
- `#249` fix: resolve credential / JWT / dockerignore security alerts
- `#251` fix(#227): remove math whitelist injection bypass
- `#260` fix(#257): hybrid engine advisory-only — never VERIFIED without proof
- `#261` fix(#259): FactVerifier advisory-only
- `#262` feat(#252): LogicVerifier migrated to DiagnosticResult
- `#276` fix(api): migrate all /verify/* endpoints to return DiagnosticResult (#264)
- `#277` fix(#270): consensus stats advisory-only, never VERIFIED
- `#278` fix(#265): control plane trust enforcement mandatory
- `#280` fix(#266): ConsensusResult DiagnosticStatus enum + proof_ref + verified_evidence
- `#281` fix(#269): consensus code execution advisory-only
- `#282` fix(#271): batch math DiagnosticResult → proof_ref + attestation + enforce_trust_decision
- `#283` fix(#267): FactVerifier SUPPORTED → UNVERIFIABLE with heuristic advisory_checks
- `#284` fix(#268): AgentStateGuard proof_ref real sha256
- `#285` fix(#279): attest translated expression, not natural language query
- `#286` fix(#274): VerificationCache tenant isolation
- `#287` fix(#275): attestation verify-before-decode + silent generic error
- `#288` fix(#272): NFC-normalize AgentStateGuard canonicalization
- `#289` fix: mock network in secret redaction tests (CI)
- `#290` fix(#273): close TOCTOU in enforce_trust_decision


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Trust Boundary Completion with mandatory attestation and proof-backed verification.
  - Standardized diagnostic responses across verification APIs.
  - Strengthened security rules by separating verification from enforcement.

- **Documentation**
  - Updated release notes, architecture guidance, deployment instructions, and roadmap for v6.0.0.

- **Chores**
  - Updated application, SDK, container, and deployment versions from 5.3.0 to 6.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->