### PR TITLE
spec: QWED Verification Context Specification v1.0 (Draft)

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest pytest-cov pytest-asyncio
-          pip install PyYAML matplotlib docker cryptography
+          pip install PyYAML matplotlib docker cryptography jsonschema
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install -e .
           

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dev = [
     "freezegun>=1.4.0",
     "matplotlib>=3.7.0",
     "docker>=7.0.0",
+    "jsonschema>=4.20.0",
 ]
 
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,41 @@
+# QWED Specifications
+
+Normative specifications for the QWED verification protocol. These documents
+define *what verification is* — the vocabulary and contracts every QWED engine,
+SDK, API, CLI, and client speaks.
+
+The ontology is frozen by the [Architecture Decision Records](../docs/adr/README.md);
+the specifications here make it precise and machine-readable.
+
+## Versions
+
+| Version | Document | Status |
+|---------|----------|--------|
+| [v1.0](v1.0/verification-context.md) | Verification Context | Draft |
+
+## Verification Context v1.0
+
+The **Verification Context** is the atomic record of a QWED verification: the
+object of verification plus the context required to interpret, reproduce, and
+trust it.
+
+- **Prose specification:** [`v1.0/verification-context.md`](v1.0/verification-context.md)
+- **Machine-readable schema:** [`v1.0/schemas/verification-context.schema.json`](v1.0/schemas/verification-context.schema.json)
+- **Conformance tests:** [`../tests/test_verification_context_spec.py`](../tests/test_verification_context_spec.py)
+
+### Core vocabulary
+
+- **Verified Object** — the formal statement being evaluated.
+- **Verification Context** — interpretation + proof + evidence + decision.
+- **Verdict** — `VERIFIED` / `UNVERIFIABLE` / `BLOCKED`.
+- **Admission** — `ADMIT` / `DENY` (truth ≠ admission).
+- **proof_ref** — an evidence commitment, not a mathematical proof.
+- **Formalization** — the NL→formal mapping; exposed but never verified.
+
+## Versioning policy
+
+- Specifications are versioned (`v1.0`, `v1.1`, …). Breaking changes bump the
+  major version; additive changes bump the minor version.
+- Each version is immutable once released. New versions live in a new directory
+  (`v1.1/`, `v2.0/`, …).
+- Conformance is defined per version in the specification's Conformance section.

--- a/spec/v1.0/schemas/verification-context.schema.json
+++ b/spec/v1.0/schemas/verification-context.schema.json
@@ -152,18 +152,22 @@
       "properties": {
         "theory": {
           "type": "string",
+          "minLength": 1,
           "description": "The theory / axiom set the statement is interpreted under."
         },
         "logic": {
           "type": "string",
+          "minLength": 1,
           "description": "The logic the statement is expressed in."
         },
         "dialect": {
           "type": "string",
+          "minLength": 1,
           "description": "The dialect (e.g. SQL dialect) where applicable."
         },
         "algebra_domain": {
           "type": "string",
+          "minLength": 1,
           "description": "The algebra domain (e.g. real-closed field) where applicable."
         }
       }

--- a/spec/v1.0/schemas/verification-context.schema.json
+++ b/spec/v1.0/schemas/verification-context.schema.json
@@ -205,7 +205,10 @@
         },
         "configuration": {
           "type": "object",
-          "description": "Solver flags, timeouts, resource limits, and options that affect the outcome."
+          "description": "Solver flags, timeouts, resource limits, and options that affect the outcome. Values MUST be within the canonical encoding's JSON domain.",
+          "additionalProperties": {
+            "$ref": "#/$defs/EncodableValue"
+          }
         },
         "theory_scope": {
           "type": "string",
@@ -230,7 +233,10 @@
       "properties": {
         "evidence": {
           "type": "object",
-          "description": "The retained evidence the proof_ref commits to."
+          "description": "The retained evidence the proof_ref commits to. Values MUST be within the canonical encoding's JSON domain; integers MUST be exactly representable as IEEE-754 doubles.",
+          "additionalProperties": {
+            "$ref": "#/$defs/EncodableValue"
+          }
         },
         "proof_ref": {
           "oneOf": [
@@ -251,6 +257,37 @@
           "$ref": "#/$defs/Admission"
         }
       }
+    },
+    "EncodableNumber": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": -9007199254740992,
+          "maximum": 9007199254740992
+        },
+        {
+          "type": "number",
+          "not": { "type": "integer" }
+        }
+      ],
+      "description": "A JSON number within the canonical encoding's IEEE-754 domain. Integer values MUST be exactly representable as IEEE-754 doubles."
+    },
+    "EncodableValue": {
+      "anyOf": [
+        { "type": "null" },
+        { "type": "boolean" },
+        { "type": "string" },
+        { "$ref": "#/$defs/EncodableNumber" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EncodableValue" }
+        },
+        {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/EncodableValue" }
+        }
+      ],
+      "description": "A JSON value that can be canonicalized and bound by proof_ref."
     }
   }
 }

--- a/spec/v1.0/schemas/verification-context.schema.json
+++ b/spec/v1.0/schemas/verification-context.schema.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qwed.dev/schemas/verification-context/v1.0",
+  "title": "QWED Verification Context",
+  "description": "QWED Verification Context v1.0 — the object of verification plus the context required to interpret, reproduce, and trust the verification. Derived from ADR-001..005.",
+  "type": "object",
+  "required": ["spec_version", "object", "context", "verdict"],
+  "additionalProperties": false,
+  "properties": {
+    "spec_version": {
+      "const": "1.0",
+      "description": "The specification version this document conforms to."
+    },
+    "object": {
+      "$ref": "#/$defs/VerifiedObject"
+    },
+    "context": {
+      "$ref": "#/$defs/VerificationContext"
+    },
+    "verdict": {
+      "$ref": "#/$defs/Verdict"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "verdict": { "const": "VERIFIED" } },
+        "required": ["verdict"]
+      },
+      "then": {
+        "properties": {
+          "context": {
+            "properties": {
+              "evidence": {
+                "required": ["proof_ref"],
+                "properties": {
+                  "proof_ref": { "$ref": "#/$defs/ProofRef" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "verdict": { "enum": ["UNVERIFIABLE", "BLOCKED"] } },
+        "required": ["verdict"]
+      },
+      "then": {
+        "properties": {
+          "context": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "proof_ref": { "type": "null" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "Verdict": {
+      "enum": ["VERIFIED", "UNVERIFIABLE", "BLOCKED"],
+      "description": "The truth verdict (ADR-001, ADR-002). VERIFIED requires a proof_ref; UNVERIFIABLE and BLOCKED are fail-closed and carry no proof."
+    },
+    "Admission": {
+      "enum": ["ADMIT", "DENY"],
+      "description": "The safe-to-run decision (ADR-003). Separate from the truth verdict: truth != admission. Execution and shipping gate exclusively on admission == ADMIT."
+    },
+    "ProofRef": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$",
+      "description": "An evidence commitment (ADR-002): sha256 of the canonical encoding of the bound payload. Provides evidence integrity and reproducibility. It is NOT itself the mathematical proof."
+    },
+    "VerifiedObject": {
+      "type": "object",
+      "required": ["formal_statement"],
+      "additionalProperties": false,
+      "description": "The object of verification (ADR-001): the formal statement being evaluated.",
+      "properties": {
+        "formal_statement": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The formal statement being verified — the object of verification."
+        },
+        "formalization": {
+          "$ref": "#/$defs/Formalization"
+        }
+      }
+    },
+    "Formalization": {
+      "type": "object",
+      "required": ["verified"],
+      "additionalProperties": false,
+      "description": "The NL -> formal mapping (ADR-004). Exposed for confirmation but NEVER itself verified.",
+      "properties": {
+        "source_query": {
+          "type": "string",
+          "description": "The original natural-language query."
+        },
+        "translator": {
+          "type": "string",
+          "description": "The translator that produced the formal statement (untrusted, outside the trust boundary)."
+        },
+        "translation_confidence": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Non-authoritative translation confidence note."
+        },
+        "verified": {
+          "const": false,
+          "description": "The formalization is never verified (ADR-004). Always false."
+        }
+      }
+    },
+    "VerificationContext": {
+      "type": "object",
+      "required": ["interpretation", "proof", "evidence", "decision"],
+      "additionalProperties": false,
+      "description": "The Verification Context (ADR-002): everything required to interpret, reproduce, and trust the verification, in four layers.",
+      "properties": {
+        "interpretation": {
+          "$ref": "#/$defs/Interpretation"
+        },
+        "proof": {
+          "$ref": "#/$defs/Proof"
+        },
+        "evidence": {
+          "$ref": "#/$defs/Evidence"
+        },
+        "decision": {
+          "$ref": "#/$defs/Decision"
+        }
+      }
+    },
+    "Interpretation": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The interpretation layer (ADR-001, ADR-002): required context that gives the object meaning. A statement is only a proposition relative to a theory.",
+      "properties": {
+        "theory": {
+          "type": "string",
+          "description": "The theory / axiom set the statement is interpreted under."
+        },
+        "logic": {
+          "type": "string",
+          "description": "The logic the statement is expressed in."
+        },
+        "dialect": {
+          "type": "string",
+          "description": "The dialect (e.g. SQL dialect) where applicable."
+        },
+        "algebra_domain": {
+          "type": "string",
+          "description": "The algebra domain (e.g. real-closed field) where applicable."
+        }
+      }
+    },
+    "Proof": {
+      "type": "object",
+      "required": ["verifier", "verifier_version"],
+      "additionalProperties": false,
+      "description": "The proof/discharge layer (ADR-002): the verifier is the trusted computing base. Declares how the object was discharged and how much to trust it.",
+      "properties": {
+        "verifier": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The verifier / discharging engine (the trusted computing base)."
+        },
+        "verifier_version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The exact verifier release."
+        },
+        "configuration": {
+          "type": "object",
+          "description": "Solver flags, timeouts, resource limits, and options that affect the outcome."
+        },
+        "theory_scope": {
+          "type": "string",
+          "description": "The logic / axiom set / theory the discharge is relative to."
+        },
+        "trusted_dependencies": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Libraries and sub-components inside the trusted computing base."
+        },
+        "outcome_treatment": {
+          "type": "string",
+          "description": "How unknown/timeout/error outcomes are treated. These are never VERIFIED; they resolve to UNVERIFIABLE or BLOCKED (fail-closed)."
+        }
+      }
+    },
+    "Evidence": {
+      "type": "object",
+      "required": ["evidence"],
+      "additionalProperties": false,
+      "description": "The evidence layer (ADR-002): what was checked, plus the evidence commitment.",
+      "properties": {
+        "evidence": {
+          "type": "object",
+          "description": "The retained evidence the proof_ref commits to."
+        },
+        "proof_ref": {
+          "oneOf": [
+            { "$ref": "#/$defs/ProofRef" },
+            { "type": "null" }
+          ],
+          "description": "The evidence commitment. Non-null (sha256) iff verdict is VERIFIED; null for UNVERIFIABLE/BLOCKED."
+        }
+      }
+    },
+    "Decision": {
+      "type": "object",
+      "required": ["admission"],
+      "additionalProperties": false,
+      "description": "The decision layer (ADR-003): the safe-to-run outcome. Truth != admission.",
+      "properties": {
+        "admission": {
+          "$ref": "#/$defs/Admission"
+        }
+      }
+    }
+  }
+}

