### PR TITLE
fix(sql): migrate SQLVerifier to DiagnosticResult

### DIFF
--- a/qwed_sdk/cli.py
+++ b/qwed_sdk/cli.py
@@ -1480,6 +1480,48 @@ def _print_doctor_report(report: dict) -> None:
     click.echo(f"\nStatus: {status_line}")
 
 
+def _run_sql_engine_cases(sql_engine, run_case) -> None:
+    """SQL self-test cases for the CLI engine smoke suite."""
+    from qwed_new.core.diagnostics import DiagnosticStatus
+
+    def is_safe(payload):
+        return (
+            payload.status == DiagnosticStatus.VERIFIED
+            and payload.developer_fields.get("is_valid") is True
+        )
+
+    def is_verified_malicious(payload):
+        return (
+            payload.status == DiagnosticStatus.VERIFIED
+            and payload.developer_fields.get("is_valid") is False
+        )
+
+    run_case(
+        "SQL",
+        "Valid SELECT",
+        "SAFE",
+        lambda: sql_engine.verify_sql("SELECT id, name FROM users WHERE id = 123"),
+        is_safe,
+        lambda payload: f"status={payload.status.value}",
+    )
+    run_case(
+        "SQL",
+        "OR 1=1 injection",
+        "BLOCKED",
+        lambda: sql_engine.verify_sql("SELECT * FROM users WHERE id = 1 OR 1=1"),
+        is_verified_malicious,
+        lambda payload: f"status={payload.status.value}, critical={payload.developer_fields.get('critical_count')}",
+    )
+    run_case(
+        "SQL",
+        "DROP TABLE stacked",
+        "BLOCKED",
+        lambda: sql_engine.verify_sql("SELECT * FROM users; DROP TABLE users;"),
+        is_verified_malicious,
+        lambda payload: f"status={payload.status.value}, critical={payload.developer_fields.get('critical_count')}",
+    )
+
+
 def _run_full_engine_tests() -> List[dict]:
     results: List[dict] = []
 
@@ -1600,44 +1642,7 @@ def _run_full_engine_tests() -> List[dict]:
         add_engine_error_cases("SQL", ["Valid SELECT", "OR 1=1 injection", "DROP TABLE stacked"], exc)
 
     if sql_engine is not None:
-        from qwed_new.core.diagnostics import DiagnosticStatus
-
-        def _sql_is_safe(p):
-            return (
-                p.status == DiagnosticStatus.VERIFIED
-                and p.developer_fields.get("is_valid") is True
-            )
-
-        def _sql_is_unsafe(p):
-            return (
-                p.status == DiagnosticStatus.VERIFIED
-                and p.developer_fields.get("is_valid") is False
-            )
-
-        run_case(
-            "SQL",
-            "Valid SELECT",
-            "SAFE",
-            lambda: sql_engine.verify_sql("SELECT id, name FROM users WHERE id = 123"),
-            _sql_is_safe,
-            lambda payload: f"status={payload.status.value}",
-        )
-        run_case(
-            "SQL",
-            "OR 1=1 injection",
-            "BLOCKED",
-            lambda: sql_engine.verify_sql("SELECT * FROM users WHERE id = 1 OR 1=1"),
-            _sql_is_unsafe,
-            lambda payload: f"status={payload.status.value}, critical={payload.developer_fields.get('critical_count')}",
-        )
-        run_case(
-            "SQL",
-            "DROP TABLE stacked",
-            "BLOCKED",
-            lambda: sql_engine.verify_sql("SELECT * FROM users; DROP TABLE users;"),
-            _sql_is_unsafe,
-            lambda payload: f"status={payload.status.value}, critical={payload.developer_fields.get('critical_count')}",
-        )
+        _run_sql_engine_cases(sql_engine, run_case)
 
     try:
         from qwed_new.core.code_verifier import CodeVerifier

--- a/qwed_sdk/cli.py
+++ b/qwed_sdk/cli.py
@@ -280,10 +280,14 @@ def _run_init_smoke_suite() -> list[dict]:
     )
 
     sql_bad = sql_engine.verify_sql("SELECT * FROM users WHERE 1=1 OR 1=1")
+    sql_bad_passed = (
+        sql_bad.status == DiagnosticStatus.VERIFIED
+        and sql_bad.developer_fields.get("is_valid") is False
+    )
     tests.append(
         {
             "label": "SELECT * WHERE 1=1",
-            "passed": sql_bad.get("status") == "BLOCKED",
+            "passed": sql_bad_passed,
             "result": "BLOCKED",
         }
     )
@@ -1596,29 +1600,40 @@ def _run_full_engine_tests() -> List[dict]:
         add_engine_error_cases("SQL", ["Valid SELECT", "OR 1=1 injection", "DROP TABLE stacked"], exc)
 
     if sql_engine is not None:
+        from qwed_new.core.diagnostics import DiagnosticStatus
+
+        def _sql_is_safe(p):
+            return (
+                p.status == DiagnosticStatus.VERIFIED
+                and p.developer_fields.get("is_valid") is True
+            )
+
+        def _sql_is_unsafe(p):
+            return p.developer_fields.get("is_valid") is False
+
         run_case(
             "SQL",
             "Valid SELECT",
             "SAFE",
             lambda: sql_engine.verify_sql("SELECT id, name FROM users WHERE id = 123"),
-            lambda payload: payload.get("status") == "SAFE",
-            lambda payload: f"status={payload.get('status')}",
+            _sql_is_safe,
+            lambda payload: f"status={payload.status.value}",
         )
         run_case(
             "SQL",
             "OR 1=1 injection",
             "BLOCKED",
             lambda: sql_engine.verify_sql("SELECT * FROM users WHERE id = 1 OR 1=1"),
-            lambda payload: payload.get("status") == "BLOCKED",
-            lambda payload: f"status={payload.get('status')}",
+            _sql_is_unsafe,
+            lambda payload: f"status={payload.status.value}, critical={payload.developer_fields.get('critical_count')}",
         )
         run_case(
             "SQL",
             "DROP TABLE stacked",
             "BLOCKED",
             lambda: sql_engine.verify_sql("SELECT * FROM users; DROP TABLE users;"),
-            lambda payload: payload.get("status") == "BLOCKED",
-            lambda payload: f"status={payload.get('status')}",
+            _sql_is_unsafe,
+            lambda payload: f"status={payload.status.value}, critical={payload.developer_fields.get('critical_count')}",
         )
 
     try:

--- a/qwed_sdk/cli.py
+++ b/qwed_sdk/cli.py
@@ -1609,7 +1609,10 @@ def _run_full_engine_tests() -> List[dict]:
             )
 
         def _sql_is_unsafe(p):
