### PR TITLE
release: v7.0.0 — Full DiagnosticResult Engine Conformance (pre-release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the QWED Protocol will be documented in this file.
 
 ## [Unreleased]
 
+## [7.0.0] - 2026-08-08
+
 ### Engine Migration to DiagnosticResult (Meta #216)
 
 #### SchemaVerifier → DiagnosticResult (#255)
@@ -45,6 +47,23 @@ All notable changes to the QWED Protocol will be documented in this file.
 - **Stats `observed_result` is JSON-safe** — a non-serializable sandbox result (e.g. a DataFrame) is coerced before entering `developer_fields`, so a legitimate `UNVERIFIABLE` verdict can no longer be silently downgraded to `BLOCKED` when the trust gate snapshots developer fields.
 
 > **Breaking wire change:** `POST /verify/stats` now returns the unified `DiagnosticResult` schema (`status` / `agent_message` / `developer_fields` / `proof_ref`) instead of the legacy `{"status": "SUCCESS" | "ERROR" | "BLOCKED", "result": ..., "code": ...}` shape. Successful execution now reports `status = "UNVERIFIABLE"` with the observed value in `developer_fields.observed_result` — execution success alone is never presented as a proven claim.
+
+#### Version Propagation
+- `qwed` (PyPI): `6.0.0` -> `7.0.0`
+- `qwed_sdk` (Python): `6.0.0` -> `7.0.0`
+- `@qwed-ai/sdk` (NPM): `6.0.0` -> `7.0.0`
+- `qwed` (crates.io/Rust): `6.0.0` -> `7.0.0`
+- API version marker: `6.0.0` -> `7.0.0`
+- Kubernetes deployment image: `6.0.0` -> `7.0.0`
+- Deployment docs version references updated
+
+#### Included PRs (merged after v6.0.0)
+- `#294` feat(core): migrate SchemaVerifier to DiagnosticResult (#255)
+- `#295` fix(sql): migrate SQLVerifier to DiagnosticResult (#253)
+- `#296` feat(core): migrate CodeVerifier and SecureCodeExecutor to DiagnosticResult (#254)
+- `#297` feat(stats): migrate StatsVerifier.verify_stats to DiagnosticResult (#256)
+
+## [6.0.0] - 2026-08-02
 
 ### Trust Boundary Completion (Epic #263)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ All notable changes to the QWED Protocol will be documented in this file.
 - `@qwed-ai/sdk` (NPM): `6.0.0` -> `7.0.0`
 - `qwed` (crates.io/Rust): `6.0.0` -> `7.0.0`
 - API version marker: `6.0.0` -> `7.0.0`
-- Kubernetes deployment image: `6.0.0` -> `7.0.0`
+- Kubernetes deployment image: stays pinned to the published `6.0.0` here; bumped to `7.0.0` only after the release publishes the image (avoids `ImagePullBackOff`)
 - Deployment docs version references updated
 
 #### Included PRs (merged after v6.0.0)
@@ -62,6 +62,9 @@ All notable changes to the QWED Protocol will be documented in this file.
 - `#295` fix(sql): migrate SQLVerifier to DiagnosticResult (#253)
 - `#296` feat(core): migrate CodeVerifier and SecureCodeExecutor to DiagnosticResult (#254)
 - `#297` feat(stats): migrate StatsVerifier.verify_stats to DiagnosticResult (#256)
+
+#### GitHub Action
+- The **QWED Verification GitHub Action** is maintained in its own repository — [`QWED-AI/qwed-verification-action`](https://github.com/QWED-AI/qwed-verification-action). It wraps the `qwedai/qwed-verification` Docker image and is versioned independently of this release; it is **not** published from this repository, so no action release is part of v7.0.0.
 
 ## [6.0.0] - 2026-08-02
 

--- a/README.md
+++ b/README.md
@@ -670,14 +670,16 @@ We are building the **Universal Verification Standard** for the agentic web.
 - **✔ DiagnosticResult model** — Unified 3-layer diagnostic contract, `proof_ref` authority bit, `AdvisoryCheck` pattern (v5.2.0)
 - **✔ SymbolicVerifier migration** — First fully `DiagnosticResult`-conformant engine; serves as reference implementation (v5.3.0)
 - **✔ Trust Boundary Completion** — All verification API pathways return `DiagnosticResult` + route through `enforce_trust_decision`; mandatory attestation at the admission boundary; VERIFIED requires a non-empty, evidence-bound proof_ref (v6.0.0)
+- **✔ Full DiagnosticResult engine conformance** — All 13 verification engines return `DiagnosticResult`; execution is never conflated with verification; fail-closed batch verification (META #216, v7.0.0)
 
 ### In Progress
 
-- **Remaining verification engines (#216)** — Migrating the remaining engines to the `DiagnosticResult` model (API surfaces are conformant; engine-internal migration continues under META #216)
+- **Deterministic statistical claim evaluation (#298)** — the path for statistical claims to reach `VERIFIED` with a deterministic, evidence-bound proof
+- **DataFrame schema validation (#299)** — deterministic schema validation for the stats engine
 
 ### Planned
 
-- **v6.1+:** QWED Client-Side (WebAssembly), Distributed Verification Network, cross-ecosystem proof exchange
+- **v7.x+:** QWED Client-Side (WebAssembly), Distributed Verification Network, cross-ecosystem proof exchange
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 
 `v7.0.0` completes **Meta #216** — every verification engine now returns the unified `DiagnosticResult`, and execution is never conflated with verification.
 
-- **All 13 engines conform to `DiagnosticResult`** — Schema, SQL, Code, and Stats join the previously-migrated Logic, Fact, Image, Reasoning, Consensus, Symbolic, and Math engines on the 3-layer contract (status / `agent_message` / `developer_fields` / `proof_ref`)
+- **All 13 engines conform to `DiagnosticResult`** — Schema, SQL, Code, SecureCodeExecutor, and Stats join the previously-migrated Math, Logic, Symbolic, Fact, Image, Graph, Reasoning, and Consensus engines on the 3-layer contract (status / `agent_message` / `developer_fields` / `proof_ref`)
 - **Execution ≠ verification** — a successful computation reports `UNVERIFIABLE`, never `VERIFIED`; `VERIFIED` requires a deterministic, evidence-bound `proof_ref`
 - **Separation of truth and admission** — `POST /verify/code` reports proven-unsafe code as `VERIFIED`-as-unsafe with `admission = BLOCKED`; admission is driven by `admission` / `is_valid`, never by `status` alone
 - **Fail-closed batch verification** — fact / image / SQL / code batches are authoritative only when every item is proven; any refuted or blocked item fails the whole batch closed
@@ -670,7 +670,7 @@ We are building the **Universal Verification Standard** for the agentic web.
 - **✔ DiagnosticResult model** — Unified 3-layer diagnostic contract, `proof_ref` authority bit, `AdvisoryCheck` pattern (v5.2.0)
 - **✔ SymbolicVerifier migration** — First fully `DiagnosticResult`-conformant engine; serves as reference implementation (v5.3.0)
 - **✔ Trust Boundary Completion** — All verification API pathways return `DiagnosticResult` + route through `enforce_trust_decision`; mandatory attestation at the admission boundary; VERIFIED requires a non-empty, evidence-bound proof_ref (v6.0.0)
-- **✔ Full DiagnosticResult engine conformance** — All 13 verification engines return `DiagnosticResult`; execution is never conflated with verification; fail-closed batch verification (META #216, v7.0.0)
+- **✔ Full DiagnosticResult engine conformance** — All 13 engines return `DiagnosticResult`; execution is never conflated with verification; fail-closed batch verification (META #216, v7.0.0)
 
 ### In Progress
 

--- a/README.md
+++ b/README.md
@@ -61,19 +61,18 @@
 
 ---
 
-## Release Update: v6.0.0 — Trust Boundary Completion
+## Release Update: v7.0.0 — Full DiagnosticResult Engine Conformance
 
-`v6.0.0` completes the **Trust Boundary Completion epic** — every verification API pathway now returns `DiagnosticResult` and routes through `enforce_trust_decision` (12/12 sub-issues, #263).
+`v7.0.0` completes **Meta #216** — every verification engine now returns the unified `DiagnosticResult`, and execution is never conflated with verification.
 
-- **All `/verify/*` endpoints return `DiagnosticResult`** — unified 3-layer response contract (status / `agent_message` / `developer_fields` / `proof_ref`) across every verification surface
-- **Mandatory attestation in the control plane** — `require_attestation=True`, attestations issued and verified at the admission boundary; enforcement result drives the response status
-- **VERIFIED is a protocol guarantee** — VERIFIED requires a non-empty `proof_ref` bound to the deterministic evidence; heuristic/advisory analysis reports `UNVERIFIABLE` with structured `advisory_checks`
-- **Architecture contract** — API = observation surface (honest witness), Control Plane = admission authority (judge); rules now codify this separation (#13-15)
-- **Security hardening** — TOCTOU closure in `enforce_trust_decision`, tenant-isolated verification cache, attestation signature-verified before claim decode, Unicode-normalized agent state
+- **All 13 engines conform to `DiagnosticResult`** — Schema, SQL, Code, and Stats join the previously-migrated Logic, Fact, Image, Reasoning, Consensus, Symbolic, and Math engines on the 3-layer contract (status / `agent_message` / `developer_fields` / `proof_ref`)
+- **Execution ≠ verification** — a successful computation reports `UNVERIFIABLE`, never `VERIFIED`; `VERIFIED` requires a deterministic, evidence-bound `proof_ref`
+- **Separation of truth and admission** — `POST /verify/code` reports proven-unsafe code as `VERIFIED`-as-unsafe with `admission = BLOCKED`; admission is driven by `admission` / `is_valid`, never by `status` alone
+- **Fail-closed batch verification** — fact / image / SQL / code batches are authoritative only when every item is proven; any refuted or blocked item fails the whole batch closed
 
-> ⚠️ **Breaking change:** `/verify/*` responses now use the `DiagnosticResult` schema. Consumers parsing the previous ad-hoc dict format must migrate to the unified contract.
+> ⚠️ **Breaking change:** `POST /verify/code` now returns `status = "VERIFIED"` for proven-unsafe code (previously `BLOCKED`), and `POST /verify/stats` reports execution success as `UNVERIFIABLE` (previously `VERIFIED`). Consumers branching on `status` for safety gating must use the `admission` / `is_valid` fields.
 
-If you're upgrading from `v5.3.x`, review the [changelog](CHANGELOG.md) for the full migration notes.
+If you're upgrading from `v6.0.x`, review the [changelog](CHANGELOG.md) for the full migration notes.
 
 ---
 

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: qwed-core
-          image: docker.io/qwedai/qwed-verification:6.0.0
+          image: docker.io/qwedai/qwed-verification:7.0.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -17,7 +17,10 @@ spec:
     spec:
       containers:
         - name: qwed-core
-          image: docker.io/qwedai/qwed-verification:7.0.0
+          # Pinned to the last PUBLISHED image. Bump to 7.0.0 only after the
+          # v7.0.0 release publishes docker.io/qwedai/qwed-verification:7.0.0
+          # (referencing an unpublished tag causes ImagePullBackOff).
+          image: docker.io/qwedai/qwed-verification:6.0.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -23,7 +23,7 @@ A `Dockerfile` is provided in the root directory. It builds the QWED core servic
 
 ```bash
 # Build the image manually
-docker build -t qweda/qwed-verification:6.0.0 .
+docker build -t qwedai/qwed-verification:7.0.0 .
 ```
 
 ### Docker Compose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed"
-version = "6.0.0"
+version = "7.0.0"
 description = "The Deterministic Verification Protocol for AI - 11 verification engines for math, logic, code, SQL, facts, images, and more. Now with Agentic Security Guards."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/qwed_sdk/__init__.py
+++ b/qwed_sdk/__init__.py
@@ -37,7 +37,7 @@ from qwed_sdk.models import (
     VerificationType,
 )
 
-__version__ = "6.0.0"
+__version__ = "7.0.0"
 __all__ = [
     "QWEDClient",
     "QWEDAsyncClient",

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qwed"
-version = "6.0.0"
+version = "7.0.0"
 edition = "2021"
 authors = ["QWED-AI"]
 description = "Rust SDK for QWED Verification Protocol"

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -11,7 +11,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qwed = "6.0.0"
+qwed = "7.0.0"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "6.0.0",
+    "version": "7.0.0",
     "description": "TypeScript SDK for QWED Verification Protocol",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -38,7 +38,7 @@ TenantDependency = Annotated[TenantContext, Depends(get_current_tenant)]
 SessionDependency = Annotated[Session, Depends(get_session)]
 AgentTokenHeader = Annotated[str, Header(...)]
 
-APP_VERSION = "6.0.0"
+APP_VERSION = "7.0.0"
 
 app = FastAPI(
     title="QWED API",


### PR DESCRIPTION
Pre-release PR for **v7.0.0**. This PR prepares the release: it reconciles the
changelog, propagates the version across all SDKs/registries, and updates the
README. It contains **no engine/API logic changes** — those shipped in
#294 / #295 / #296 / #297.

## Why v7.0.0 (major)
The public verification contract changed observably after v6.0.0:
- `POST /verify/code` returns `status = "VERIFIED"` for proven-unsafe code
  (previously `BLOCKED`); admission is driven by `admission` / `is_valid`.
- `POST /verify/stats` reports execution success as `UNVERIFIABLE`
  (previously `VERIFIED`).
Breaking changes to the public contract ⇒ new major under SemVer, and the
version now matches the CHANGELOG's "breaking wire change" language.

## What this PR does
**1. CHANGELOG reconciliation**
- Restores the `## [6.0.0]` section (Trust Boundary Completion) that was folded
  into `[Unreleased]` on main.
- Adds `## [7.0.0]` for the Meta #216 engine migration, with a Version
  Propagation block and the Included PRs list.

**2. Version propagation `6.0.0 → 7.0.0`**
- `pyproject.toml` (PyPI `qwed`)
- `qwed_sdk/__init__.py` (Python SDK)
- `src/qwed_new/api/main.py` (`APP_VERSION`)
- `sdk-ts/package.json` (npm `@qwed-ai/sdk`)
- `sdk-rust/Cargo.toml` + `sdk-rust/README.md` (crates.io `qwed`)
- `deploy/kubernetes/deployment.yaml` (image tag)
- `docs/DEPLOYMENT.md` (also fixes `qweda/` → `qwedai/`)

**3. README**
- Release banner → v7.0.0; roadmap marks Meta #216 engine conformance complete.

## Included PRs (merged after v6.0.0)
- #294 SchemaVerifier (#255)
- #295 SQLVerifier (#253)
- #296 CodeVerifier + SecureCodeExecutor (#254)
- #297 StatsVerifier (#256) + fact/image batch

## Notes
- Docker image tag and Go SDK version are derived from the git tag at release
  time (no manual change).
- `sdk-ts/package-lock.json` is gitignored and regenerated by the publish workflow.
- The **GitHub Action is NOT in scope** — it lives in the separate
  `qwed-verification-action` repo (independent versioning; wraps the Docker
  image), so no action bump or release step here.
- The v7.0.0 release note will mirror the CHANGELOG `[7.0.0]` section above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced version 7.0.0 with unified diagnostic results across all verification engines.
  * Separated execution from verification and clarified truth versus admission outcomes.
  * Added fail-closed behavior for batch verification.
  * Completed full engine conformance and updated verification status handling.

* **Documentation**
  * Updated release notes, SDK installation guidance, deployment instructions, roadmap, and breaking-change information.

* **Chores**
  * Updated application and SDK versions to 7.0.0, while retaining the currently published deployment image until the new release is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->