--- a/spec/v1.0/schemas/verification-context.schema.json
+++ b/spec/v1.0/schemas/verification-context.schema.json
@@ -165,6 +165,21 @@
           "minLength": 1,
           "description": "The dialect (e.g. SQL dialect) where applicable."
         },
+        "parser_version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The parser version (e.g. SQL parser) where applicable."
+        },
+        "language": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The source language (e.g. for code verification) where applicable."
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The policy version (e.g. code security policy) where applicable."
+        },
         "algebra_domain": {
           "type": "string",
           "minLength": 1,

--- a/spec/v1.0/schemas/verification-context.schema.json
+++ b/spec/v1.0/schemas/verification-context.schema.json
@@ -52,8 +52,14 @@
           "context": {
             "properties": {
               "evidence": {
+                "required": ["proof_ref"],
                 "properties": {
                   "proof_ref": { "type": "null" }
+                }
+              },
+              "decision": {
+                "properties": {
+                  "admission": { "const": "DENY" }
                 }
               }
             }
@@ -140,8 +146,9 @@
     },
     "Interpretation": {
       "type": "object",
+      "minProperties": 1,
       "additionalProperties": false,
-      "description": "The interpretation layer (ADR-001, ADR-002): required context that gives the object meaning. A statement is only a proposition relative to a theory.",
+      "description": "The interpretation layer (ADR-001, ADR-002): required context that gives the object meaning. A statement is only a proposition relative to a theory. At least one interpretation field must be present.",
       "properties": {
         "theory": {
           "type": "string",

--- a/spec/v1.0/verification-context.md
+++ b/spec/v1.0/verification-context.md
@@ -134,23 +134,24 @@ the commitment.
   bytes:
   - UTF-8 representation, **no** ASCII-escaping of non-ASCII characters
     (`ensure_ascii=False`).
-  - Object keys sorted lexicographically by Unicode code point (`sort_keys=True`).
+  - Object keys MUST be strings; non-string keys are rejected. Keys are sorted
+    by their UTF-16 big-endian byte representation (UTF-16 code-unit order), not
+    by Unicode code-point order.
   - Compact separators with no whitespace: `","` between items and `":"` between
     key and value (`separators=(",", ":")`).
-  - **Canonical numbers (normative):** numbers are serialized by this exact,
-    language-independent algorithm:
+  - **Canonical numbers (normative):** every number is an IEEE-754 double and is
+    serialized per **RFC 8785 §3.2.2** (ECMAScript `Number::toString`): the
+    shortest decimal form that round-trips the double, with fixed-point notation
+    for exponents in `[-6, 21]` and exponential notation otherwise (e.g.
+    `1e-6` → `0.000001`, `1e-7` → `1e-7`, `1e21` → `1e+21`). This makes `1`
+    and `1.0` commit identically and normalizes negative zero (`-0.0`) to `0`.
     1. **Reject non-finite values.** `NaN`, `+Infinity`, and `-Infinity` are not
       permitted in the bound payload; producers MUST fail-closed rather than
       serialize them.
-    2. **Integer-valued numbers** (integers and integer-valued floats) are
-      serialized as base-10 JSON integers with no leading zeros and no decimal
-      point or exponent; large integers use arbitrary precision. This makes `1`
-      and `1.0` commit identically and normalizes negative zero (`-0.0`) to `0`.
-    3. **Non-integer finite numbers** are serialized per **RFC 8785 §3.2.2**
-      (ECMAScript `Number::toString`): the shortest decimal form that round-trips
-      the IEEE 754 double, with fixed-point notation for exponents in `[-6, 21]`
-      and exponential notation otherwise (e.g. `1e-6` → `0.000001`, `1e-7` →
-      `1e-7`). No rounding is applied beyond the value's own double precision.
+    2. **Reject integers that are not exactly representable as IEEE-754
+      doubles.** An integer value MUST be rejected if converting it to a double
+      and back changes its value; arbitrary-precision integer serialization is
+      not permitted.
     Producers MUST NOT emit `NaN`/`Infinity` (fail-closed instead). Note that
     Python's `json.dumps` does **not** implement this number form (it emits
     `1e-07` / `1e-06`); implementations MUST use an RFC 8785-compatible number
@@ -158,7 +159,7 @@ the commitment.
   - No ambient/non-deterministic fields (wall-clock time, memory addresses,
     randomness) in the bound payload.
   The canonical encoding is RFC 8785 (JSON Canonicalization Scheme): UTF-8,
-  lexicographically sorted object keys, no insignificant whitespace, and the
+  UTF-16 big-endian sorted object keys, no insignificant whitespace, and the
   number form above.
 - **Commitment algorithm:** SHA-256 of the canonical encoding bytes, expressed as
   `sha256:<64-lowercase-hex>`.

--- a/spec/v1.0/verification-context.md
+++ b/spec/v1.0/verification-context.md
@@ -137,14 +137,26 @@ the commitment.
   - Object keys sorted lexicographically by Unicode code point (`sort_keys=True`).
   - Compact separators with no whitespace: `","` between items and `":"` between
     key and value (`separators=(",", ":")`).
-  - **Canonical numbers:** integer-valued numbers are serialized as JSON integers
-    (no trailing `.0`), so equivalent values `1` and `1.0` commit identically.
-    Non-integer numbers use the shortest round-trip decimal form. Producers MUST
-    NOT emit `NaN`/`Infinity` (fail-closed instead).
+  - **Canonical numbers (normative):** numbers are serialized by this exact,
+    language-independent algorithm:
+    1. **Reject non-finite values.** `NaN`, `+Infinity`, and `-Infinity` are not
+      permitted in the bound payload; producers MUST fail-closed rather than
+      serialize them.
+    2. **Normalize integer-valued numbers to integers.** Any number whose value is
+      an integer is serialized as a base-10 JSON integer with no leading zeros and
+      no decimal point or exponent. This makes `1` and `1.0` commit identically,
+      and normalizes negative zero (`-0.0`) to `0`. Large integers use arbitrary
+      precision (no exponent notation).
+    3. **Non-integer finite numbers** are serialized in the shortest round-trip
+      decimal form that uniquely identifies the IEEE 754 double-precision value
+      (the RFC 8785 §3.2.2 / ECMAScript `Number::toString` form). No rounding is
+      applied beyond the value's own double-precision precision.
+    Producers MUST NOT emit `NaN`/`Infinity` (fail-closed instead).
   - No ambient/non-deterministic fields (wall-clock time, memory addresses,
     randomness) in the bound payload.
   Equivalent to serializing the number-normalized bound payload with
-  `json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)`.
+  `json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
+  allow_nan=False)` over the number-normalized bound payload.
 - **Commitment algorithm:** SHA-256 of the canonical encoding bytes, expressed as
   `sha256:<64-lowercase-hex>`.
 

--- a/spec/v1.0/verification-context.md
+++ b/spec/v1.0/verification-context.md
@@ -126,17 +126,36 @@ the commitment.
   cannot include itself: hashing a payload that contains the stored digest would
   require a SHA-256 fixed point, which is not a normal content-addressed hash.
   Producers and resolvers MUST both exclude `proof_ref` from the bound payload.
-- **Canonical encoding:** the bound payload is serialized with a deterministic,
-  canonical encoding (stable key ordering, no ambient/non-deterministic fields
-  such as wall-clock time or memory addresses).
-- **Commitment algorithm:** a cryptographic hash (SHA-256) of the canonical
-  encoding, expressed as `sha256:<64-hex>`.
+- **Canonical encoding (normative, v1.0):** the bound payload is serialized as
+  JSON with **all** of the following, so any two implementations derive identical
+  bytes:
+  - UTF-8 representation, **no** ASCII-escaping of non-ASCII characters
+    (`ensure_ascii=False`).
+  - Object keys sorted lexicographically by Unicode code point (`sort_keys=True`).
+  - Compact separators with no whitespace: `","` between items and `":"` between
+    key and value (`separators=(",", ":")`).
+  - Numbers per RFC 8259; producers MUST NOT emit `NaN`/`Infinity` (fail-closed
+    instead).
+  - No ambient/non-deterministic fields (wall-clock time, memory addresses,
+    randomness) in the bound payload.
+  Equivalent to `json.dumps(payload, sort_keys=True, separators=(",", ":"),
+  ensure_ascii=False)` over the bound payload.
+- **Commitment algorithm:** SHA-256 of the canonical encoding bytes, expressed as
+  `sha256:<64-lowercase-hex>`.
+
+This is the **single canonical commitment** for the Verification Context protocol:
+producers and resolvers MUST use this exact bound payload + encoding + algorithm.
+It is distinct from any engine-internal evidence hashing (e.g. a
+`compute_proof_ref` over evidence alone); a Verification Context `proof_ref`
+always commits to the whole bound payload defined above.
 
 **Resolution and failure semantics.**
 
 - A consumer **resolves** `proof_ref` by removing `context.evidence.proof_ref`,
   re-deriving the commitment from the supplied formal statement + remaining
-  Verification Context + evidence, and comparing it to the stored value.
+  Verification Context + evidence using the canonical encoding above, and comparing
+  it to the stored value.
+- A resolver MUST reject a mismatch **before** any `ADMIT` decision.
 - **Missing, malformed, or mismatched** evidence/commitment is treated as
   **unverified (fail-closed)** — never as verified. A `proof_ref` that cannot be
   resolved confers no authority.

--- a/spec/v1.0/verification-context.md
+++ b/spec/v1.0/verification-context.md
@@ -115,9 +115,9 @@ is the **evidence commitment**.
 > mathematical proof.** *(ADR-002)*
 
 **What it binds.** `proof_ref` commits to the formal statement together with the
-complete Verification Context — interpretation, proof, and evidence — **with the
-`proof_ref` field itself excluded** (see below). Changing any bound field changes
-the commitment.
+complete Verification Context — interpretation, proof, evidence, and decision —
+**with the `proof_ref` field itself excluded** (see below). Changing any bound
+field changes the commitment.
 
 **How it is computed.**
 
@@ -137,6 +137,8 @@ the commitment.
   - Object keys MUST be strings; non-string keys are rejected. Keys are sorted
     by their UTF-16 big-endian byte representation (UTF-16 code-unit order), not
     by Unicode code-point order.
+  - Strings MUST NOT contain unpaired UTF-16 surrogates (U+D800..U+DFFF); such
+    values cannot be encoded as UTF-8 and MUST be rejected.
   - Compact separators with no whitespace: `","` between items and `":"` between
     key and value (`separators=(",", ":")`).
   - **Canonical numbers (normative):** every number is an IEEE-754 double and is
@@ -177,6 +179,10 @@ always commits to the whole bound payload defined above.
   Verification Context + evidence using the canonical encoding above, and comparing
   it to the stored value.
 - A resolver MUST reject a mismatch **before** any `ADMIT` decision.
+- A resolver MUST treat any failure while deriving the canonical encoding
+  (unencodable number, unpaired surrogate, or non-string key) as failed
+  resolution. Schema validation alone is not sufficient to accept a `VERIFIED`
+  record; the stored `proof_ref` MUST resolve.
 - **Missing, malformed, or mismatched** evidence/commitment is treated as
   **unverified (fail-closed)** — never as verified. A `proof_ref` that cannot be
   resolved confers no authority.

--- a/spec/v1.0/verification-context.md
+++ b/spec/v1.0/verification-context.md
@@ -142,21 +142,24 @@ the commitment.
     1. **Reject non-finite values.** `NaN`, `+Infinity`, and `-Infinity` are not
       permitted in the bound payload; producers MUST fail-closed rather than
       serialize them.
-    2. **Normalize integer-valued numbers to integers.** Any number whose value is
-      an integer is serialized as a base-10 JSON integer with no leading zeros and
-      no decimal point or exponent. This makes `1` and `1.0` commit identically,
-      and normalizes negative zero (`-0.0`) to `0`. Large integers use arbitrary
-      precision (no exponent notation).
-    3. **Non-integer finite numbers** are serialized in the shortest round-trip
-      decimal form that uniquely identifies the IEEE 754 double-precision value
-      (the RFC 8785 §3.2.2 / ECMAScript `Number::toString` form). No rounding is
-      applied beyond the value's own double-precision precision.
-    Producers MUST NOT emit `NaN`/`Infinity` (fail-closed instead).
+    2. **Integer-valued numbers** (integers and integer-valued floats) are
+      serialized as base-10 JSON integers with no leading zeros and no decimal
+      point or exponent; large integers use arbitrary precision. This makes `1`
+      and `1.0` commit identically and normalizes negative zero (`-0.0`) to `0`.
+    3. **Non-integer finite numbers** are serialized per **RFC 8785 §3.2.2**
+      (ECMAScript `Number::toString`): the shortest decimal form that round-trips
+      the IEEE 754 double, with fixed-point notation for exponents in `[-6, 21]`
+      and exponential notation otherwise (e.g. `1e-6` → `0.000001`, `1e-7` →
+      `1e-7`). No rounding is applied beyond the value's own double precision.
+    Producers MUST NOT emit `NaN`/`Infinity` (fail-closed instead). Note that
+    Python's `json.dumps` does **not** implement this number form (it emits
+    `1e-07` / `1e-06`); implementations MUST use an RFC 8785-compatible number
+    serializer.
   - No ambient/non-deterministic fields (wall-clock time, memory addresses,
     randomness) in the bound payload.
-  Equivalent to serializing the number-normalized bound payload with
-  `json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
-  allow_nan=False)` over the number-normalized bound payload.
+  The canonical encoding is RFC 8785 (JSON Canonicalization Scheme): UTF-8,
+  lexicographically sorted object keys, no insignificant whitespace, and the
+  number form above.
 - **Commitment algorithm:** SHA-256 of the canonical encoding bytes, expressed as
   `sha256:<64-lowercase-hex>`.
 

--- a/spec/v1.0/verification-context.md
+++ b/spec/v1.0/verification-context.md
@@ -115,11 +115,17 @@ is the **evidence commitment**.
 > mathematical proof.** *(ADR-002)*
 
 **What it binds.** `proof_ref` commits to the formal statement together with the
-complete Verification Context — interpretation, proof, and evidence. Changing any
-of these changes the commitment.
+complete Verification Context — interpretation, proof, and evidence — **with the
+`proof_ref` field itself excluded** (see below). Changing any bound field changes
+the commitment.
 
 **How it is computed.**
 
+- **Bound payload:** the formal statement + the complete Verification Context, with
+  `context.evidence.proof_ref` **removed** before serialization. The commitment
+  cannot include itself: hashing a payload that contains the stored digest would
+  require a SHA-256 fixed point, which is not a normal content-addressed hash.
+  Producers and resolvers MUST both exclude `proof_ref` from the bound payload.
 - **Canonical encoding:** the bound payload is serialized with a deterministic,
   canonical encoding (stable key ordering, no ambient/non-deterministic fields
   such as wall-clock time or memory addresses).
@@ -128,9 +134,9 @@ of these changes the commitment.
 
 **Resolution and failure semantics.**
 
-- A consumer **resolves** `proof_ref` by re-deriving the commitment from the
-  supplied formal statement + Verification Context + evidence and comparing it to
-  the stored value.
+- A consumer **resolves** `proof_ref` by removing `context.evidence.proof_ref`,
+  re-deriving the commitment from the supplied formal statement + remaining
+  Verification Context + evidence, and comparing it to the stored value.
 - **Missing, malformed, or mismatched** evidence/commitment is treated as
   **unverified (fail-closed)** — never as verified. A `proof_ref` that cannot be
   resolved confers no authority.

--- a/spec/v1.0/verification-context.md
+++ b/spec/v1.0/verification-context.md
@@ -1,0 +1,252 @@
+# QWED Verification Context Specification
+
+**Version:** 1.0 (Draft)
+**Status:** Draft — pending review
+**Derived from:** ADR-001..005
+**Machine-readable schema:** [`schemas/verification-context.schema.json`](schemas/verification-context.schema.json)
+
+---
+
+## 1. Overview
+
+This specification defines the **Verification Context** — the atomic record of a
+QWED verification. It standardizes *what is being verified*, *what it means*, *how
+it was proven*, *on what evidence*, and *what decision followed*, so that every
+QWED engine, SDK, API, CLI, and client speaks one protocol.
+
+A Verification Context document is a single JSON object conforming to the JSON
+Schema in [`schemas/verification-context.schema.json`](schemas/verification-context.schema.json).
+
+### Design goals
+
+- **One protocol.** Every verification surface emits the same shape.
+- **Fail-closed.** Anything not proven is `UNVERIFIABLE` or `BLOCKED`, never
+  `VERIFIED`.
+- **Truth ≠ admission.** A proven verdict and a safe-to-run decision are separate.
+- **Honesty.** QWED never claims to have verified intent; it verifies a formal
+  statement and shows you exactly what was proven.
+
+---
+
+## 2. The Verified Object
+
+> **The Verified Object is the formal statement being evaluated.**
+> *(ADR-001)*
+
+The object of verification is a **formal statement** — e.g. `∀x. x + 0 = x` or
+`x² − 4 = 0`. It is captured in `object.formal_statement`.
+
+### The theory is required interpretation context
+
+A formal statement is only *meaningful* relative to a theory/interpretation.
+`x² = 4` over the reals, over integers mod 5, and over bitvectors are different
+propositions. Therefore the theory/logic/dialect belongs in the **Interpretation**
+layer of the context (see §3.1), not in the object. The object is the statement;
+the theory is what gives it meaning.
+
+### Prover independence is semantic, not textual
+
+Changing the prover does not change the semantic proposition **when both provers
+encode the same proposition under equivalent theories and encodings** (e.g. Lean
+vs Coq proving the same theorem). A different logic, axiom set, or formal encoding
+can change the proposition, so the formal encoding and Verification Context remain
+necessary to interpret and reproduce the object.
+
+### The formalization is exposed but never verified
+
+QWED never claims *"we verified your intent."* It claims *"we verified THIS formal
+statement."* The mapping from natural language to the formal statement (the
+**formalization**) is surfaced in `object.formalization` for confirmation but is
+**never itself verified** (`object.formalization.verified` is always `false`).
+*(ADR-004)*
+
+---
+
+## 3. The Verification Context
+
+> **The Verification Context is all information required to correctly interpret,
+> reproduce, and trust a verification.** *(ADR-002)*
+
+It has four layers, captured in `context`:
+
+| Layer | Field | Contents | Role |
+|-------|-------|----------|------|
+| Interpretation | `context.interpretation` | theory / logic / dialect / algebra domain | Gives the object meaning |
+| Proof | `context.proof` | verifier + version + config + theory scope + trusted deps | How the object was discharged; sets proof strength |
+| Evidence | `context.evidence` | evidence + `proof_ref` | What was checked; evidence integrity |
+| Decision | `context.decision` | admission | The safe-to-run outcome |
+
+### 3.1 Interpretation layer
+
+`context.interpretation` records the theory / logic / dialect / algebra domain the
+statement is interpreted under. It is **required to interpret** the object. Each
+engine exposes only the interpretation it needs:
+
+- Theorem prover → theory, logic
+- SQL → dialect, parser version
+- Code → language, policy version
+- Symbolic math → algebra domain
+
+### 3.2 Proof layer
+
+`context.proof` records the discharge. **The verifier is the trusted computing
+base (TCB).** A proof discharged by SymPy (large TCB) is a different-strength
+guarantee than one checked by Lean/Coq (small trusted kernel). Declaring the
+verifier declares how much to trust the proof.
+
+The Proof layer records the full trust boundary:
+
+- `verifier` + `verifier_version` — the exact engine and release.
+- `configuration` — solver flags, timeouts, resource limits.
+- `theory_scope` — the logic / axiom set the discharge is relative to.
+- `trusted_dependencies` — libraries/components inside the TCB.
+- `outcome_treatment` — how `unknown`/`timeout`/`error` outcomes are treated.
+  These are **never** `VERIFIED`; they resolve to `UNVERIFIABLE` or `BLOCKED`
+  (fail-closed). Soundness/determinism claims apply **only** to supported
+  configurations that produce a definitive proof outcome.
+
+### 3.3 Evidence layer and `proof_ref`
+
+`context.evidence.evidence` is the retained evidence. `context.evidence.proof_ref`
+is the **evidence commitment**.
+
+> **`proof_ref`** is an immutable commitment to the verification evidence. It
+> provides **evidence integrity and reproducibility**. It is **not itself the
+> mathematical proof.** *(ADR-002)*
+
+**What it binds.** `proof_ref` commits to the formal statement together with the
+complete Verification Context — interpretation, proof, and evidence. Changing any
+of these changes the commitment.
+
+**How it is computed.**
+
+- **Canonical encoding:** the bound payload is serialized with a deterministic,
+  canonical encoding (stable key ordering, no ambient/non-deterministic fields
+  such as wall-clock time or memory addresses).
+- **Commitment algorithm:** a cryptographic hash (SHA-256) of the canonical
+  encoding, expressed as `sha256:<64-hex>`.
+
+**Resolution and failure semantics.**
+
+- A consumer **resolves** `proof_ref` by re-deriving the commitment from the
+  supplied formal statement + Verification Context + evidence and comparing it to
+  the stored value.
+- **Missing, malformed, or mismatched** evidence/commitment is treated as
+  **unverified (fail-closed)** — never as verified. A `proof_ref` that cannot be
+  resolved confers no authority.
+
+---
+
+## 4. Verdict
+
+> The verdict is the truth judgment. *(ADR-001, ADR-002)*
+
+`verdict` is one of:
+
+| Verdict | Meaning | `proof_ref` |
+|---------|---------|-------------|
+| `VERIFIED` | The claim was checked and proven. | **non-null** (`sha256:<64-hex>`) |
+| `UNVERIFIABLE` | Not proven (fail-closed). | `null` |
+| `BLOCKED` | Verification could not be attempted/completed (fail-closed). | `null` |
+
+**Invariants** (enforced by the schema):
+
+- `verdict == VERIFIED` ⟹ `context.evidence.proof_ref` is present and matches
+  `^sha256:[a-f0-9]{64}$`.
+- `verdict ∈ {UNVERIFIABLE, BLOCKED}` ⟹ `context.evidence.proof_ref` is `null`.
+
+A `VERIFIED` verdict is a **truth guarantee**, not an admission guarantee (see §5).
+
+---
+
+## 5. Admission (Truth ≠ Admission)
+
+> **`VERIFIED` is a truth guarantee, not an admission guarantee. Admission is a
+> separate decision.** *(ADR-003)*
+
+`context.decision.admission` is one of `ADMIT` / `DENY`. It is the safe-to-run /
+safe-to-ship decision, computed from the verdict plus policy.
+
+**VERIFIED-as-unsafe.** A proven-unsafe artifact is `VERIFIED` (we *proved* it is
+unsafe) with admission `DENY`. This is the critical case a conflated model gets
+wrong.
+
+**Gating.** Execution and shipping consumers gate **exclusively** on
+`admission == "ADMIT"`. `is_valid` contributes to the admission decision but is
+**not** an alternative authorization gate — a valid statement can still be denied
+by policy.
+
+| Verdict | Truth | Admission (typical) |
+|---------|-------|---------------------|
+| `VERIFIED`, valid | proven safe | `ADMIT` |
+| `VERIFIED`, unsafe | proven unsafe | **`DENY`** |
+| `UNVERIFIABLE` | not proven | `DENY` (fail-closed) |
+| `BLOCKED` | verification failed | `DENY` (fail-closed) |
+
+---
+
+## 6. Root of Trust
+
+> **What is the root of trust?** *(ADR-005)*
+
+QWED currently **self-attests**: each app process signs verdicts with its own
+private key. This is circular trust and an interim stage.
+
+**Self-signature limits.** The self-signature authenticates **only the canonical
+attestation bytes relative to the configured key.** It does **not** establish
+independent trust, validate the formal statement, reduce the verifier TCB, increase
+proof strength, change the `VERIFIED` verdict, or imply admission.
+
+**Attestation envelope.** Attestations MUST use a **versioned, canonical payload**
+binding, at minimum: the formal statement, the complete Verification Context,
+verifier + version, evidence, `proof_ref`, verdict, admission, key identity, and
+freshness (issued-at / expiry / nonce). This binding prevents a future external
+witness from reinterpreting or replaying an attestation.
+
+**Witness semantics.** A transparency log adds an **inclusion proof** (the
+attestation was recorded); it does **not** co-sign the payload. A **co-signature**
+(a second signature over the same canonical payload by an independent key) is a
+distinct, stronger guarantee. The two must not be conflated.
+
+**Multi-replica caveat.** Multi-replica deployments require shared or persisted
+signing keys (or authenticated replica-key resolution) before self-attestation is
+meaningful across replicas; until then, multi-replica attestation is unsupported.
+
+The root of trust (who witnesses attestations, the independent trust anchor) is an
+**open question** resolved in a future ADR.
+
+---
+
+## 7. Conformance
+
+An implementation **conforms** to this specification if:
+
+1. It emits Verification Context documents that validate against
+   [`schemas/verification-context.schema.json`](schemas/verification-context.schema.json).
+2. It upholds the verdict invariants (§4): `VERIFIED` ⟹ non-null `proof_ref`;
+   `UNVERIFIABLE`/`BLOCKED` ⟹ `null` `proof_ref`.
+3. It treats `proof_ref` as an evidence commitment, not a proof of truth (§3.3).
+4. It separates truth from admission (§5) and gates execution on
+   `admission == "ADMIT"` only.
+5. It exposes the formalization but never marks it verified (§2, ADR-004).
+6. It treats `unknown`/`timeout`/`error` outcomes as fail-closed (§3.2).
+
+---
+
+## 8. Example documents
+
+See [`schemas/verification-context.schema.json`](schemas/verification-context.schema.json)
+for the normative schema and the conformance test suite
+(`tests/test_verification_context_spec.py`) for valid and invalid examples.
+
+---
+
+## Appendix: Mapping to ADRs
+
+| Section | ADR |
+|---------|-----|
+| §2 The Verified Object | ADR-001 |
+| §3 Verification Context, `proof_ref` | ADR-002 |
+| §5 Admission | ADR-003 |
+| §2 Formalization | ADR-004 |
+| §6 Root of Trust | ADR-005 |

--- a/spec/v1.0/verification-context.md
+++ b/spec/v1.0/verification-context.md
@@ -121,11 +121,14 @@ the commitment.
 
 **How it is computed.**
 
-- **Bound payload:** the formal statement + the complete Verification Context, with
-  `context.evidence.proof_ref` **removed** before serialization. The commitment
+- **Bound payload (normative):** the JSON object
+  `{"formal_statement": <object.formal_statement>, "context": <context>}`, with
+  `context.evidence.proof_ref` **removed** before serialization. Note
+  `object.formalization` is deliberately **not** part of the bound payload — the
+  commitment binds the formal statement, not how it was derived. The commitment
   cannot include itself: hashing a payload that contains the stored digest would
   require a SHA-256 fixed point, which is not a normal content-addressed hash.
-  Producers and resolvers MUST both exclude `proof_ref` from the bound payload.
+  Producers and resolvers MUST both use this exact payload definition.
 - **Canonical encoding (normative, v1.0):** the bound payload is serialized as
   JSON with **all** of the following, so any two implementations derive identical
   bytes:
@@ -134,12 +137,14 @@ the commitment.
   - Object keys sorted lexicographically by Unicode code point (`sort_keys=True`).
   - Compact separators with no whitespace: `","` between items and `":"` between
     key and value (`separators=(",", ":")`).
-  - Numbers per RFC 8259; producers MUST NOT emit `NaN`/`Infinity` (fail-closed
-    instead).
+  - **Canonical numbers:** integer-valued numbers are serialized as JSON integers
+    (no trailing `.0`), so equivalent values `1` and `1.0` commit identically.
+    Non-integer numbers use the shortest round-trip decimal form. Producers MUST
+    NOT emit `NaN`/`Infinity` (fail-closed instead).
   - No ambient/non-deterministic fields (wall-clock time, memory addresses,
     randomness) in the bound payload.
-  Equivalent to `json.dumps(payload, sort_keys=True, separators=(",", ":"),
-  ensure_ascii=False)` over the bound payload.
+  Equivalent to serializing the number-normalized bound payload with
+  `json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)`.
 - **Commitment algorithm:** SHA-256 of the canonical encoding bytes, expressed as
   `sha256:<64-lowercase-hex>`.
 

--- a/tests/test_verification_context_spec.py
+++ b/tests/test_verification_context_spec.py
@@ -82,6 +82,14 @@ def _es_number_to_string(value):
     return ("-" if neg else "") + out
 
 
+def _reject_unpaired_surrogates(value):
+    for ch in value:
+        if 0xD800 <= ord(ch) <= 0xDFFF:
+            raise ValueError(
+                f"unpaired UTF-16 surrogate not allowed in proof_ref payload: {value!r}"
+            )
+
+
 def _canonical_json(value):
     """Serialize a value to canonical JSON per RFC 8785 (JCS)."""
     if value is None:
@@ -107,6 +115,7 @@ def _canonical_json(value):
             )
         return _es_number_to_string(value)
     if isinstance(value, str):