-            return p.developer_fields.get("is_valid") is False
+            return (
+                p.status == DiagnosticStatus.VERIFIED
+                and p.developer_fields.get("is_valid") is False
+            )
 
         run_case(
             "SQL",

--- a/qwed_sdk/cli.py
+++ b/qwed_sdk/cli.py
@@ -1488,12 +1488,15 @@ def _run_sql_engine_cases(sql_engine, run_case) -> None:
         return (
             payload.status == DiagnosticStatus.VERIFIED
             and payload.developer_fields.get("is_valid") is True
+            and bool(payload.proof_ref)
         )
 
     def is_verified_malicious(payload):
         return (
             payload.status == DiagnosticStatus.VERIFIED
             and payload.developer_fields.get("is_valid") is False
+            and payload.developer_fields.get("malicious_classification") is True
+            and bool(payload.proof_ref)
         )
 
     run_case(

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -736,20 +736,11 @@ async def verify_sql(
 
         result = verifier.verify_sql(query, schema_ddl, dialect=dialect)
 
-        if result.is_fail_closed:
-            # Parse/execution/connection failure — engine already returned BLOCKED.
-            dr = result
-        elif bool(result.developer_fields.get("is_valid", False)):
-            # Safe query — engine returned VERIFIED with proof_ref bound to the AST.
-            dr = result
-        else:
-            # Proven malicious (VERIFIED-as-malicious). The stricter admission
-            # boundary downgrades this to BLOCKED so an unsafe query is never
-            # admissible for control flow (issue #253).
-            dr = DiagnosticResult.blocked(
-                result.agent_message,
-                developer_fields=result.developer_fields,
-            )
+        # The engine's verdict is authoritative and unchanged. A proven-malicious query
+        # is VERIFIED-as-malicious (developer_fields.is_valid False); admission policy
+        # gating on is_valid lives in the consumer, not here (issue #253). Only
+        # fail-closed BLOCKED/UNVERIFIABLE results surface as-is.
+        dr = result
         dr = _enforce_trust(dr, query=query)
 
         log = VerificationLog(

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -8,7 +8,12 @@ import logging
 from fractions import Fraction
 
 from qwed_new.core.security import redact_pii
-from qwed_new.core.diagnostics import DiagnosticResult, enforce_trust_decision, merge_diagnostic_result
+from qwed_new.core.diagnostics import (
+    DiagnosticResult,
+    admission_decision,
+    enforce_trust_decision,
+    merge_diagnostic_result,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -736,12 +741,14 @@ async def verify_sql(
 
         result = verifier.verify_sql(query, schema_ddl, dialect=dialect)
 
-        # The engine's verdict is authoritative and unchanged. A proven-malicious query
-        # is VERIFIED-as-malicious (developer_fields.is_valid False); admission policy
-        # gating on is_valid lives in the consumer, not here (issue #253). Only
-        # fail-closed BLOCKED/UNVERIFIABLE results surface as-is.
+        # Verification truth is preserved unchanged: a proven-malicious query is
+        # VERIFIED-as-malicious (developer_fields.is_valid False, proof_ref bound).
+        # Admission is a SEPARATE decision at this boundary (QWED #7, #13, #15): unsafe
+        # SQL must never be admitted, so we expose an explicit AdmissionDecision rather
+        # than letting authority-only consumers treat proof_ref as "safe to execute".
         dr = result
         dr = _enforce_trust(dr, query=query)
+        admission = admission_decision(dr)
 
         log = VerificationLog(
             organization_id=tenant.organization_id,
@@ -752,7 +759,9 @@ async def verify_sql(
         )
         _safe_commit_log(session, log)
 
-        return _merge_response(dr)
+        response = _merge_response(dr)
+        response["admission"] = admission.value
+        return response
 
     except HTTPException:
         raise
@@ -771,7 +780,9 @@ async def verify_sql(
             domain="SQL"
         )
         _safe_commit_log(session, log)
-        return _merge_response(dr)
+        response = _merge_response(dr)
+        response["admission"] = admission_decision(dr).value
+        return response
 
 
 @app.post("/verify/image")

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -736,17 +736,19 @@ async def verify_sql(
 
         result = verifier.verify_sql(query, schema_ddl, dialect=dialect)
 
-        is_valid = result.get("is_valid", False)
-        if is_valid:
-            dr = DiagnosticResult.verified(
-                "SQL query is valid for the given schema",
-                developer_fields=result,
-                evidence={"query": query, "dialect": dialect, "analysis": result.get("analysis", "")},
-            )
+        if result.is_fail_closed:
+            # Parse/execution/connection failure — engine already returned BLOCKED.
+            dr = result
+        elif bool(result.developer_fields.get("is_valid", False)):
+            # Safe query — engine returned VERIFIED with proof_ref bound to the AST.
+            dr = result
         else:
+            # Proven malicious (VERIFIED-as-malicious). The stricter admission
+            # boundary downgrades this to BLOCKED so an unsafe query is never
+            # admissible for control flow (issue #253).
             dr = DiagnosticResult.blocked(
-                result.get("message", "SQL query is invalid or unsafe"),
-                developer_fields=result,
+                result.agent_message,
+                developer_fields=result.developer_fields,
             )
         dr = _enforce_trust(dr, query=query)
 

--- a/src/qwed_new/core/batch.py
+++ b/src/qwed_new/core/batch.py
@@ -249,7 +249,7 @@ class BatchVerificationService:
                 item.query,
                 item.params.get("schema_ddl", ""),
                 dialect=item.params.get("dialect", "sqlite")
-            )
+            ).to_dict()
         
         else:
             raise ValueError(f"Unknown verification type: {item.verification_type}")

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -862,9 +862,9 @@ def admission_decision(result: DiagnosticResult) -> AdmissionDecision:
     deterministic gate turns it into a fail-closed admission outcome:
 
     - fail-closed status (BLOCKED/UNVERIFIABLE)         -> BLOCKED
-    - ``developer_fields.is_valid is False`` (unsafe)   -> BLOCKED
-    - authoritative (VERIFIED) and valid                -> ADMIT
-    - anything else (non-authoritative)                 -> BLOCKED
+    - ``developer_fields.is_valid is not True``          -> BLOCKED (missing/malformed)
+    - authoritative (VERIFIED) and valid                 -> ADMIT
+    - anything else (non-authoritative)                  -> BLOCKED
 
     Returning ``BLOCKED`` for a VERIFIED-but-unsafe result is a policy decision
     at the boundary (QWED #7), not a reinterpretation of the verdict (QWED #15):
@@ -872,7 +872,7 @@ def admission_decision(result: DiagnosticResult) -> AdmissionDecision:
     """
     if result.is_fail_closed:
         return AdmissionDecision.BLOCKED
-    if result.developer_fields.get("is_valid") is False:
+    if result.developer_fields.get("is_valid") is not True:
         return AdmissionDecision.BLOCKED
     if result.is_authoritative:
         return AdmissionDecision.ADMIT

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -82,6 +82,25 @@ class DiagnosticStatus(str, Enum):
     BLOCKED = "BLOCKED"
 
 
+class AdmissionDecision(str, Enum):
+    """Admission outcome at an enforcement boundary.
+
+    Distinct from :class:`DiagnosticStatus` by design (QWED #13 Separation of
+    Responsibilities, #15 Truth Before Policy): a ``DiagnosticResult`` answers
+    *"is this claim provably true?"* while an ``AdmissionDecision`` answers
+    *"should this be allowed at this boundary?"* A provably-malicious query is
+    ``VERIFIED`` (truth) yet ``BLOCKED`` (admission), so generic consumers that
+    gate on the admission decision never accept unsafe input even when the
+    underlying verification was authoritative.
+
+    Values:
+        ADMIT:   The boundary may proceed with the verdict.
+        BLOCKED: The boundary must not admit. This is the fail-closed default.
+    """
+    ADMIT = "ADMIT"
+    BLOCKED = "BLOCKED"
+
+
 # ---------------------------------------------------------------------------
 # Advisory check — structured representation of non-proof-bearing analysis.
 # Used for: LLM fallback output, NLI entailment labels, VLM interpretation,
@@ -836,6 +855,30 @@ DIAGNOSTIC_RESPONSE_KEYS = frozenset({
 })
 
 
+def admission_decision(result: DiagnosticResult) -> AdmissionDecision:
+    """Map a verification result to an admission decision for a SQL boundary.
+
+    The engine's ``DiagnosticResult`` is the truth and is never modified. This
+    deterministic gate turns it into a fail-closed admission outcome:
+
+    - fail-closed status (BLOCKED/UNVERIFIABLE)         -> BLOCKED
+    - ``developer_fields.is_valid is False`` (unsafe)   -> BLOCKED
+    - authoritative (VERIFIED) and valid                -> ADMIT
+    - anything else (non-authoritative)                 -> BLOCKED
+
+    Returning ``BLOCKED`` for a VERIFIED-but-unsafe result is a policy decision
+    at the boundary (QWED #7), not a reinterpretation of the verdict (QWED #15):
+    the original DiagnosticResult is preserved unchanged alongside it.
+    """
+    if result.is_fail_closed:
+        return AdmissionDecision.BLOCKED
+    if result.developer_fields.get("is_valid") is False:
+        return AdmissionDecision.BLOCKED
+    if result.is_authoritative:
+        return AdmissionDecision.ADMIT
+    return AdmissionDecision.BLOCKED
+
+
 def merge_diagnostic_result(dr: DiagnosticResult) -> Dict[str, Any]:
     """Merge DiagnosticResult with developer fields, ensuring diagnostic keys win.
 
@@ -851,7 +894,9 @@ __all__ = [
     "DiagnosticStatus",
     "DiagnosticResult",
     "AdvisoryCheck",
+    "AdmissionDecision",
     "compute_proof_ref",
     "enforce_trust_decision",
+    "admission_decision",
     "merge_diagnostic_result",
 ]

--- a/src/qwed_new/core/sql_verifier.py
+++ b/src/qwed_new/core/sql_verifier.py
@@ -22,6 +22,7 @@ CONSTRAINT_EXECUTION_ERROR = "sql_verifier.execution_error"
 CONSTRAINT_CONNECTION_FAILURE = "sql_verifier.connection_failure"
 CONSTRAINT_SQL_VALID = "sql_verifier.sql_valid"
 CONSTRAINT_MALICIOUS = "sql_verifier.malicious"
+CONSTRAINT_BATCH_BLOCKED = "sql_verifier.batch_blocked"
 
 
 def _available_expression_types(*names: str) -> Set[type]:
@@ -156,7 +157,9 @@ class SQLVerifier:
                           is malicious IS a successful proof, so it is not BLOCKED (issue #253).
         - Parse error     → BLOCKED (``sql_verifier.parse_error``)
         - Internal error  → BLOCKED (``sql_verifier.execution_error``)
-        - Connection fail → BLOCKED (``sql_verifier.connection_failure``)
+
+        ``sql_verifier.connection_failure`` is reserved for consumers whose engines open a
+        database connection; this verifier performs static AST analysis only.
 
         ``agent_message`` is agent-safe: it never leaks detection rules, rule IDs, or raw
         SQLGlot output. Rule-level detail lives in ``developer_fields``.
@@ -175,7 +178,7 @@ class SQLVerifier:
         # 1. Parse Query
         try:
             parsed_query = parse_one(query, read=dialect)
-        except Exception:
+        except Exception as exc:  # noqa: BLE001 — fail-closed by design
             return DiagnosticResult.blocked(
                 agent_message=(
                     "SQL verification could not be completed because the query "
@@ -184,6 +187,7 @@ class SQLVerifier:
                 developer_fields={
                     "constraint_id": CONSTRAINT_PARSE_ERROR,
                     "is_valid": False,
+                    "error_type": type(exc).__name__,
                     "issues": [{"severity": "CRITICAL", "description": "SQL Syntax Error"}],
                     "engine": "SQLGlot-AST-Scanner",
                 },
@@ -204,7 +208,7 @@ class SQLVerifier:
 
             if schema_ddl:
                 issues.extend(self._validate_against_schema(parsed_query, schema_ddl, dialect))
-        except Exception:
+        except Exception as exc:  # noqa: BLE001 — fail-closed by design
             return DiagnosticResult.blocked(
                 agent_message=(
                     "SQL verification could not be completed due to an internal error."
@@ -212,6 +216,7 @@ class SQLVerifier:
                 developer_fields={
                     "constraint_id": CONSTRAINT_EXECUTION_ERROR,
                     "is_valid": False,
+                    "error_type": type(exc).__name__,
                 },
             )
 
@@ -248,7 +253,16 @@ class SQLVerifier:
             "engine": "SQLGlot-AST-Scanner",
         }
 
-        evidence = self._build_evidence(parsed_query, query, dialect, schema_ddl)
+        evidence = self._build_evidence(
+            parsed_query,
+            query,
+            dialect,
+            schema_ddl,
+            is_valid=is_valid,
+            critical_count=critical_count,
+            issues=issues,
+            check_complexity=check_complexity,
+        )
 
         if is_valid:
             return DiagnosticResult.verified(
@@ -273,15 +287,31 @@ class SQLVerifier:
         query: str,
         dialect: str,
         schema_ddl: Optional[str],
+        *,
+        is_valid: bool,
+        critical_count: int,
+        issues: List[SQLIssue],
+        check_complexity: bool,
     ) -> Dict[str, Any]:
-        """Build deterministic, JSON-serializable proof evidence bound to the AST."""
+        """Build deterministic, JSON-serializable proof evidence bound to the verdict.
+
+        The proof_ref hashes the AST, the verdict, and the effective policy
+        (``allow_destructive``, ``blocked_columns``, ``limits``) so two configurations
+        that reach opposite verdicts on identical input can never share a proof_ref.
+        """
         return {
             "engine": "SQLAst-Scanner",
             "query": query,
             "dialect": dialect,
             "schema_ddl": schema_ddl if schema_ddl else None,
-            "normalized_sql": parsed_query.sql(),
             "ast": parsed_query.dump(),
+            "is_valid": is_valid,
+            "critical_count": critical_count,
+            "issue_types": sorted({issue.issue_type for issue in issues}),
+            "check_complexity": check_complexity,
+            "allow_destructive": self.allow_destructive,
+            "blocked_columns": sorted(self.blocked_columns),
+            "limits": {key: self.limits[key] for key in sorted(self.limits)},
         }
     
     # =========================================================================
@@ -588,11 +618,14 @@ class SQLVerifier:
         """
         Verify multiple SQL queries.
 
-        Returns a single :class:`DiagnosticResult`. Status is VERIFIED because the batch
-        analysis completed deterministically; individual verdicts live in
+        Returns a single :class:`DiagnosticResult`. Per-query verdicts live in
         ``developer_fields.results`` (each a serialized per-query DiagnosticResult) and
-        ``developer_fields.summary``. ``developer_fields.is_valid`` is True only when
-        every query is safe.
+        ``developer_fields.summary``.
+
+        The batch is authoritative (VERIFIED with ``proof_ref``) only when every query is
+        safe. A batch containing any malicious or blocked query returns BLOCKED (non-
+        authoritative, ``proof_ref`` None) so generic consumers that admit on
+        ``is_authoritative`` can never accept unsafe SQL (issue #253).
 
         Args:
             queries: List of SQL queries to verify.
@@ -600,9 +633,13 @@ class SQLVerifier:
             dialect: SQL dialect.
 
         Example:
-            >>> result = verifier.verify_batch(["SELECT * FROM table1", "DROP TABLE table2"])
-            >>> print(result.developer_fields["summary"]["blocked"])
-            1
+            >>> result = verifier.verify_batch(["SELECT * FROM table1", "SELEC FROM t"])
+            >>> print(
+            ...     result.developer_fields["summary"]["safe"],
+            ...     result.developer_fields["summary"]["unsafe"],
+            ...     result.developer_fields["summary"]["blocked"],
+            ... )
+            1 0 1
         """
         items: List[Dict[str, Any]] = []
         for query in queries:
@@ -612,14 +649,27 @@ class SQLVerifier:
             items.append(serialized)
 
         total = len(queries)
-        is_valid_all = all(item["developer_fields"]["is_valid"] for item in items)
-        safe = sum(1 for item in items if item["status"] == "VERIFIED" and item["developer_fields"]["is_valid"])
-        blocked_invalid = sum(1 for item in items if item["developer_fields"]["is_valid"] is False)
+        safe = sum(
+            1
+            for item in items
+            if item["status"] == "VERIFIED" and item["developer_fields"].get("is_valid") is True
+        )
+        malicious = sum(
+            1
+            for item in items
+            if item["status"] == "VERIFIED" and item["developer_fields"].get("is_valid") is False
+        )
+        blocked = total - safe - malicious
+
+        is_valid_all = safe == total
+        has_proven_malicious = malicious > 0
 
         summary = {
             "total": total,
             "safe": safe,
-            "unsafe": blocked_invalid,
+            "unsafe": malicious,
+            "malicious": malicious,
+            "blocked": blocked,
             "total_critical": sum(
                 item["developer_fields"].get("critical_count", 0) for item in items
             ),
@@ -633,22 +683,48 @@ class SQLVerifier:
             "dialect": dialect,
             "count": total,
             "queries": [item["query"] for item in items],
+            "verdicts": [
+                {"status": item["status"], "is_valid": item["developer_fields"].get("is_valid")}
+                for item in items
+            ],
+            "allow_destructive": self.allow_destructive,
         }
 
+        if is_valid_all:
+            batch_constraint_id = CONSTRAINT_SQL_VALID
+            batch_malicious = False
+        else:
+            # A parse/execution failure is NOT a proven-malicious verdict (Greptile P1):
+            # only classify the batch as malicious when at least one item was proven so.
+            batch_constraint_id = (
+                CONSTRAINT_MALICIOUS if has_proven_malicious else CONSTRAINT_BATCH_BLOCKED
+            )
+            batch_malicious = has_proven_malicious
+
         batch_fields: Dict[str, Any] = {
-            "constraint_id": CONSTRAINT_SQL_VALID if is_valid_all else CONSTRAINT_MALICIOUS,
+            "constraint_id": batch_constraint_id,
             "is_valid": is_valid_all,
-            "malicious_classification": not is_valid_all,
+            "malicious_classification": batch_malicious,
             "results": items,
             "summary": summary,
             "engine": "SQLGlot-AST-Scanner",
         }
 
-        return DiagnosticResult.verified(
+        if is_valid_all:
+            return DiagnosticResult.verified(
+                agent_message=(
+                    "Batch SQL verification succeeded: all queries passed security checks."
+                ),
+                developer_fields=batch_fields,
+                evidence=evidence,
+            )
+
+        # Fail-closed: an unsafe or blocked query makes the whole batch non-authoritative
+        # (security policy violation per the BLOCKED status contract).
+        return DiagnosticResult.blocked(
             agent_message=(
-                "Batch SQL verification completed. Inspect developer_fields for "
-                "per-query verdicts."
+                "Batch SQL verification flagged unsafe or blocked queries; "
+                "the batch is not admissible."
             ),
             developer_fields=batch_fields,
-            evidence=evidence,
         )

--- a/src/qwed_new/core/sql_verifier.py
+++ b/src/qwed_new/core/sql_verifier.py
@@ -25,6 +25,8 @@ CONSTRAINT_CONNECTION_FAILURE = "sql_verifier.connection_failure"
 CONSTRAINT_SQL_VALID = "sql_verifier.sql_valid"
 CONSTRAINT_MALICIOUS = "sql_verifier.malicious"
 CONSTRAINT_COMPLEXITY_LIMIT_EXCEEDED = "sql_verifier.complexity_limit_exceeded"
+CONSTRAINT_SCHEMA_PARSE_ERROR = "sql_verifier.schema_parse_error"
+CONSTRAINT_EMPTY_BATCH = "sql_verifier.empty_batch"
 CONSTRAINT_BATCH_BLOCKED = "sql_verifier.batch_blocked"
 
 # Issue types that prove malice. Resource-limit violations (complexity_*) are CRITICAL
@@ -170,6 +172,9 @@ class SQLVerifier:
         - Malicious query → VERIFIED as-malicious (``is_valid`` False,
                           ``developer_fields.malicious_classification`` True). Proving a query
                           is malicious IS a successful proof, so it is not BLOCKED (issue #253).
+                          Malicious is the only unsafe case that retains a proof_ref.
+        - Complexity-limit violation → BLOCKED (``sql_verifier.complexity_limit_exceeded``)
+        - DDL schema parse failure → BLOCKED (``sql_verifier.schema_parse_error``)
         - Parse error     → BLOCKED (``sql_verifier.parse_error``)
         - Internal error  → BLOCKED (``sql_verifier.execution_error``)
 
@@ -247,9 +252,12 @@ class SQLVerifier:
             i.severity == "CRITICAL" and i.issue_type in MALICIOUS_ISSUE_TYPES
             for i in issues
         )
+        schema_parse_failed = any(i.issue_type == "schema_parse_error" for i in issues)
 
         if malicious:
             constraint_id = CONSTRAINT_MALICIOUS
+        elif schema_parse_failed:
+            constraint_id = CONSTRAINT_SCHEMA_PARSE_ERROR
         elif not is_valid:
             constraint_id = CONSTRAINT_COMPLEXITY_LIMIT_EXCEEDED
         else:
@@ -293,21 +301,24 @@ class SQLVerifier:
             check_complexity=check_complexity,
         )
 
-        if is_valid:
+        if is_valid or malicious:
             return DiagnosticResult.verified(
-                agent_message="The SQL query passed verification and is safe to execute.",
+                agent_message=(
+                    "The SQL query passed verification and is safe to execute."
+                    if is_valid
+                    else "The SQL query failed security verification and is not safe to execute."
+                ),
                 developer_fields=developer_fields,
                 evidence=evidence,
             )
 
-        # Proven malicious: still VERIFIED with proof_ref — the AST proves the verdict.
-        # Consumers gate on is_valid / malicious_classification, not status (issue #253).
-        return DiagnosticResult.verified(
-            agent_message=(
-                "The SQL query failed security verification and is not safe to execute."
-            ),
+        # Complexity-limit, schema-parse, and other non-malicious admission failures
+        # are BLOCKED (non-authoritative, no proof_ref): they are not proofs of malice
+        # and theorem-providing engines must not emit an authoritative VERIFIED for an
+        # incomplete analysis. Only proven-malicious results may carry a proof_ref.
+        return DiagnosticResult.blocked(
+            agent_message="The SQL query failed admission checks and is not safe to execute.",
             developer_fields=developer_fields,
-            evidence=evidence,
         )
 
     def _build_evidence(
@@ -615,9 +626,9 @@ class SQLVerifier:
                     tables_in_schema[table_name] = columns
         except Exception:
             issues.append(SQLIssue(
-                severity="WARNING",
+                severity="CRITICAL",
                 issue_type="schema_parse_error",
-                description="Could not parse DDL schema."
+                description="Could not parse DDL schema; schema verification is incomplete."
             ))
             return issues
         
@@ -676,6 +687,26 @@ class SQLVerifier:
             serialized = dr.to_dict()
             serialized["query"] = query[:100] + "..." if len(query) > 100 else query
             items.append(serialized)
+
+        if not queries:
+            return DiagnosticResult.blocked(
+                agent_message="Batch SQL verification requires at least one query.",
+                developer_fields={
+                    "constraint_id": CONSTRAINT_EMPTY_BATCH,
+                    "is_valid": False,
+                    "malicious_classification": False,
+                    "results": [],
+                    "summary": {
+                        "total": 0,
+                        "safe": 0,
+                        "unsafe": 0,
+                        "malicious": 0,
+                        "blocked": 0,
+                        "total_critical": 0,
+                        "total_warnings": 0,
+                    },
+                },
+            )
 
         total = len(queries)
         safe = sum(

--- a/src/qwed_new/core/sql_verifier.py
+++ b/src/qwed_new/core/sql_verifier.py
@@ -14,6 +14,15 @@ from sqlglot import exp, parse_one
 from typing import List, Dict, Any, Optional, Set
 from dataclasses import dataclass
 
+from .diagnostics import DiagnosticResult
+
+
+CONSTRAINT_PARSE_ERROR = "sql_verifier.parse_error"
+CONSTRAINT_EXECUTION_ERROR = "sql_verifier.execution_error"
+CONSTRAINT_CONNECTION_FAILURE = "sql_verifier.connection_failure"
+CONSTRAINT_SQL_VALID = "sql_verifier.sql_valid"
+CONSTRAINT_MALICIOUS = "sql_verifier.malicious"
+
 
 def _available_expression_types(*names: str) -> Set[type]:
     """Return the sqlglot expression classes that exist in the installed version."""
@@ -135,73 +144,93 @@ class SQLVerifier:
         schema_ddl: Optional[str] = None, 
         dialect: str = "postgres",
         check_complexity: bool = True
-    ) -> Dict[str, Any]:
+    ) -> DiagnosticResult:
         """
         Verify a SQL query for safety.
-        
+
+        Returns a structured :class:`DiagnosticResult`:
+
+        - SAFE query      → VERIFIED (``developer_fields.is_valid`` True, proof_ref from AST)
+        - Malicious query → VERIFIED as-malicious (``is_valid`` False,
+                          ``developer_fields.malicious_classification`` True). Proving a query
+                          is malicious IS a successful proof, so it is not BLOCKED (issue #253).
+        - Parse error     → BLOCKED (``sql_verifier.parse_error``)
+        - Internal error  → BLOCKED (``sql_verifier.execution_error``)
+        - Connection fail → BLOCKED (``sql_verifier.connection_failure``)
+
+        ``agent_message`` is agent-safe: it never leaks detection rules, rule IDs, or raw
+        SQLGlot output. Rule-level detail lives in ``developer_fields``.
+
         Args:
             query: The SQL query to verify.
             schema_ddl: Optional DDL for schema validation.
             dialect: SQL dialect (postgres, mysql, sqlite, etc.).
             check_complexity: Whether to check complexity limits.
-            
-        Returns:
-            Dict with verification results including safety status and issues list.
 
         Example:
             >>> result = verifier.verify_sql("SELECT * FROM users WHERE id = 1")
-            >>> print(result["is_safe"])
+            >>> print(result.developer_fields.get("is_valid"))
             True
         """
-        issues: List[SQLIssue] = []
-        
         # 1. Parse Query
         try:
             parsed_query = parse_one(query, read=dialect)
-        except Exception as e:
-            return {
-                "is_safe": False,
-                "status": "SYNTAX_ERROR",
-                "issues": [{"severity": "CRITICAL", "description": f"SQL Syntax Error: {str(e)}"}],
-                "complexity": None,
-                "engine": "SQLGlot-AST-Scanner"
-            }
+        except Exception:
+            return DiagnosticResult.blocked(
+                agent_message=(
+                    "SQL verification could not be completed because the query "
+                    "could not be parsed."
+                ),
+                developer_fields={
+                    "constraint_id": CONSTRAINT_PARSE_ERROR,
+                    "is_valid": False,
+                    "issues": [{"severity": "CRITICAL", "description": "SQL Syntax Error"}],
+                    "engine": "SQLGlot-AST-Scanner",
+                },
+            )
 
-        # 2. Command Type Check
-        issues.extend(self._check_command_type(parsed_query))
-        
-        # 3. Column Security Check
-        issues.extend(self._check_column_access(parsed_query))
-        
-        # 4. Injection Pattern Detection
-        issues.extend(self._check_injection_patterns(parsed_query, query))
-        
-        # 5. Complexity Analysis
-        complexity = self._analyze_complexity(parsed_query)
-        
-        # 6. Complexity Limit Checks
-        if check_complexity:
-            issues.extend(self._check_complexity_limits(complexity))
-        
-        # 7. Schema Validation
-        if schema_ddl:
-            issues.extend(self._validate_against_schema(parsed_query, schema_ddl, dialect))
+        # 2..7 Analysis — unexpected failures fail closed as execution errors.
+        try:
+            issues: List[SQLIssue] = []
+
+            issues.extend(self._check_command_type(parsed_query))
+            issues.extend(self._check_column_access(parsed_query))
+            issues.extend(self._check_injection_patterns(parsed_query, query))
+
+            complexity = self._analyze_complexity(parsed_query)
+
+            if check_complexity:
+                issues.extend(self._check_complexity_limits(complexity))
+
+            if schema_ddl:
+                issues.extend(self._validate_against_schema(parsed_query, schema_ddl, dialect))
+        except Exception:
+            return DiagnosticResult.blocked(
+                agent_message=(
+                    "SQL verification could not be completed due to an internal error."
+                ),
+                developer_fields={
+                    "constraint_id": CONSTRAINT_EXECUTION_ERROR,
+                    "is_valid": False,
+                },
+            )
 
         # Determine overall safety
         critical_count = sum(1 for i in issues if i.severity == "CRITICAL")
         warning_count = sum(1 for i in issues if i.severity == "WARNING")
-        
-        is_safe = critical_count == 0
-        
-        return {
-            "is_safe": is_safe,
-            "status": "SAFE" if is_safe else "BLOCKED",
+
+        is_valid = critical_count == 0
+
+        developer_fields: Dict[str, Any] = {
+            "constraint_id": CONSTRAINT_SQL_VALID if is_valid else CONSTRAINT_MALICIOUS,
+            "is_valid": is_valid,
+            "malicious_classification": not is_valid,
             "issues": [
                 {
                     "severity": i.severity,
                     "type": i.issue_type,
                     "description": i.description,
-                    "recommendation": i.recommendation
+                    "recommendation": i.recommendation,
                 }
                 for i in issues
             ],
@@ -212,11 +241,47 @@ class SQLVerifier:
                 "column_count": complexity.column_count,
                 "condition_count": complexity.condition_count,
                 "aggregate_count": complexity.aggregate_count,
-                "estimated_cost": round(complexity.estimated_cost, 2)
+                "estimated_cost": round(complexity.estimated_cost, 2),
             },
             "critical_count": critical_count,
             "warning_count": warning_count,
-            "engine": "SQLGlot-AST-Scanner"
+            "engine": "SQLGlot-AST-Scanner",
+        }
+
+        evidence = self._build_evidence(parsed_query, query, dialect, schema_ddl)
+
+        if is_valid:
+            return DiagnosticResult.verified(
+                agent_message="The SQL query passed verification and is safe to execute.",
+                developer_fields=developer_fields,
+                evidence=evidence,
+            )
+
+        # Proven malicious: still VERIFIED with proof_ref — the AST proves the verdict.
+        # Consumers gate on is_valid / malicious_classification, not status (issue #253).
+        return DiagnosticResult.verified(
+            agent_message=(
+                "The SQL query failed security verification and is not safe to execute."
+            ),
+            developer_fields=developer_fields,
+            evidence=evidence,
+        )
+
+    def _build_evidence(
+        self,
+        parsed_query: exp.Expression,
+        query: str,
+        dialect: str,
+        schema_ddl: Optional[str],
+    ) -> Dict[str, Any]:
+        """Build deterministic, JSON-serializable proof evidence bound to the AST."""
+        return {
+            "engine": "SQLAst-Scanner",
+            "query": query,
+            "dialect": dialect,
+            "schema_ddl": schema_ddl if schema_ddl else None,
+            "normalized_sql": parsed_query.sql(),
+            "ast": parsed_query.dump(),
         }
     
     # =========================================================================
@@ -519,40 +584,71 @@ class SQLVerifier:
         queries: List[str], 
         schema_ddl: Optional[str] = None,
         dialect: str = "postgres"
-    ) -> Dict[str, Any]:
+    ) -> DiagnosticResult:
         """
         Verify multiple SQL queries.
+
+        Returns a single :class:`DiagnosticResult`. Status is VERIFIED because the batch
+        analysis completed deterministically; individual verdicts live in
+        ``developer_fields.results`` (each a serialized per-query DiagnosticResult) and
+        ``developer_fields.summary``. ``developer_fields.is_valid`` is True only when
+        every query is safe.
 
         Args:
             queries: List of SQL queries to verify.
             schema_ddl: Optional DDL schema.
             dialect: SQL dialect.
 
-        Returns:
-            Dict containing batch results and summary statistics.
-
         Example:
             >>> result = verifier.verify_batch(["SELECT * FROM table1", "DROP TABLE table2"])
-            >>> print(result["summary"]["blocked"])
+            >>> print(result.developer_fields["summary"]["blocked"])
             1
         """
-        results = []
-        
+        items: List[Dict[str, Any]] = []
         for query in queries:
-            result = self.verify_sql(query, schema_ddl, dialect)
-            results.append({
-                "query": query[:100] + "..." if len(query) > 100 else query,
-                **result
-            })
-        
-        return {
-            "results": results,
-            "summary": {
-                "total": len(queries),
-                "safe": sum(1 for r in results if r["status"] == "SAFE"),
-                "blocked": sum(1 for r in results if r["status"] == "BLOCKED"),
-                "syntax_errors": sum(1 for r in results if r["status"] == "SYNTAX_ERROR"),
-                "total_critical": sum(r["critical_count"] for r in results if "critical_count" in r),
-                "total_warnings": sum(r["warning_count"] for r in results if "warning_count" in r)
-            }
+            dr = self.verify_sql(query, schema_ddl, dialect)
+            serialized = dr.to_dict()
+            serialized["query"] = query[:100] + "..." if len(query) > 100 else query
+            items.append(serialized)
+
+        total = len(queries)
+        is_valid_all = all(item["developer_fields"]["is_valid"] for item in items)
+        safe = sum(1 for item in items if item["status"] == "VERIFIED" and item["developer_fields"]["is_valid"])
+        blocked_invalid = sum(1 for item in items if item["developer_fields"]["is_valid"] is False)
+
+        summary = {
+            "total": total,
+            "safe": safe,
+            "unsafe": blocked_invalid,
+            "total_critical": sum(
+                item["developer_fields"].get("critical_count", 0) for item in items
+            ),
+            "total_warnings": sum(
+                item["developer_fields"].get("warning_count", 0) for item in items
+            ),
         }
+
+        evidence = {
+            "engine": "SQLAst-Scanner",
+            "dialect": dialect,
+            "count": total,
+            "queries": [item["query"] for item in items],
+        }
+
+        batch_fields: Dict[str, Any] = {
+            "constraint_id": CONSTRAINT_SQL_VALID if is_valid_all else CONSTRAINT_MALICIOUS,
+            "is_valid": is_valid_all,
+            "malicious_classification": not is_valid_all,
+            "results": items,
+            "summary": summary,
+            "engine": "SQLGlot-AST-Scanner",
+        }
+
+        return DiagnosticResult.verified(
+            agent_message=(
+                "Batch SQL verification completed. Inspect developer_fields for "
+                "per-query verdicts."
+            ),
+            developer_fields=batch_fields,
+            evidence=evidence,
+        )

--- a/src/qwed_new/core/sql_verifier.py
+++ b/src/qwed_new/core/sql_verifier.py
@@ -172,7 +172,9 @@ class SQLVerifier:
         - Malicious query → VERIFIED as-malicious (``is_valid`` False,
                           ``developer_fields.malicious_classification`` True). Proving a query
                           is malicious IS a successful proof, so it is not BLOCKED (issue #253).
-                          Malicious is the only unsafe case that retains a proof_ref.
+                          Malicious is the only unsafe case that retains a proof_ref — unless
+                          the DDL schema also fails to parse, in which case the incomplete
+                          analysis is BLOCKED (schema_parse_error takes precedence).
         - Complexity-limit violation → BLOCKED (``sql_verifier.complexity_limit_exceeded``)
         - DDL schema parse failure → BLOCKED (``sql_verifier.schema_parse_error``)
         - Parse error     → BLOCKED (``sql_verifier.parse_error``)
@@ -254,10 +256,13 @@ class SQLVerifier:
         )
         schema_parse_failed = any(i.issue_type == "schema_parse_error" for i in issues)
 
-        if malicious:
-            constraint_id = CONSTRAINT_MALICIOUS
-        elif schema_parse_failed:
+        # A DDL schema parse failure means the analysis is incomplete: an authoritative
+        # proof must never be generated from an incomplete analysis (fail-closed), so it
+        # takes precedence over malice detection below (Sentry HIGH).
+        if schema_parse_failed:
             constraint_id = CONSTRAINT_SCHEMA_PARSE_ERROR
+        elif malicious:
+            constraint_id = CONSTRAINT_MALICIOUS
         elif not is_valid:
             constraint_id = CONSTRAINT_COMPLEXITY_LIMIT_EXCEEDED
         else:
@@ -301,7 +306,12 @@ class SQLVerifier:
             check_complexity=check_complexity,
         )
 
-        if is_valid or malicious:
+        # Only fully-analysed results may be VERIFIED: sql_valid and proven-malicious.
+        # Schema-parse failures (incomplete analysis), complexity-limit violations, and
+        # other admission failures are BLOCKED (non-authoritative, no proof_ref). A
+        # malicious query whose schema also fails to parse is BLOCKED because the
+        # analysis is incomplete (constraint_id is schema_parse_error in that case).
+        if is_valid or constraint_id == CONSTRAINT_MALICIOUS:
             return DiagnosticResult.verified(
                 agent_message=(
                     "The SQL query passed verification and is safe to execute."
@@ -312,10 +322,6 @@ class SQLVerifier:
                 evidence=evidence,
             )
 
-        # Complexity-limit, schema-parse, and other non-malicious admission failures
-        # are BLOCKED (non-authoritative, no proof_ref): they are not proofs of malice
-        # and theorem-providing engines must not emit an authoritative VERIFIED for an
-        # incomplete analysis. Only proven-malicious results may carry a proof_ref.
         return DiagnosticResult.blocked(
             agent_message="The SQL query failed admission checks and is not safe to execute.",
             developer_fields=developer_fields,

--- a/src/qwed_new/core/sql_verifier.py
+++ b/src/qwed_new/core/sql_verifier.py
@@ -9,6 +9,8 @@ Provides AST-based SQL analysis to prevent:
 5. Schema violations
 """
 
+import hashlib
+
 import sqlglot
 from sqlglot import exp, parse_one
 from typing import List, Dict, Any, Optional, Set
@@ -22,7 +24,20 @@ CONSTRAINT_EXECUTION_ERROR = "sql_verifier.execution_error"
 CONSTRAINT_CONNECTION_FAILURE = "sql_verifier.connection_failure"
 CONSTRAINT_SQL_VALID = "sql_verifier.sql_valid"
 CONSTRAINT_MALICIOUS = "sql_verifier.malicious"
+CONSTRAINT_COMPLEXITY_LIMIT_EXCEEDED = "sql_verifier.complexity_limit_exceeded"
 CONSTRAINT_BATCH_BLOCKED = "sql_verifier.batch_blocked"
+
+# Issue types that prove malice. Resource-limit violations (complexity_*) are CRITICAL
+# admission failures but are NOT evidence of malicious intent, so they must never set
+# developer_fields.malicious_classification (CodeRabbit).
+MALICIOUS_ISSUE_TYPES = frozenset({
+    "destructive_command",
+    "admin_command",
+    "sensitive_column_access",
+    "injection_tautology",
+    "injection_or_true",
+    "stacked_queries",
+})
 
 
 def _available_expression_types(*names: str) -> Set[type]:
@@ -226,10 +241,24 @@ class SQLVerifier:
 
         is_valid = critical_count == 0
 
+        # Malice proof requires true-malice issue types; a resource-limit violation
+        # is a CRITICAL admission failure but NOT evidence of malicious intent.
+        malicious = any(
+            i.severity == "CRITICAL" and i.issue_type in MALICIOUS_ISSUE_TYPES
+            for i in issues
+        )
+
+        if malicious:
+            constraint_id = CONSTRAINT_MALICIOUS
+        elif not is_valid:
+            constraint_id = CONSTRAINT_COMPLEXITY_LIMIT_EXCEEDED
+        else:
+            constraint_id = CONSTRAINT_SQL_VALID
+
         developer_fields: Dict[str, Any] = {
-            "constraint_id": CONSTRAINT_SQL_VALID if is_valid else CONSTRAINT_MALICIOUS,
+            "constraint_id": constraint_id,
             "is_valid": is_valid,
-            "malicious_classification": not is_valid,
+            "malicious_classification": malicious,
             "issues": [
                 {
                     "severity": i.severity,
@@ -657,7 +686,8 @@ class SQLVerifier:
         malicious = sum(
             1
             for item in items
-            if item["status"] == "VERIFIED" and item["developer_fields"].get("is_valid") is False
+            if item["status"] == "VERIFIED"
+            and item["developer_fields"].get("malicious_classification") is True
         )
         blocked = total - safe - malicious
 
@@ -683,11 +713,19 @@ class SQLVerifier:
             "dialect": dialect,
             "count": total,
             "queries": [item["query"] for item in items],
+            # Full-query digests bind the complete query text (the truncated
+            # ``queries`` field is display-only and not proof-bearing).
+            "query_digests": [
+                hashlib.sha256(query.encode("utf-8")).hexdigest() for query in queries
+            ],
+            "schema_ddl": schema_ddl if schema_ddl else None,
             "verdicts": [
                 {"status": item["status"], "is_valid": item["developer_fields"].get("is_valid")}
                 for item in items
             ],
             "allow_destructive": self.allow_destructive,
+            "blocked_columns": sorted(self.blocked_columns),
+            "limits": {key: self.limits[key] for key in sorted(self.limits)},
         }
 
         if is_valid_all:

--- a/tests/test_cli_test_command.py
+++ b/tests/test_cli_test_command.py
@@ -70,17 +70,32 @@ def test_run_full_engine_tests_returns_expected_shape(
     mock_sql.verify_sql.side_effect = [
         DiagnosticResult.verified(
             "The SQL query passed verification and is safe to execute.",
-            {"constraint_id": "sql_verifier.sql_valid", "is_valid": True, "critical_count": 0},
+            {
+                "constraint_id": "sql_verifier.sql_valid",
+                "is_valid": True,
+                "malicious_classification": False,
+                "critical_count": 0,
+            },
             {"query": "q"},
         ),
         DiagnosticResult.verified(
             "The SQL query failed security verification and is not safe to execute.",
-            {"constraint_id": "sql_verifier.malicious", "is_valid": False, "critical_count": 1},
+            {
+                "constraint_id": "sql_verifier.malicious",
+                "is_valid": False,
+                "malicious_classification": True,
+                "critical_count": 1,
+            },
             {"query": "q"},
         ),
         DiagnosticResult.verified(
             "The SQL query failed security verification and is not safe to execute.",
-            {"constraint_id": "sql_verifier.malicious", "is_valid": False, "critical_count": 1},
+            {
+                "constraint_id": "sql_verifier.malicious",
+                "is_valid": False,
+                "malicious_classification": True,
+                "critical_count": 1,
+            },
             {"query": "q"},
         ),
     ]

--- a/tests/test_cli_test_command.py
+++ b/tests/test_cli_test_command.py
@@ -60,7 +60,7 @@ def test_run_full_engine_tests_returns_expected_shape(
         {"status": "CORRECTION_NEEDED", "calculated_value": 4.0},
         {"status": "VERIFIED", "calculated_value": 994010994.0},
     ]
-    from qwed_new.core.diagnostics import DiagnosticStatus, DiagnosticResult
+    from qwed_new.core.diagnostics import DiagnosticResult
 
     mock_logic.verify_logic.side_effect = [
         DiagnosticResult.unverifiable("UNSAT", {"constraint_id": "test.mock"}),
@@ -68,9 +68,21 @@ def test_run_full_engine_tests_returns_expected_shape(
         DiagnosticResult.unverifiable("UNSAT", {"constraint_id": "test.mock"}),
     ]
     mock_sql.verify_sql.side_effect = [
-        {"status": "SAFE"},
-        {"status": "BLOCKED"},
-        {"status": "BLOCKED"},
+        DiagnosticResult.verified(
+            "The SQL query passed verification and is safe to execute.",
+            {"constraint_id": "sql_verifier.sql_valid", "is_valid": True, "critical_count": 0},
+            {"query": "q"},
+        ),
+        DiagnosticResult.verified(
+            "The SQL query failed security verification and is not safe to execute.",
+            {"constraint_id": "sql_verifier.malicious", "is_valid": False, "critical_count": 1},
+            {"query": "q"},
+        ),
+        DiagnosticResult.verified(
+            "The SQL query failed security verification and is not safe to execute.",
+            {"constraint_id": "sql_verifier.malicious", "is_valid": False, "critical_count": 1},
+            {"query": "q"},
+        ),
     ]
     mock_code.verify_code.side_effect = [
         {"status": "SAFE"},

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -282,11 +282,8 @@ def test_verify_fact_unknown_result(client):
 
 
 def test_verify_sql_unverified(client):
-    """Engine is_valid=False (VERIFIED-as-malicious) -> endpoint returns verdict unchanged.
-
-    Asserts the malicious constraints (constraint_id + is_valid + proof_ref) so the test
-    fails if verify_sql raised and the generic error handler returned the same status.
-    """
+    """Engine is_valid=False (VERIFIED-as-malicious) -> endpoint returns verdict unchanged
+    but exposes an explicit BLOCKED admission decision (Greptile P1)."""
     malicious = DiagnosticResult.verified(
         "The SQL query failed security verification and is not safe to execute.",
         {"constraint_id": "sql_verifier.malicious", "is_valid": False},
@@ -301,10 +298,13 @@ def test_verify_sql_unverified(client):
 
         assert response.status_code == 200
         data = response.json()
+        # Verification truth preserved unchanged.
         assert data["status"] == "VERIFIED"
         assert data["proof_ref"] is not None
         assert data["developer_fields"]["constraint_id"] == "sql_verifier.malicious"
         assert data["developer_fields"]["is_valid"] is False
+        # Admission is a SEPARATE, fail-closed decision.
+        assert data["admission"] == "BLOCKED"
 
 
 def test_verify_sql_engine_blocked_passthrough(client):
@@ -325,10 +325,11 @@ def test_verify_sql_engine_blocked_passthrough(client):
         assert data["status"] == "BLOCKED"
         assert data["proof_ref"] is None
         assert data["developer_fields"]["constraint_id"] == "sql_verifier.parse_error"
+        assert data["admission"] == "BLOCKED"
 
 
 def test_verify_sql_safe_passthrough_verified(client):
-    """Engine returns VERIFIED-as-safe -> endpoint returns VERIFIED."""
+    """Engine returns VERIFIED-as-safe -> endpoint returns VERIFIED and ADMIT."""
     safe = DiagnosticResult.verified(
         "The SQL query passed verification and is safe to execute.",
         {"constraint_id": "sql_verifier.sql_valid", "is_valid": True},
@@ -346,6 +347,7 @@ def test_verify_sql_safe_passthrough_verified(client):
         assert data["status"] == "VERIFIED"
         assert data["proof_ref"] is not None
         assert data["developer_fields"]["is_valid"] is True
+        assert data["admission"] == "ADMIT"
 
 
 def test_verify_code_missing_code_returns_400(client):

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -282,8 +282,13 @@ def test_verify_fact_unknown_result(client):
 
 
 def test_verify_sql_unverified(client):
-    """Cover SQL endpoint is_valid=False -> BLOCKED."""
-    with patch("qwed_new.core.sql_verifier.SQLVerifier.verify_sql", return_value={"is_valid": False, "message": "Invalid syntax"}), \
+    """Engine is_valid=False (VERIFIED-as-malicious) -> endpoint downgrades to BLOCKED."""
+    malicious = DiagnosticResult.verified(
+        "The SQL query failed security verification and is not safe to execute.",
+        {"constraint_id": "sql_verifier.malicious", "is_valid": False},
+        {"query": "SELECT *"},
+    )
+    with patch("qwed_new.core.sql_verifier.SQLVerifier.verify_sql", return_value=malicious), \
          patch("qwed_new.api.main.check_rate_limit"):
         response = client.post(
             "/verify/sql",

--- a/tests/test_diagnostic_coverage.py
+++ b/tests/test_diagnostic_coverage.py
@@ -282,7 +282,11 @@ def test_verify_fact_unknown_result(client):
 
 
 def test_verify_sql_unverified(client):
-    """Engine is_valid=False (VERIFIED-as-malicious) -> endpoint downgrades to BLOCKED."""
+    """Engine is_valid=False (VERIFIED-as-malicious) -> endpoint returns verdict unchanged.
+
+    Asserts the malicious constraints (constraint_id + is_valid + proof_ref) so the test
+    fails if verify_sql raised and the generic error handler returned the same status.
+    """
     malicious = DiagnosticResult.verified(
         "The SQL query failed security verification and is not safe to execute.",
         {"constraint_id": "sql_verifier.malicious", "is_valid": False},
@@ -297,8 +301,51 @@ def test_verify_sql_unverified(client):
 
         assert response.status_code == 200
         data = response.json()
+        assert data["status"] == "VERIFIED"
+        assert data["proof_ref"] is not None
+        assert data["developer_fields"]["constraint_id"] == "sql_verifier.malicious"
+        assert data["developer_fields"]["is_valid"] is False
+
+
+def test_verify_sql_engine_blocked_passthrough(client):
+    """Engine returns BLOCKED (e.g. parse error) -> endpoint passes it through as BLOCKED."""
+    blocked = DiagnosticResult.blocked(
+        "SQL verification could not be completed because the query could not be parsed.",
+        {"constraint_id": "sql_verifier.parse_error", "is_valid": False},
+    )
+    with patch("qwed_new.core.sql_verifier.SQLVerifier.verify_sql", return_value=blocked), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/sql",
+            json={"query": "SELECT *", "schema_ddl": "CREATE TABLE t (id int)", "type": "postgres"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
         assert data["status"] == "BLOCKED"
         assert data["proof_ref"] is None
+        assert data["developer_fields"]["constraint_id"] == "sql_verifier.parse_error"
+
+
+def test_verify_sql_safe_passthrough_verified(client):
+    """Engine returns VERIFIED-as-safe -> endpoint returns VERIFIED."""
+    safe = DiagnosticResult.verified(
+        "The SQL query passed verification and is safe to execute.",
+        {"constraint_id": "sql_verifier.sql_valid", "is_valid": True},
+        {"query": "SELECT *"},
+    )
+    with patch("qwed_new.core.sql_verifier.SQLVerifier.verify_sql", return_value=safe), \
+         patch("qwed_new.api.main.check_rate_limit"):
+        response = client.post(
+            "/verify/sql",
+            json={"query": "SELECT *", "schema_ddl": "CREATE TABLE t (id int)", "type": "postgres"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "VERIFIED"
+        assert data["proof_ref"] is not None
+        assert data["developer_fields"]["is_valid"] is True
 
 
 def test_verify_code_missing_code_returns_400(client):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -20,9 +20,11 @@ import hashlib
 import unittest
 from unittest.mock import MagicMock, patch
 from src.qwed_new.core.diagnostics import (
+    AdmissionDecision,
     DiagnosticStatus,
     DiagnosticResult,
     AdvisoryCheck,
+    admission_decision,
     compute_proof_ref,
     enforce_trust_decision,
 )
@@ -1125,6 +1127,49 @@ class TestEnforceTrustDecision(unittest.TestCase):
 
         self.assertTrue(r.is_fail_closed)
         self.assertEqual(r.developer_fields.get("constraint_id"), "trust_gate.claims_missing")
+
+
+class TestAdmissionDecision(unittest.TestCase):
+    """admission_decision maps verification truth to a fail-closed admission outcome."""
+
+    def test_safe_verified_is_admit(self):
+        dr = DiagnosticResult.verified(
+            "safe", {"is_valid": True}, {"q": "SELECT *"}
+        )
+        self.assertIs(admission_decision(dr), AdmissionDecision.ADMIT)
+
+    def test_verified_malicious_is_blocked(self):
+        dr = DiagnosticResult.verified(
+            "malicious",
+            {"is_valid": False, "malicious_classification": True},
+            {"q": "DROP TABLE users"},
+        )
+        self.assertIs(admission_decision(dr), AdmissionDecision.BLOCKED)
+
+    def test_fail_closed_is_blocked(self):
+        blocked = DiagnosticResult.blocked("parse error", {"is_valid": False})
+        self.assertIs(admission_decision(blocked), AdmissionDecision.BLOCKED)
+
+        unverifiable = DiagnosticResult.unverifiable("unsure", {"is_valid": False})
+        self.assertIs(admission_decision(unverifiable), AdmissionDecision.BLOCKED)
+
+    def test_verified_without_is_valid_defaults_admit(self):
+        # A bare authoritative VERIFIED (no is_valid flag) is admitted, matching
+        # engine behavior where is_valid is domain-specific.
+        dr = DiagnosticResult.verified("ok", {}, {"q": "SELECT *"})
+        self.assertIs(admission_decision(dr), AdmissionDecision.ADMIT)
+
+    def test_does_not_mutate_verification_result(self):
+        fields = {"is_valid": False, "malicious_classification": True}
+        dr = DiagnosticResult.verified(
+            "malicious", fields, {"q": "DROP TABLE users"}
+        )
+        original_status = dr.status
+        original_proof = dr.proof_ref
+        admission_decision(dr)
+        self.assertEqual(dr.status, original_status)
+        self.assertEqual(dr.proof_ref, original_proof)
+        self.assertIs(dr.developer_fields.get("is_valid"), False)
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1153,11 +1153,16 @@ class TestAdmissionDecision(unittest.TestCase):
         unverifiable = DiagnosticResult.unverifiable("unsure", {"is_valid": False})
         self.assertIs(admission_decision(unverifiable), AdmissionDecision.BLOCKED)
 
-    def test_verified_without_is_valid_defaults_admit(self):
-        # A bare authoritative VERIFIED (no is_valid flag) is admitted, matching
-        # engine behavior where is_valid is domain-specific.
+    def test_verified_without_is_valid_is_blocked(self):
+        # A VERIFIED result with no explicit is_valid=True must not be admitted:
+        # the proof proves the verdict, not that SQL is safe. Fail closed (CodeRabbit).
         dr = DiagnosticResult.verified("ok", {}, {"q": "SELECT *"})
-        self.assertIs(admission_decision(dr), AdmissionDecision.ADMIT)
+        self.assertIs(admission_decision(dr), AdmissionDecision.BLOCKED)
+
+    def test_verified_malformed_is_valid_is_blocked(self):
+        # A malformed (non-boolean) is_valid value is not admitted.
+        dr = DiagnosticResult.verified("ok", {"is_valid": "true"}, {"q": "SELECT *"})
+        self.assertIs(admission_decision(dr), AdmissionDecision.BLOCKED)
 
     def test_does_not_mutate_verification_result(self):
         fields = {"is_valid": False, "malicious_classification": True}

--- a/tests/test_sql_safety.py
+++ b/tests/test_sql_safety.py
@@ -299,7 +299,15 @@ def test_sql_verifier_empty_batch_is_not_authoritative():
     assert result.developer_fields.get("is_valid") is False
     assert result.developer_fields.get("malicious_classification") is False
     assert result.developer_fields.get("constraint_id") == "sql_verifier.empty_batch"
-    assert result.developer_fields["summary"]["total"] == 0
+    assert result.developer_fields["results"] == []
+    summary = result.developer_fields["summary"]
+    assert summary["total"] == 0
+    assert summary["safe"] == 0
+    assert summary["unsafe"] == 0
+    assert summary["malicious"] == 0
+    assert summary["blocked"] == 0
+    assert summary["total_critical"] == 0
+    assert summary["total_warnings"] == 0
 
 
 def test_sql_verifier_malicious_classification_requires_malice_proof():

--- a/tests/test_sql_safety.py
+++ b/tests/test_sql_safety.py
@@ -267,11 +267,39 @@ def test_sql_verifier_complexity_violation_is_not_malicious():
     result = verifier.verify_sql(
         "SELECT u.id FROM users u JOIN orders o ON u.id = o.uid JOIN items i ON i.id = o.item_id"
     )
-    assert result.status is DiagnosticStatus.VERIFIED
+    assert result.status is DiagnosticStatus.BLOCKED
+    assert result.proof_ref is None
     assert result.developer_fields.get("is_valid") is False
     assert result.developer_fields.get("critical_count") == 1
     assert result.developer_fields.get("malicious_classification") is False
     assert result.developer_fields.get("constraint_id") == "sql_verifier.complexity_limit_exceeded"
+
+
+def test_sql_verifier_schema_parse_failure_is_blocked():
+    """Unparseable DDL blocks with a dedicated constraint, never a VERIFIED result."""
+    verifier = SQLVerifier()
+
+    result = verifier.verify_sql(
+        "SELECT name FROM users", schema_ddl="CREATE TABLE users (id INT, name TEXT"
+    )
+    assert result.status is DiagnosticStatus.BLOCKED
+    assert result.proof_ref is None
+    assert result.developer_fields.get("is_valid") is False
+    assert result.developer_fields.get("constraint_id") == "sql_verifier.schema_parse_error"
+    assert result.developer_fields.get("malicious_classification") is False
+
+
+def test_sql_verifier_empty_batch_is_not_authoritative():
+    """An empty batch must never produce an authoritative VERIFIED result."""
+    verifier = SQLVerifier()
+
+    result = verifier.verify_batch([])
+    assert result.status is DiagnosticStatus.BLOCKED
+    assert result.proof_ref is None
+    assert result.developer_fields.get("is_valid") is False
+    assert result.developer_fields.get("malicious_classification") is False
+    assert result.developer_fields.get("constraint_id") == "sql_verifier.empty_batch"
+    assert result.developer_fields["summary"]["total"] == 0
 
 
 def test_sql_verifier_malicious_classification_requires_malice_proof():

--- a/tests/test_sql_safety.py
+++ b/tests/test_sql_safety.py
@@ -1,4 +1,3 @@
-import pytest
 import sys
 import os
 
@@ -6,90 +5,151 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 from qwed_new.core.sql_verifier import SQLVerifier
+from qwed_new.core.diagnostics import DiagnosticStatus
+
+
+def _issues(result):
+    return result.developer_fields.get("issues", [])
+
 
 def test_sql_verifier_destructive_commands():
     verifier = SQLVerifier()
-    
-    # DROP should be blocked
+
+    # DROP is proven malicious -> VERIFIED-as-malicious (not BLOCKED), is_valid False
     result = verifier.verify_sql("DROP TABLE users")
-    assert result["is_safe"] is False
-    assert result["status"] == "BLOCKED"
-    # Check that there's an issue about destructive command
-    assert any("Destructive" in str(issue.get("description", issue)) or 
+    assert result.status is DiagnosticStatus.VERIFIED
+    assert result.developer_fields.get("is_valid") is False
+    assert result.developer_fields.get("malicious_classification") is True
+    assert result.proof_ref is not None
+    assert any("Destructive" in str(issue.get("description", issue)) or
                "destructive" in str(issue.get("type", issue))
-               for issue in result["issues"])
-    
+               for issue in _issues(result))
+
     # TRUNCATE should be blocked
     result = verifier.verify_sql("TRUNCATE TABLE logs")
-    assert result["is_safe"] is False
-    assert any("Destructive" in str(issue.get("description", issue)) or 
+    assert result.developer_fields.get("is_valid") is False
+    assert any("Destructive" in str(issue.get("description", issue)) or
                "destructive" in str(issue.get("type", issue)) or
                "admin" in str(issue.get("type", issue))
-               for issue in result["issues"])
+               for issue in _issues(result))
 
-    # SET ROLE should remain blocked as an administrative command
+    # SET ROLE should remain identified as an administrative command
     result = verifier.verify_sql("SET ROLE app_reader")
-    assert result["is_safe"] is False
+    assert result.developer_fields.get("is_valid") is False
     assert any(
         "Administrative" in str(issue.get("description", issue))
         or "admin" in str(issue.get("type", issue)).lower()
-        for issue in result["issues"]
+        for issue in _issues(result)
     )
+
 
 def test_sql_verifier_sensitive_columns():
     verifier = SQLVerifier()
-    
-    # Accessing password_hash should be blocked
+
+    # Accessing password_hash should be flagged
     result = verifier.verify_sql("SELECT email, password_hash FROM users")
-    assert result["is_safe"] is False
+    assert result.developer_fields.get("is_valid") is False
     # Check for sensitive column issue
     assert any("password_hash" in str(issue.get("description", issue)) or
                "sensitive" in str(issue.get("type", issue)).lower()
-               for issue in result["issues"])
-    
-    # Accessing salary should be blocked
+               for issue in _issues(result))
+
+    # Accessing salary should be flagged
     result = verifier.verify_sql("SELECT name FROM employees WHERE salary > 1000")
-    assert result["is_safe"] is False
+    assert result.developer_fields.get("is_valid") is False
     assert any("salary" in str(issue.get("description", issue)) or
                "sensitive" in str(issue.get("type", issue)).lower()
-               for issue in result["issues"])
+               for issue in _issues(result))
+
 
 def test_sql_verifier_injection_patterns():
     verifier = SQLVerifier()
-    
+
     # Tautology injection (OR 1=1)
     result = verifier.verify_sql("SELECT * FROM users WHERE id = 1 OR 1=1")
-    assert result["is_safe"] is False
+    assert result.developer_fields.get("is_valid") is False
     # Check for tautology or injection issue
     assert any("tautology" in str(issue.get("description", issue)).lower() or
                "tautology" in str(issue.get("type", issue)).lower() or
                "injection" in str(issue.get("type", issue)).lower()
-               for issue in result["issues"])
-    
+               for issue in _issues(result))
+
     # Another tautology (a=a)
     result = verifier.verify_sql("SELECT * FROM users WHERE 'a' = 'a'")
-    assert result["is_safe"] is False
+    assert result.developer_fields.get("is_valid") is False
     assert any("tautology" in str(issue.get("description", issue)).lower() or
                "tautology" in str(issue.get("type", issue)).lower()
-               for issue in result["issues"])
+               for issue in _issues(result))
+
 
 def test_sql_verifier_safe_query():
     verifier = SQLVerifier()
-    
+
     # Normal SELECT should pass
     result = verifier.verify_sql("SELECT id, name, email FROM users WHERE id = 123")
-    assert result["is_safe"] is True
-    assert result["status"] == "SAFE"
+    assert result.status is DiagnosticStatus.VERIFIED
+    assert result.developer_fields.get("is_valid") is True
+    assert result.proof_ref is not None
+
 
 def test_sql_verifier_schema_validation():
     verifier = SQLVerifier()
     schema = "CREATE TABLE users (id INT, name TEXT, email TEXT);"
-    
+
     # Table exists in schema
     result = verifier.verify_sql("SELECT name FROM users", schema_ddl=schema)
-    assert result["is_safe"] is True
-    
+    assert result.developer_fields.get("is_valid") is True
+
     # Table does NOT exist in schema - this generates WARNING not CRITICAL
     result = verifier.verify_sql("SELECT name FROM passwords", schema_ddl=schema)
-    # Schema validation issues are warnings, not critical
-    assert result["warning_count"] > 0 or result["is_safe"] is False
+    assert result.developer_fields.get("warning_count", 0) > 0 or result.developer_fields.get("is_valid") is False
+
+
+def test_sql_verifier_parse_error_is_blocked():
+    verifier = SQLVerifier()
+
+    result = verifier.verify_sql("SELEC FROM users WHERE")  # unparseable
+    assert result.status is DiagnosticStatus.BLOCKED
+    assert result.proof_ref is None
+    assert result.constraint_id == "sql_verifier.parse_error"
+    assert result.developer_fields.get("is_valid") is False
+    # agent_message must be sanitized (no raw SQLGlot output leaked)
+    assert "sql" in result.agent_message.lower()
+
+
+def test_sql_verifier_agent_message_is_sanitized():
+    """agent_message must never leak detection rules, rule IDs, or the raw query."""
+    verifier = SQLVerifier()
+
+    result = verifier.verify_sql("SELECT password_hash FROM users; DROP TABLE users;")
+    # Rule-level detail lives in developer_fields, not agent_message.
+    for secret in ("password_hash", "destructive_command", "injection", "DROP"):
+        assert secret.lower() not in result.agent_message.lower()
+    assert "verify" in result.agent_message.lower() or "safe" in result.agent_message.lower()
+
+
+def test_sql_verifier_malicious_proof_is_deterministic():
+    """Same malicious input yields the same proof_ref (verdict is bound to the AST)."""
+    verifier = SQLVerifier()
+    a = verifier.verify_sql("SELECT * FROM users; DROP TABLE users;")
+    b = verifier.verify_sql("SELECT * FROM users; DROP TABLE users;")
+    assert a.status is DiagnosticStatus.VERIFIED
+    assert a.developer_fields.get("is_valid") is False
+    assert a.proof_ref == b.proof_ref
+    assert a.proof_ref.startswith("sha256:")
+
+
+def test_sql_verifier_batch_returns_diagnostic_result():
+    verifier = SQLVerifier()
+
+    result = verifier.verify_batch(
+        ["SELECT id FROM users WHERE id = 1", "DROP TABLE users; DROP TABLE orders;"]
+    )
+    assert result.status is DiagnosticStatus.VERIFIED
+    assert result.proof_ref is not None
+    assert result.developer_fields.get("is_valid") is False
+    summary = result.developer_fields["summary"]
+    assert summary["total"] == 2
+    assert summary["safe"] == 1
+    assert summary["unsafe"] == 1
+    assert len(result.developer_fields["results"]) == 2

--- a/tests/test_sql_safety.py
+++ b/tests/test_sql_safety.py
@@ -258,3 +258,68 @@ def test_sql_verifier_execution_error_is_blocked(monkeypatch):
     assert result.proof_ref is None
     assert result.constraint_id == "sql_verifier.execution_error"
     assert "internal" in result.agent_message.lower()
+
+
+def test_sql_verifier_complexity_violation_is_not_malicious():
+    """A resource-limit (complexity) violation is CRITICAL but NOT malicious (CodeRabbit)."""
+    verifier = SQLVerifier(complexity_limits={"max_tables": 1})
+
+    result = verifier.verify_sql(
+        "SELECT u.id FROM users u JOIN orders o ON u.id = o.uid JOIN items i ON i.id = o.item_id"
+    )
+    assert result.status is DiagnosticStatus.VERIFIED
+    assert result.developer_fields.get("is_valid") is False
+    assert result.developer_fields.get("critical_count") == 1
+    assert result.developer_fields.get("malicious_classification") is False
+    assert result.developer_fields.get("constraint_id") == "sql_verifier.complexity_limit_exceeded"
+
+
+def test_sql_verifier_malicious_classification_requires_malice_proof():
+    """Injection/stacking prove malice; complexity alone never does."""
+    verifier = SQLVerifier(complexity_limits={"max_tables": 1})
+
+    injection = verifier.verify_sql("SELECT * FROM users WHERE id = 1 OR 1=1")
+    assert injection.developer_fields.get("malicious_classification") is True
+    assert injection.developer_fields.get("constraint_id") == "sql_verifier.malicious"
+
+    stacked = verifier.verify_sql("SELECT * FROM users; DROP TABLE users;")
+    assert stacked.developer_fields.get("malicious_classification") is True
+    assert stacked.developer_fields.get("constraint_id") == "sql_verifier.malicious"
+
+
+def test_sql_verifier_batch_counts_complexity_as_blocked_not_malicious():
+    """Batch summary: complexity-only items land in 'blocked', not 'malicious'."""
+    verifier = SQLVerifier(complexity_limits={"max_tables": 1})
+
+    result = verifier.verify_batch(
+        [
+            "SELECT id FROM users WHERE id = 1",
+            "SELECT u.id FROM users u JOIN orders o ON u.id = o.uid JOIN items i ON i.id = o.item_id",
+        ]
+    )
+    assert result.status is DiagnosticStatus.BLOCKED
+    assert result.developer_fields.get("malicious_classification") is False
+    assert result.developer_fields.get("constraint_id") == "sql_verifier.batch_blocked"
+    summary = result.developer_fields["summary"]
+    assert summary["total"] == 2
+    assert summary["safe"] == 1
+    assert summary["malicious"] == 0
+    assert summary["blocked"] == 1
+
+
+def test_sql_verifier_batch_evidence_binds_policy_and_schema():
+    """Batch proof_ref changes when limits, blocked columns, or schema change."""
+    queries = ["SELECT id FROM users WHERE id = 1"]
+
+    base = SQLVerifier().verify_batch(queries)
+    relimited = SQLVerifier(complexity_limits={"max_tables": 5}).verify_batch(queries)
+    reblocked = SQLVerifier(blocked_columns={"custom_secret_col"}).verify_batch(queries)
+    with_schema = SQLVerifier().verify_batch(
+        queries, schema_ddl="CREATE TABLE users (id INT, name TEXT);"
+    )
+
+    assert base.proof_ref is not None
+    assert base.proof_ref == SQLVerifier().verify_batch(queries).proof_ref
+    assert base.proof_ref != relimited.proof_ref
+    assert base.proof_ref != reblocked.proof_ref
+    assert base.proof_ref != with_schema.proof_ref

--- a/tests/test_sql_safety.py
+++ b/tests/test_sql_safety.py
@@ -102,7 +102,8 @@ def test_sql_verifier_schema_validation():
 
     # Table does NOT exist in schema - this generates WARNING not CRITICAL
     result = verifier.verify_sql("SELECT name FROM passwords", schema_ddl=schema)
-    assert result.developer_fields.get("warning_count", 0) > 0 or result.developer_fields.get("is_valid") is False
+    assert result.developer_fields.get("warning_count", 0) > 0
+    assert result.developer_fields.get("is_valid") is True
 
 
 def test_sql_verifier_parse_error_is_blocked():
@@ -139,17 +140,121 @@ def test_sql_verifier_malicious_proof_is_deterministic():
     assert a.proof_ref.startswith("sha256:")
 
 
-def test_sql_verifier_batch_returns_diagnostic_result():
+def test_sql_verifier_proof_is_bound_to_the_verdict():
+    """Opposite verdicts on one AST must not share a proof_ref."""
+    strict = SQLVerifier(allow_destructive=False)
+    permissive = SQLVerifier(allow_destructive=True)
+
+    blocked_verdict = strict.verify_sql("DROP TABLE users")
+    allowed_verdict = permissive.verify_sql("DROP TABLE users")
+
+    assert blocked_verdict.developer_fields.get("is_valid") is False
+    assert allowed_verdict.developer_fields.get("is_valid") is True
+    assert blocked_verdict.proof_ref != allowed_verdict.proof_ref
+
+
+def test_sql_verifier_batch_separates_blocked_from_malicious():
+    """Batch summary separates parse-blocked items from proven-malicious items."""
+    verifier = SQLVerifier()
+
+    result = verifier.verify_batch(
+        [
+            "SELECT id FROM users WHERE id = 1",
+            "DROP TABLE users; DROP TABLE orders;",
+            "SELEC FROM users WHERE",  # unparseable -> BLOCKED
+        ]
+    )
+    assert result.status is DiagnosticStatus.BLOCKED
+    summary = result.developer_fields["summary"]
+    assert summary["total"] == 3
+    assert summary["safe"] == 1
+    assert summary["malicious"] == 1
+    assert summary["unsafe"] == 1
+    assert summary["blocked"] == 1
+
+
+def test_sql_verifier_batch_all_safe_is_verified():
+    verifier = SQLVerifier()
+
+    result = verifier.verify_batch(
+        ["SELECT id FROM users WHERE id = 1", "SELECT name FROM users WHERE id = 2"]
+    )
+    assert result.status is DiagnosticStatus.VERIFIED
+    assert result.proof_ref is not None
+    assert result.developer_fields.get("is_valid") is True
+    summary = result.developer_fields["summary"]
+    assert summary["total"] == 2
+    assert summary["safe"] == 2
+    assert summary["unsafe"] == 0
+    assert summary["malicious"] == 0
+    assert summary["blocked"] == 0
+    assert "blocked" in summary  # documented summary field is present
+
+
+def test_sql_verifier_batch_with_malicious_is_blocked():
+    """A batch containing a malicious query is non-authoritative (BLOCKED)."""
     verifier = SQLVerifier()
 
     result = verifier.verify_batch(
         ["SELECT id FROM users WHERE id = 1", "DROP TABLE users; DROP TABLE orders;"]
     )
-    assert result.status is DiagnosticStatus.VERIFIED
-    assert result.proof_ref is not None
+    assert result.status is DiagnosticStatus.BLOCKED
+    assert result.proof_ref is None
     assert result.developer_fields.get("is_valid") is False
+    assert result.developer_fields.get("malicious_classification") is True
+    assert result.developer_fields.get("constraint_id") == "sql_verifier.malicious"
     summary = result.developer_fields["summary"]
     assert summary["total"] == 2
     assert summary["safe"] == 1
     assert summary["unsafe"] == 1
+    assert summary["malicious"] == 1
+    assert summary["blocked"] == 0
     assert len(result.developer_fields["results"]) == 2
+
+
+def test_sql_verifier_batch_with_parse_error_is_not_malicious():
+    """A parse-error batch must never be classified as malicious (Greptile P1)."""
+    verifier = SQLVerifier()
+
+    result = verifier.verify_batch(["SELECT id FROM users WHERE id = 1", "SELEC FROM users WHERE"])
+    assert result.status is DiagnosticStatus.BLOCKED
+    assert result.proof_ref is None
+    assert result.developer_fields.get("malicious_classification") is False
+    assert result.developer_fields.get("constraint_id") == "sql_verifier.batch_blocked"
+    summary = result.developer_fields["summary"]
+    assert summary["total"] == 2
+    assert summary["safe"] == 1
+    assert summary["unsafe"] == 0
+    assert summary["malicious"] == 0
+    assert summary["blocked"] == 1
+
+
+def test_sql_verifier_batch_with_execution_error_is_not_malicious(monkeypatch):
+    """A batch with an internal analysis failure is blocked, not malicious (Greptile P1)."""
+    verifier = SQLVerifier()
+
+    def _boom(self, parsed_query):
+        raise RuntimeError("internal analysis failure")
+
+    monkeypatch.setattr(SQLVerifier, "_check_column_access", _boom)
+    result = verifier.verify_batch(["SELECT id FROM users WHERE id = 1", "SELECT name FROM users"])
+    assert result.status is DiagnosticStatus.BLOCKED
+    assert result.developer_fields.get("malicious_classification") is False
+    summary = result.developer_fields["summary"]
+    assert summary["safe"] == 0
+    assert summary["malicious"] == 0
+    assert summary["blocked"] == 2
+
+
+def test_sql_verifier_execution_error_is_blocked(monkeypatch):
+    verifier = SQLVerifier()
+
+    def _boom(self, parsed_query):
+        raise RuntimeError("internal analysis failure")
+
+    monkeypatch.setattr(SQLVerifier, "_check_column_access", _boom)
+    result = verifier.verify_sql("SELECT id FROM users WHERE id = 1")
+    assert result.status is DiagnosticStatus.BLOCKED
+    assert result.proof_ref is None
+    assert result.constraint_id == "sql_verifier.execution_error"
+    assert "internal" in result.agent_message.lower()

--- a/tests/test_sql_safety.py
+++ b/tests/test_sql_safety.py
@@ -289,6 +289,23 @@ def test_sql_verifier_schema_parse_failure_is_blocked():
     assert result.developer_fields.get("malicious_classification") is False
 
 
+def test_sql_verifier_malicious_with_schema_parse_failure_is_blocked():
+    """Malice does not override an incomplete analysis: malicious + schema parse
+    failure is BLOCKED (schema_parse_error), never VERIFIED (Sentry HIGH)."""
+    verifier = SQLVerifier()
+
+    result = verifier.verify_sql(
+        "SELECT * FROM users; DROP TABLE users;",
+        schema_ddl="CREATE TABLE users (id INT, name TEXT",
+    )
+    assert result.status is DiagnosticStatus.BLOCKED
+    assert result.proof_ref is None
+    assert result.developer_fields.get("is_valid") is False
+    assert result.developer_fields.get("constraint_id") == "sql_verifier.schema_parse_error"
+    # The malicious finding is preserved as truth even though admission is blocked.
+    assert result.developer_fields.get("malicious_classification") is True
+
+
 def test_sql_verifier_empty_batch_is_not_authoritative():
     """An empty batch must never produce an authoritative VERIFIED result."""
     verifier = SQLVerifier()


### PR DESCRIPTION
## **User description**
Closes #253.

- verify_sql now returns DiagnosticResult. Proven-malicious queries move off BLOCKED onto VERIFIED-as-malicious (developer_fields.is_valid=False, malicious_classification=True; proof_ref from AST evidence) per issue #253.
- Parse error -> BLOCKED (sql_verifier.parse_error); internal failure -> BLOCKED (sql_verifier.execution_error).
- agent_message sanitized (no rule IDs / raw SQLGlot output); rule detail in developer_fields.
- verify_batch returns a DiagnosticResult carrying per-query results/summary.
- /verify/sql endpoint consumes the DiagnosticResult with fail-closed downgrade for is_valid=False.
- Updated core/batch.py, qwed_sdk/cli.py, and SQL/API/CLI tests.

Full suite: 1768 passed, 102 skipped. ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQL verification now reports structured safety statuses, issue details, constraints, and query evidence.
  * Batch checks provide per-query diagnostics and aggregate counts for safe, malicious, blocked, and warning outcomes.
  * Verification distinguishes schema and complexity policy violations.
  * Added clear admission outcomes indicating whether verified SQL is allowed or blocked.

* **Bug Fixes**
  * Invalid, malicious, unparseable, or failed SQL consistently fails closed.
  * Diagnostic results and malicious-query verdicts remain distinct and are preserved through verification.

* **Tests**
  * Expanded coverage for errors, evidence, diagnostics, admission decisions, and batch verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Return fail-closed, structured SQL verification results

### What Changed
- SQL verification now returns structured results that distinguish safe queries, proven-malicious queries, parse failures, internal errors, schema failures, and complexity violations.
- Proven-malicious queries retain a verification proof while being marked invalid; API consumers separately receive an explicit `BLOCKED` admission decision.
- Batch verification reports safe, malicious, and blocked queries separately, rejects empty batches, and blocks the entire batch when any query is unsafe or cannot be verified.
- SQL errors and agent-facing messages are sanitized, while detailed findings remain available for developers.
- Verification evidence is tied to the query, verdict, schema, and active security policy so it cannot be reused under different conditions.
- Updated API, batch processing, CLI checks, and regression coverage for the new outcomes.

### Impact
`✅ Fail-closed SQL admission`
`✅ Clear separation of malicious queries and verification errors`
`✅ Actionable batch safety summaries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