+        _reject_unpaired_surrogates(value)
         return json.dumps(value, ensure_ascii=False)
     if isinstance(value, (list, tuple)):
         return "[" + ",".join(_canonical_json(v) for v in value) + "]"
@@ -116,6 +125,7 @@ def _canonical_json(value):
                 raise ValueError(
                     f"non-string object key not allowed in proof_ref payload: {key!r}"
                 )
+            _reject_unpaired_surrogates(key)
         items = sorted(value.items(), key=lambda kv: kv[0].encode("utf-16-be"))
         return (
             "{"
@@ -505,3 +515,49 @@ def test_canonical_json_key_order_utf16():
         + ":1}"
     )
     assert _canonical_json(value) == expected
+
+
+def test_verified_proof_ref_binds_admission():
+    doc = _verified_doc()
+    stored = doc["context"]["evidence"]["proof_ref"]
+    doc["context"]["decision"]["admission"] = "DENY"
+    assert _canonical_proof_ref(doc) != stored
+
+
+def test_canonical_json_rejects_unpaired_surrogate_string():
+    with pytest.raises(ValueError):
+        _canonical_json(chr(0xD800))
+
+
+def test_canonical_json_rejects_unpaired_surrogate_key():
+    with pytest.raises(ValueError):
+        _canonical_json({chr(0xD800): 1})
+
+
+def test_canonical_json_accepts_valid_supplementary_character():
+    ch = chr(0x1F600)
+    assert _canonical_json(ch) == json.dumps(ch, ensure_ascii=False)
+
+
+def test_evidence_with_non_roundtrip_integer_rejected(schema):
+    doc = _verified_doc()
+    doc["context"]["evidence"]["evidence"] = {"value": 2**53 + 1}
+    assert not _validated(schema, doc)
+
+
+def test_evidence_with_nested_non_roundtrip_integer_rejected(schema):
+    doc = _verified_doc()
+    doc["context"]["evidence"]["evidence"] = {"nested": {"value": 2**53 + 1}}
+    assert not _validated(schema, doc)
+
+
+def test_proof_configuration_with_non_roundtrip_integer_rejected(schema):
+    doc = _verified_doc()
+    doc["context"]["proof"]["configuration"] = {"value": 2**53 + 1}
+    assert not _validated(schema, doc)
+
+
+def test_evidence_with_representable_integer_accepted(schema):
+    doc = _verified_doc()
+    doc["context"]["evidence"]["evidence"] = {"value": 2**53}
+    assert _validated(schema, doc)

--- a/tests/test_verification_context_spec.py
+++ b/tests/test_verification_context_spec.py
@@ -1,0 +1,165 @@
+"""Conformance tests for the QWED Verification Context Specification v1.0.
+
+Validates example Verification Context documents against the normative JSON
+Schema (spec/v1.0/schemas/verification-context.schema.json), proving the schema
+is machine-checkable and that the load-bearing invariants hold:
+
+  - VERIFIED      -> proof_ref present and matches ^sha256:[a-f0-9]{64}$
+  - UNVERIFIABLE  -> proof_ref is null
+  - BLOCKED       -> proof_ref is null
+  - admission     in {ADMIT, DENY}
+  - object.formal_statement required
+  - object.formalization.verified is always false
+"""
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+jsonschema = pytest.importorskip("jsonschema")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "spec" / "v1.0" / "schemas" / "verification-context.schema.json"
+
+PROOF = "sha256:" + "a" * 64
+
+
+@pytest.fixture(scope="module")
+def schema():
+    with open(SCHEMA_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _validated(schema, doc):
+    """Return True if doc validates against the schema, else False."""
+    try:
+        jsonschema.validate(instance=doc, schema=schema)
+        return True
+    except jsonschema.ValidationError:
+        return False
+
+
+def _verified_doc():
+    return {
+        "spec_version": "1.0",
+        "object": {
+            "formal_statement": "x**2 - 4 = 0",
+            "formalization": {
+                "source_query": "Is x squared minus four zero?",
+                "translator": "qwed-translator",
+                "translation_confidence": 0.9,
+                "verified": False,
+            },
+        },
+        "context": {
+            "interpretation": {"theory": "real-closed fields", "logic": "first-order"},
+            "proof": {
+                "verifier": "SymPy",
+                "verifier_version": "1.14.0",
+                "configuration": {"timeout_ms": 5000},
+                "theory_scope": "real-closed fields",
+                "trusted_dependencies": ["sympy"],
+                "outcome_treatment": "unknown/timeout/error resolve to UNVERIFIABLE or BLOCKED",
+            },
+            "evidence": {
+                "evidence": {"roots": [-2, 2]},
+                "proof_ref": PROOF,
+            },
+            "decision": {"admission": "ADMIT"},
+        },
+        "verdict": "VERIFIED",
+    }
+
+
+def test_schema_is_valid_json_schema(schema):
+    # The schema itself must be a valid JSON Schema document.
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_verified_document_valid(schema):
+    assert _validated(schema, _verified_doc())
+
+
+def test_unverifiable_document_valid(schema):
+    doc = _verified_doc()
+    doc["verdict"] = "UNVERIFIABLE"
+    doc["context"]["evidence"]["proof_ref"] = None
+    doc["context"]["decision"]["admission"] = "DENY"
+    assert _validated(schema, doc)
+
+
+def test_blocked_document_valid(schema):
+    doc = _verified_doc()
+    doc["verdict"] = "BLOCKED"
+    doc["context"]["evidence"]["proof_ref"] = None
+    doc["context"]["decision"]["admission"] = "DENY"
+    assert _validated(schema, doc)
+
+
+def test_verified_without_proof_ref_rejected(schema):
+    doc = _verified_doc()
+    doc["context"]["evidence"]["proof_ref"] = None
+    assert not _validated(schema, doc)
+
+
+def test_verified_with_missing_proof_ref_rejected(schema):
+    doc = _verified_doc()
+    del doc["context"]["evidence"]["proof_ref"]
+    assert not _validated(schema, doc)
+
+
+def test_unverifiable_with_nonnull_proof_ref_rejected(schema):
+    doc = _verified_doc()
+    doc["verdict"] = "UNVERIFIABLE"
+    # proof_ref left non-null -> must be rejected
+    assert not _validated(schema, doc)
+
+
+def test_malformed_proof_ref_rejected(schema):
+    doc = _verified_doc()
+    doc["context"]["evidence"]["proof_ref"] = "sha256:zzz"  # not 64 hex chars
+    assert not _validated(schema, doc)
+
+
+def test_missing_formal_statement_rejected(schema):
+    doc = _verified_doc()
+    del doc["object"]["formal_statement"]
+    assert not _validated(schema, doc)
+
+
+def test_formalization_marked_verified_rejected(schema):
+    doc = _verified_doc()
+    doc["object"]["formalization"]["verified"] = True
+    assert not _validated(schema, doc)
+
+
+def test_invalid_admission_rejected(schema):
+    doc = _verified_doc()
+    doc["context"]["decision"]["admission"] = "MAYBE"
+    assert not _validated(schema, doc)
+
+
+def test_invalid_verdict_rejected(schema):
+    doc = _verified_doc()
+    doc["verdict"] = "PROBABLY"
+    assert not _validated(schema, doc)
+
+
+def test_missing_context_layer_rejected(schema):
+    doc = _verified_doc()
+    del doc["context"]["decision"]
+    assert not _validated(schema, doc)
+
+
+def test_unknown_top_level_field_rejected(schema):
+    doc = _verified_doc()
+    doc["unexpected"] = True
+    assert not _validated(schema, doc)
+
+
+def test_wrong_spec_version_rejected(schema):
+    doc = _verified_doc()
+    doc["spec_version"] = "2.0"
+    assert not _validated(schema, doc)

--- a/tests/test_verification_context_spec.py
+++ b/tests/test_verification_context_spec.py
@@ -39,20 +39,40 @@ def _validated(schema, doc):
         return False
 
 
+def _canonicalize_numbers(value):
+    """Normalize numbers so equivalent values commit identically.
+
+    JSON does not distinguish ``1`` and ``1.0`` semantically, but they serialize
+    to different bytes. Normalizing integer-valued floats to integers gives a
+    unique canonical form (spec section 3.3, canonical encoding).
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, dict):
+        return {k: _canonicalize_numbers(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_canonicalize_numbers(v) for v in value]
+    return value
+
+
 def _canonical_proof_ref(doc):
     """Compute proof_ref per the spec (verification-context.md, section 3.3).
 
-    The commitment is the SHA-256 of the canonical encoding of the bound payload
-    — the object + complete Verification Context — with
-    ``context.evidence.proof_ref`` itself EXCLUDED (the commitment cannot include
-    itself). Producers and resolvers must both apply this exclusion.
+    The bound payload is the formal statement + the complete Verification Context,
+    with ``context.evidence.proof_ref`` itself EXCLUDED (the commitment cannot
+    include itself). Note ``object.formalization`` is deliberately NOT part of the
+    bound payload — the commitment binds the formal statement, not how it was
+    derived. Producers and resolvers must both apply this payload definition.
     """
     bound = {
-        "object": doc["object"],
+        "formal_statement": doc["object"]["formal_statement"],
         "context": copy.deepcopy(doc["context"]),
     }
     bound["context"]["evidence"].pop("proof_ref", None)
-    payload = json.dumps(bound, sort_keys=True, separators=(",", ":"))
+    bound = _canonicalize_numbers(bound)
+    payload = json.dumps(bound, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
@@ -248,4 +268,55 @@ def test_empty_string_interpretation_rejected(schema):
     """An interpretation field present but empty must not satisfy the layer."""
     doc = _verified_doc()
     doc["context"]["interpretation"] = {"theory": ""}
+    assert not _validated(schema, doc)
+
+
+# --- canonical number representation -----------------------------------------
+
+def test_numeric_canonicalization_equal_values_commit_identically():
+    """Equivalent numbers (1 and 1.0) must commit identically (spec 3.3)."""
+    doc_int = _verified_doc()
+    doc_int["context"]["evidence"]["evidence"] = {"value": 1}
+    doc_float = _verified_doc()
+    doc_float["context"]["evidence"]["evidence"] = {"value": 1.0}
+    assert _canonical_proof_ref(doc_int) == _canonical_proof_ref(doc_float)
+
+
+def test_distinct_numbers_commit_differently():
+    doc_one = _verified_doc()
+    doc_one["context"]["evidence"]["evidence"] = {"value": 1}
+    doc_two = _verified_doc()
+    doc_two["context"]["evidence"]["evidence"] = {"value": 2}
+    assert _canonical_proof_ref(doc_one) != _canonical_proof_ref(doc_two)
+
+
+# --- commitment binds the formal statement, not the formalization ------------
+
+def test_formalization_excluded_from_commitment():
+    """Changing object.formalization must not change the commitment (spec 3.3)."""
+    doc_a = _verified_doc()
+    doc_b = _verified_doc()
+    doc_b["object"]["formalization"]["translator"] = "a-different-translator"
+    assert _canonical_proof_ref(doc_a) == _canonical_proof_ref(doc_b)
+
+
+# --- documented engine-specific interpretation fields ------------------------
+
+def test_code_interpretation_fields_accepted(schema):
+    """Code contexts use language + policy_version (spec 3.1)."""
+    doc = _verified_doc()
+    doc["context"]["interpretation"] = {"language": "python", "policy_version": "1.0"}
+    assert _validated(schema, doc)
+
+
+def test_sql_interpretation_fields_accepted(schema):
+    """SQL contexts use dialect + parser_version (spec 3.1)."""
+    doc = _verified_doc()
+    doc["context"]["interpretation"] = {"dialect": "postgres", "parser_version": "0.21"}
+    assert _validated(schema, doc)
+
+
+def test_undocumented_interpretation_field_rejected(schema):
+    doc = _verified_doc()
+    doc["context"]["interpretation"] = {"theory": "arithmetic", "bogus_field": "x"}
     assert not _validated(schema, doc)

--- a/tests/test_verification_context_spec.py
+++ b/tests/test_verification_context_spec.py
@@ -17,9 +17,8 @@ import hashlib
 import json
 from pathlib import Path
 
+import jsonschema
 import pytest
-
-jsonschema = pytest.importorskip("jsonschema")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = REPO_ROOT / "spec" / "v1.0" / "schemas" / "verification-context.schema.json"
@@ -242,4 +241,11 @@ def test_blocked_with_admit_rejected(schema):
 def test_empty_interpretation_rejected(schema):
     doc = _verified_doc()
     doc["context"]["interpretation"] = {}
+    assert not _validated(schema, doc)
+
+
+def test_empty_string_interpretation_rejected(schema):
+    """An interpretation field present but empty must not satisfy the layer."""
+    doc = _verified_doc()
+    doc["context"]["interpretation"] = {"theory": ""}
     assert not _validated(schema, doc)

--- a/tests/test_verification_context_spec.py
+++ b/tests/test_verification_context_spec.py
@@ -13,6 +13,7 @@ is machine-checkable and that the load-bearing invariants hold:
 """
 
 import copy
+import hashlib
 import json
 from pathlib import Path
 
@@ -22,8 +23,6 @@ jsonschema = pytest.importorskip("jsonschema")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = REPO_ROOT / "spec" / "v1.0" / "schemas" / "verification-context.schema.json"
-
-PROOF = "sha256:" + "a" * 64
 
 
 @pytest.fixture(scope="module")
@@ -41,8 +40,25 @@ def _validated(schema, doc):
         return False
 
 
+def _canonical_proof_ref(doc):
+    """Compute proof_ref per the spec (verification-context.md, section 3.3).
+
+    The commitment is the SHA-256 of the canonical encoding of the bound payload
+    — the object + complete Verification Context — with
+    ``context.evidence.proof_ref`` itself EXCLUDED (the commitment cannot include
+    itself). Producers and resolvers must both apply this exclusion.
+    """
+    bound = {
+        "object": doc["object"],
+        "context": copy.deepcopy(doc["context"]),
+    }
+    bound["context"]["evidence"].pop("proof_ref", None)
+    payload = json.dumps(bound, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def _verified_doc():
-    return {
+    doc = {
         "spec_version": "1.0",
         "object": {
             "formal_statement": "x**2 - 4 = 0",
@@ -65,12 +81,14 @@ def _verified_doc():
             },
             "evidence": {
                 "evidence": {"roots": [-2, 2]},
-                "proof_ref": PROOF,
             },
             "decision": {"admission": "ADMIT"},
         },
         "verdict": "VERIFIED",
     }
+    # Derive proof_ref from the canonical payload (content-bound), not a constant.
+    doc["context"]["evidence"]["proof_ref"] = _canonical_proof_ref(doc)
+    return doc
 
 
 def test_schema_is_valid_json_schema(schema):
@@ -162,4 +180,66 @@ def test_unknown_top_level_field_rejected(schema):
 def test_wrong_spec_version_rejected(schema):
     doc = _verified_doc()
     doc["spec_version"] = "2.0"
+    assert not _validated(schema, doc)
+
+
+# --- proof_ref is content-bound (spec section 3.3) ---------------------------
+
+def test_verified_proof_ref_is_content_bound(schema):
+    """The fixture's proof_ref must resolve against its own payload."""
+    doc = _verified_doc()
+    assert doc["context"]["evidence"]["proof_ref"] == _canonical_proof_ref(doc)
+    assert _validated(schema, doc)
+
+
+def test_verified_proof_ref_mismatch_detected(schema):
+    """Tampering with the bound payload must change the commitment (mismatch)."""
+    doc = _verified_doc()
+    stored = doc["context"]["evidence"]["proof_ref"]
+    # Tamper with a bound field after the commitment was made.
+    doc["object"]["formal_statement"] = "x**2 - 9 = 0"
+    assert _canonical_proof_ref(doc) != stored
+
+
+# --- fail-closed verdicts must carry an explicit null proof_ref --------------
+
+def test_unverifiable_missing_proof_ref_rejected(schema):
+    doc = _verified_doc()
+    doc["verdict"] = "UNVERIFIABLE"
+    doc["context"]["decision"]["admission"] = "DENY"
+    del doc["context"]["evidence"]["proof_ref"]
+    assert not _validated(schema, doc)
+
+
+def test_blocked_missing_proof_ref_rejected(schema):
+    doc = _verified_doc()
+    doc["verdict"] = "BLOCKED"
+    doc["context"]["decision"]["admission"] = "DENY"
+    del doc["context"]["evidence"]["proof_ref"]
+    assert not _validated(schema, doc)
+
+
+# --- fail-closed verdicts must DENY admission --------------------------------
+
+def test_unverifiable_with_admit_rejected(schema):
+    doc = _verified_doc()
+    doc["verdict"] = "UNVERIFIABLE"
+    doc["context"]["evidence"]["proof_ref"] = None
+    doc["context"]["decision"]["admission"] = "ADMIT"
+    assert not _validated(schema, doc)
+
+
+def test_blocked_with_admit_rejected(schema):
+    doc = _verified_doc()
+    doc["verdict"] = "BLOCKED"
+    doc["context"]["evidence"]["proof_ref"] = None
+    doc["context"]["decision"]["admission"] = "ADMIT"
+    assert not _validated(schema, doc)
+
+
+# --- interpretation must be non-empty ----------------------------------------
+
+def test_empty_interpretation_rejected(schema):
+    doc = _verified_doc()
+    doc["context"]["interpretation"] = {}
     assert not _validated(schema, doc)

--- a/tests/test_verification_context_spec.py
+++ b/tests/test_verification_context_spec.py
@@ -40,40 +40,8 @@ def _validated(schema, doc):
         return False
 
 
-def _canonicalize_numbers(value):
-    """Normalize numbers so equivalent values commit identically.
-
-    JSON does not distinguish ``1`` and ``1.0`` semantically, but they serialize
-    to different bytes. Normalizing integer-valued floats to integers gives a
-    unique canonical form (spec section 3.3, canonical encoding). Non-finite
-    floats (NaN, +/-Infinity) are rejected (fail-closed) rather than serialized.
-    """
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise ValueError(
-                f"non-finite number not allowed in proof_ref payload: {value!r}"
-            )
-        if value.is_integer():
-            return int(value)
-        return value
-    if isinstance(value, dict):
-        return {k: _canonicalize_numbers(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_canonicalize_numbers(v) for v in value]
-    return value
-
-
 def _es_number_to_string(value):
-    """Serialize a finite, non-zero, non-integer float per ECMAScript
-    Number::toString (the number form mandated by RFC 8785 section 3.2.2).
-
-    Python's ``json.dumps`` does NOT implement this form (e.g. it emits ``1e-07``
-    where ECMAScript emits ``1e-7``, and ``1e-06`` where ECMAScript emits
-    ``0.000001``). This reference implementation matches ECMAScript so producers
-    and resolvers in different languages derive identical bytes.
-    """
+    """Serialize a finite IEEE-754 double per ECMAScript Number::toString."""
     neg = value < 0
     ax = abs(value)
     r = repr(ax)  # shortest round-trip decimal for the double
@@ -115,36 +83,44 @@ def _es_number_to_string(value):
 
 
 def _canonical_json(value):
-    """Serialize a value to canonical JSON per RFC 8785 (JCS).
-
-    Numbers: integer-valued numbers as base-10 JSON integers; non-integer finite
-    floats per ECMAScript Number::toString; non-finite rejected. Objects have
-    sorted keys and no whitespace; strings are UTF-8 JSON strings.
-    """
+    """Serialize a value to canonical JSON per RFC 8785 (JCS)."""
     if value is None:
         return "null"
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, int):
-        return str(value)
+        try:
+            as_float = float(value)
+        except OverflowError as exc:
+            raise ValueError(
+                f"integer not representable as IEEE-754 double: {value!r}"
+            ) from exc
+        if int(as_float) != value:
+            raise ValueError(
+                f"integer not representable as IEEE-754 double: {value!r}"
+            )
+        return _es_number_to_string(as_float)
     if isinstance(value, float):
         if not math.isfinite(value):
             raise ValueError(
                 f"non-finite number not allowed in proof_ref payload: {value!r}"
             )
-        if value.is_integer():
-            return str(int(value))
         return _es_number_to_string(value)
     if isinstance(value, str):
         return json.dumps(value, ensure_ascii=False)
     if isinstance(value, (list, tuple)):
         return "[" + ",".join(_canonical_json(v) for v in value) + "]"
     if isinstance(value, dict):
-        items = sorted(value.items(), key=lambda kv: str(kv[0]))
+        for key in value:
+            if not isinstance(key, str):
+                raise ValueError(
+                    f"non-string object key not allowed in proof_ref payload: {key!r}"
+                )
+        items = sorted(value.items(), key=lambda kv: kv[0].encode("utf-16-be"))
         return (
             "{"
             + ",".join(
-                json.dumps(str(k), ensure_ascii=False) + ":" + _canonical_json(v)
+                json.dumps(k, ensure_ascii=False) + ":" + _canonical_json(v)
                 for k, v in items
             )
             + "}"
@@ -387,7 +363,7 @@ def test_distinct_numbers_commit_differently():
 
 def test_negative_zero_canonicalizes_to_zero():
     """0 and -0 must commit identically (negative zero normalizes to 0)."""
-    assert _canonicalize_numbers(-0.0) == _canonicalize_numbers(0) == 0
+    assert _canonical_json(-0.0) == _canonical_json(0) == "0"
     doc_pos = _verified_doc()
     doc_pos["context"]["evidence"]["evidence"] = {"value": 0.0}
     doc_neg = _verified_doc()
@@ -396,8 +372,8 @@ def test_negative_zero_canonicalizes_to_zero():
 
 
 def test_large_integer_canonical_form():
-    """Integer-valued floats normalize to arbitrary-precision integers."""
-    assert _canonicalize_numbers(1e21) == _canonicalize_numbers(10**21) == 10**21
+    """Representable integer doubles serialize per ECMAScript Number::toString."""
+    assert _canonical_json(1e21) == _canonical_json(10**21) == "1e+21"
     doc_float = _verified_doc()
     doc_float["context"]["evidence"]["evidence"] = {"value": 1e21}
     doc_int = _verified_doc()
@@ -452,13 +428,13 @@ def test_canonical_json_exponent_golden_vectors():
 
 
 def test_canonical_json_integer_golden_vectors():
-    """Integer-valued numbers serialize as base-10 JSON integers."""
+    """Finite IEEE-754 numbers serialize per ECMAScript Number::toString."""
     assert _canonical_json(1) == "1"
     assert _canonical_json(1.0) == "1"
     assert _canonical_json(0) == "0"
     assert _canonical_json(-0.0) == "0"
-    assert _canonical_json(10**21) == "1000000000000000000000"
-    assert _canonical_json(1e21) == "1000000000000000000000"
+    assert _canonical_json(10**21) == "1e+21"
+    assert _canonical_json(1e21) == "1e+21"
 
 
 def test_canonical_json_equivalent_floats_commit_identically():
@@ -500,3 +476,32 @@ def test_undocumented_interpretation_field_rejected(schema):
     doc = _verified_doc()
     doc["context"]["interpretation"] = {"theory": "arithmetic", "bogus_field": "x"}
     assert not _validated(schema, doc)
+
+
+def test_canonical_json_rejects_non_roundtrip_integer():
+    with pytest.raises(ValueError):
+        _canonical_json(2**53 + 1)
+
+
+def test_canonical_json_rejects_overflowing_integer():
+    with pytest.raises(ValueError):
+        _canonical_json(10**400)
+
+
+def test_canonical_json_rejects_non_string_keys():
+    with pytest.raises(ValueError):
+        _canonical_json({1: 1})
+
+
+def test_canonical_json_key_order_utf16():
+    high = chr(0x10000)
+    low = chr(0xE000)
+    value = {low: 1, high: 2}
+    expected = (
+        "{"
+        + json.dumps(high, ensure_ascii=False)
+        + ":2,"
+        + json.dumps(low, ensure_ascii=False)
+        + ":1}"
+    )
+    assert _canonical_json(value) == expected

--- a/tests/test_verification_context_spec.py
+++ b/tests/test_verification_context_spec.py
@@ -15,6 +15,7 @@ is machine-checkable and that the load-bearing invariants hold:
 import copy
 import hashlib
 import json
+import math
 from pathlib import Path
 
 import jsonschema
@@ -44,12 +45,19 @@ def _canonicalize_numbers(value):
 
     JSON does not distinguish ``1`` and ``1.0`` semantically, but they serialize
     to different bytes. Normalizing integer-valued floats to integers gives a
-    unique canonical form (spec section 3.3, canonical encoding).
+    unique canonical form (spec section 3.3, canonical encoding). Non-finite
+    floats (NaN, +/-Infinity) are rejected (fail-closed) rather than serialized.
     """
     if isinstance(value, bool):
         return value
-    if isinstance(value, float) and value.is_integer():
-        return int(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(
+                f"non-finite number not allowed in proof_ref payload: {value!r}"
+            )
+        if value.is_integer():
+            return int(value)
+        return value
     if isinstance(value, dict):
         return {k: _canonicalize_numbers(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
@@ -72,7 +80,9 @@ def _canonical_proof_ref(doc):
     }
     bound["context"]["evidence"].pop("proof_ref", None)
     bound = _canonicalize_numbers(bound)
-    payload = json.dumps(bound, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    payload = json.dumps(
+        bound, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    )
     return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
@@ -288,6 +298,57 @@ def test_distinct_numbers_commit_differently():
     doc_two = _verified_doc()
     doc_two["context"]["evidence"]["evidence"] = {"value": 2}
     assert _canonical_proof_ref(doc_one) != _canonical_proof_ref(doc_two)
+
+
+def test_negative_zero_canonicalizes_to_zero():
+    """0 and -0 must commit identically (negative zero normalizes to 0)."""
+    assert _canonicalize_numbers(-0.0) == _canonicalize_numbers(0) == 0
+    doc_pos = _verified_doc()
+    doc_pos["context"]["evidence"]["evidence"] = {"value": 0.0}
+    doc_neg = _verified_doc()
+    doc_neg["context"]["evidence"]["evidence"] = {"value": -0.0}
+    assert _canonical_proof_ref(doc_pos) == _canonical_proof_ref(doc_neg)
+
+
+def test_large_integer_canonical_form():
+    """Integer-valued floats normalize to arbitrary-precision integers."""
+    assert _canonicalize_numbers(1e21) == _canonicalize_numbers(10**21) == 10**21
+    doc_float = _verified_doc()
+    doc_float["context"]["evidence"]["evidence"] = {"value": 1e21}
+    doc_int = _verified_doc()
+    doc_int["context"]["evidence"]["evidence"] = {"value": 10**21}
+    assert _canonical_proof_ref(doc_float) == _canonical_proof_ref(doc_int)
+
+
+def test_precision_sensitive_decimal_deterministic():
+    """A non-integer float commits deterministically (golden vector)."""
+    doc = _verified_doc()
+    doc["context"]["evidence"]["evidence"] = {"value": 3.141592653589793}
+    first = _canonical_proof_ref(doc)
+    second = _canonical_proof_ref(doc)
+    assert first == second
+    assert first.startswith("sha256:")
+
+
+def test_canonical_proof_ref_rejects_nan():
+    doc = _verified_doc()
+    doc["context"]["evidence"]["evidence"] = {"value": float("nan")}
+    with pytest.raises(ValueError):
+        _canonical_proof_ref(doc)
+
+
+def test_canonical_proof_ref_rejects_infinity():
+    doc = _verified_doc()
+    doc["context"]["evidence"]["evidence"] = {"value": float("inf")}
+    with pytest.raises(ValueError):
+        _canonical_proof_ref(doc)
+
+
+def test_canonical_proof_ref_rejects_negative_infinity():
+    doc = _verified_doc()
+    doc["context"]["evidence"]["evidence"] = {"value": float("-inf")}
+    with pytest.raises(ValueError):
+        _canonical_proof_ref(doc)
 
 
 # --- commitment binds the formal statement, not the formalization ------------

--- a/tests/test_verification_context_spec.py
+++ b/tests/test_verification_context_spec.py
@@ -65,6 +65,93 @@ def _canonicalize_numbers(value):
     return value
 
 
+def _es_number_to_string(value):
+    """Serialize a finite, non-zero, non-integer float per ECMAScript
+    Number::toString (the number form mandated by RFC 8785 section 3.2.2).
+
+    Python's ``json.dumps`` does NOT implement this form (e.g. it emits ``1e-07``
+    where ECMAScript emits ``1e-7``, and ``1e-06`` where ECMAScript emits
+    ``0.000001``). This reference implementation matches ECMAScript so producers
+    and resolvers in different languages derive identical bytes.
+    """
+    neg = value < 0
+    ax = abs(value)
+    r = repr(ax)  # shortest round-trip decimal for the double
+    if "e" in r:
+        mant, exp_s = r.split("e")
+        e10 = int(exp_s)
+    else:
+        mant = r
+        e10 = 0
+    if "." in mant:
+        ip, fp = mant.split(".")
+        coeff = int(ip + fp) if (ip + fp).lstrip("0") else 0
+        e10 -= len(fp)
+    else:
+        coeff = int(mant)
+    # Strip trailing zeros from the coefficient, adjusting the exponent.
+    while coeff > 0 and coeff % 10 == 0:
+        coeff //= 10
+        e10 += 1
+    if coeff == 0:
+        return "0"
+    s_digits = str(coeff)
+    k = len(s_digits)
+    n = e10 + k  # value == coeff * 10**(n - k)
+    if k <= n <= 21:
+        out = s_digits + "0" * (n - k)
+    elif 0 < n <= 21:
+        out = s_digits[:n] + "." + s_digits[n:]
+    elif -6 < n <= 0:
+        out = "0." + "0" * (-n) + s_digits
+    else:
+        exp = n - 1
+        sign = "+" if exp >= 0 else "-"
+        if k == 1:
+            out = s_digits + "e" + sign + str(abs(exp))
+        else:
+            out = s_digits[0] + "." + s_digits[1:] + "e" + sign + str(abs(exp))
+    return ("-" if neg else "") + out
+
+
+def _canonical_json(value):
+    """Serialize a value to canonical JSON per RFC 8785 (JCS).
+
+    Numbers: integer-valued numbers as base-10 JSON integers; non-integer finite
+    floats per ECMAScript Number::toString; non-finite rejected. Objects have
+    sorted keys and no whitespace; strings are UTF-8 JSON strings.
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(
+                f"non-finite number not allowed in proof_ref payload: {value!r}"
+            )
+        if value.is_integer():
+            return str(int(value))
+        return _es_number_to_string(value)
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_canonical_json(v) for v in value) + "]"
+    if isinstance(value, dict):
+        items = sorted(value.items(), key=lambda kv: str(kv[0]))
+        return (
+            "{"
+            + ",".join(
+                json.dumps(str(k), ensure_ascii=False) + ":" + _canonical_json(v)
+                for k, v in items
+            )
+            + "}"
+        )
+    raise ValueError(f"unsupported type in proof_ref payload: {type(value).__name__}")
+
+
 def _canonical_proof_ref(doc):
     """Compute proof_ref per the spec (verification-context.md, section 3.3).
 
@@ -72,17 +159,15 @@ def _canonical_proof_ref(doc):
     with ``context.evidence.proof_ref`` itself EXCLUDED (the commitment cannot
     include itself). Note ``object.formalization`` is deliberately NOT part of the
     bound payload — the commitment binds the formal statement, not how it was
-    derived. Producers and resolvers must both apply this payload definition.
+    derived. Producers and resolvers must both apply this payload definition. The
+    payload is serialized with the RFC 8785 canonical encoding.
     """
     bound = {
         "formal_statement": doc["object"]["formal_statement"],
         "context": copy.deepcopy(doc["context"]),
     }
     bound["context"]["evidence"].pop("proof_ref", None)
-    bound = _canonicalize_numbers(bound)
-    payload = json.dumps(
-        bound, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
-    )
+    payload = _canonical_json(bound)
     return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
@@ -349,6 +434,40 @@ def test_canonical_proof_ref_rejects_negative_infinity():
     doc["context"]["evidence"]["evidence"] = {"value": float("-inf")}
     with pytest.raises(ValueError):
         _canonical_proof_ref(doc)
+
+
+# --- RFC 8785 / ECMAScript number encoding golden vectors --------------------
+
+def test_canonical_json_exponent_golden_vectors():
+    """Non-integer floats use ECMAScript Number::toString, not Python repr.
+
+    Python's json.dumps emits 1e-07 / 1e-06; RFC 8785 requires 1e-7 / 0.000001.
+    These byte-level vectors pin the cross-language canonical form.
+    """
+    assert _canonical_json(1e-7) == "1e-7"
+    assert _canonical_json(1e-6) == "0.000001"
+    assert _canonical_json(3.141592653589793) == "3.141592653589793"
+    assert _canonical_json(-1e-7) == "-1e-7"
+    assert _canonical_json(1.5e-7) == "1.5e-7"
+
+
+def test_canonical_json_integer_golden_vectors():
+    """Integer-valued numbers serialize as base-10 JSON integers."""
+    assert _canonical_json(1) == "1"
+    assert _canonical_json(1.0) == "1"
+    assert _canonical_json(0) == "0"
+    assert _canonical_json(-0.0) == "0"
+    assert _canonical_json(10**21) == "1000000000000000000000"
+    assert _canonical_json(1e21) == "1000000000000000000000"
+
+
+def test_canonical_json_equivalent_floats_commit_identically():
+    """1e-6 and 0.000001 (the same double) commit identically."""
+    doc_a = _verified_doc()
+    doc_a["context"]["evidence"]["evidence"] = {"value": 1e-6}
+    doc_b = _verified_doc()
+    doc_b["context"]["evidence"]["evidence"] = {"value": 0.000001}
+    assert _canonical_proof_ref(doc_a) == _canonical_proof_ref(doc_b)
 
 
 # --- commitment binds the formal statement, not the formalization ------------


### PR DESCRIPTION
## **User description**
## Summary

Freezes the QWED verification ontology as a **machine-readable protocol** ÔÇö the
**QWED Verification Context Specification v1.0 (Draft)** ÔÇö derived from
ADR-001..005 (merged in #301). This is the reference that the SDK / API / CLI /
Marketplace will conform to, turning QWED from "a product" into "a protocol."

This is the "Specification" step: **ADR ÔåÆ Specification ÔåÆ Implementation ÔåÆ Gap
audit ÔåÆ Marketplace UX**.

## What's in it

- **`spec/README.md`** ÔÇö overview, versioning policy, conformance model.
- **`spec/v1.0/verification-context.md`** ÔÇö prose specification:
  - The **Verified Object** (the formal statement; theory is required
    interpretation context; formalization exposed but never verified).
  - The **Verification Context** ÔÇö four layers: Interpretation / Proof / Evidence /
    Decision.
  - **`proof_ref` semantics** ÔÇö an evidence commitment (canonical encoding +
    SHA-256), not a proof of truth; resolution + fail-closed failure semantics.
  - **Verdict** (`VERIFIED`/`UNVERIFIABLE`/`BLOCKED`) + **Admission**
    (`ADMIT`/`DENY`); truth Ôëá admission; execution gates on `admission == ADMIT`.
  - **Root of Trust** ÔÇö self-attestation limits, attestation envelope, witness
    semantics, multi-replica caveat.
- **`spec/v1.0/schemas/verification-context.schema.json`** ÔÇö JSON Schema
  (draft 2020-12) encoding the structure + load-bearing invariants.
- **`tests/test_verification_context_spec.py`** ÔÇö 50 conformance tests validating
  example documents against the schema (valid + invalid cases).

## Invariants the schema enforces

- `VERIFIED` Ôƒ╣ `proof_ref` non-null (`sha256:<64-hex>`)
- `UNVERIFIABLE` / `BLOCKED` Ôƒ╣ `proof_ref = null`
- `admission Ôêê {ADMIT, DENY}`
- `object.formal_statement` required
- `object.formalization.verified` always `false`

## Scope

Docs + schema + one test only ÔÇö **no engine code changes** ÔÇö so this is low-risk
and reviewable. Adds `jsonschema` to the `dev` extra for the conformance test.

## Verification

- Schema validates as a valid JSON Schema (`Draft202012Validator.check_schema`).
- 50 conformance tests pass (valid + invalid documents).
- Full suite: 1878 passed.


___

## **CodeAnt-AI Description**
Define and validate the QWED Verification Context v1.0 draft protocol

### What Changed
- Adds a machine-readable Verification Context specification covering the verified statement, interpretation, proof, evidence, verdict, admission, and trust boundaries
- Adds a JSON Schema that enforces valid verdicts, admissions, proof references, required context layers, fixed specification version, and fail-closed verification rules
- Adds conformance tests for valid documents and invalid cases such as missing evidence, malformed proof references, unsupported verdicts, and altered formalizations
- Documents versioning and conformance guidance for SDK, API, CLI, engine, and client integrations
- Adds the schema validation dependency for development and test environments

### Impact
`Ô£à Consistent verification records across QWED interfaces`
`Ô£à Invalid or incomplete verification results are rejected`
`Ô£à Fail-closed handling for unverifiable and blocked outcomes`
<details><summary><strong>­ƒÆí Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the QWED Verification Context v1.0 specification and JSON Schema.
  * Defined structured verification records with fail-closed verdict and admission rules.
  * Added proof-reference commitments, evidence layers, and canonical serialization requirements.

* **Documentation**
  * Added guidance on terminology, versioning, conformance, and references.

* **Tests**
  * Added comprehensive validation for valid, invalid, incomplete, and tampered contexts.

* **Chores**
  * Added JSON Schema validation support for development and automated analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->