### PR TITLE
feat: public proof_ref generation and resolution

### DIFF
--- a/src/qwed_new/core/__init__.py
+++ b/src/qwed_new/core/__init__.py
@@ -43,8 +43,11 @@ from .verification_context import (
     VerificationContextValidationError,
     VerifiedObject,
     compute_context_proof_ref,
+    compute_document_proof_ref,
     is_valid_document,
     load_schema,
+    resolve_context_proof_ref,
+    resolve_document_proof_ref,
     validate_document,
 )
 
@@ -81,8 +84,11 @@ __all__ = [
     "VerificationContextValidationError",
     "VerifiedObject",
     "compute_context_proof_ref",
+    "compute_document_proof_ref",
     "is_valid_document",
     "load_schema",
+    "resolve_context_proof_ref",
+    "resolve_document_proof_ref",
     "validate_document",
 ]
 

--- a/src/qwed_new/core/verification_context.py
+++ b/src/qwed_new/core/verification_context.py
@@ -646,6 +646,7 @@ def resolve_document_proof_ref(document: Mapping[str, Any]) -> bool:
             return False
         if document.get("verdict") != Verdict.VERIFIED.value:
             return False
+        validate_document(document)
         expected = compute_document_proof_ref(document)
         stored = document["context"]["evidence"]["proof_ref"]
         return isinstance(stored, str) and stored == expected
@@ -658,11 +659,11 @@ def resolve_context_proof_ref(
     context: VerificationContext,
     proof_ref: Optional[str],
 ) -> bool:
-    if proof_ref is None:
+    if not isinstance(proof_ref, str):
         return False
     try:
         return compute_context_proof_ref(formal_statement, context) == proof_ref
-    except VerificationContextValidationError:
+    except Exception:
         return False
 
 

--- a/src/qwed_new/core/verification_context.py
+++ b/src/qwed_new/core/verification_context.py
@@ -20,6 +20,10 @@ class VerificationContextValidationError(ValueError):
     pass
 
 
+_MISSING_BOUND_FIELD_ERRORS = (KeyError, TypeError, AttributeError)
+_RESOLVER_ERRORS = (VerificationContextValidationError,) + _MISSING_BOUND_FIELD_ERRORS
+
+
 class Verdict(str, Enum):
     VERIFIED = "VERIFIED"
     UNVERIFIABLE = "UNVERIFIABLE"
@@ -632,9 +636,7 @@ def compute_document_proof_ref(document: Mapping[str, Any]) -> str:
         )
     try:
         return _expected_document_proof_ref(document)
-    except VerificationContextValidationError:
-        raise
-    except Exception as exc:
+    except _MISSING_BOUND_FIELD_ERRORS as exc:
         raise VerificationContextValidationError(
             "bound payload is missing required Verification Context fields"
         ) from exc
@@ -650,7 +652,7 @@ def resolve_document_proof_ref(document: Mapping[str, Any]) -> bool:
         expected = compute_document_proof_ref(document)
         stored = document["context"]["evidence"]["proof_ref"]
         return isinstance(stored, str) and stored == expected
-    except Exception:
+    except _RESOLVER_ERRORS:
         return False
 
 
@@ -659,11 +661,15 @@ def resolve_context_proof_ref(
     context: VerificationContext,
     proof_ref: Optional[str],
 ) -> bool:
+    if not isinstance(formal_statement, str):
+        return False
+    if not isinstance(context, VerificationContext):
+        return False
     if not isinstance(proof_ref, str):
         return False
     try:
         return compute_context_proof_ref(formal_statement, context) == proof_ref
-    except Exception:
+    except _RESOLVER_ERRORS:
         return False
 
 

--- a/src/qwed_new/core/verification_context.py
+++ b/src/qwed_new/core/verification_context.py
@@ -21,7 +21,10 @@ class VerificationContextValidationError(ValueError):
 
 
 _MISSING_BOUND_FIELD_ERRORS = (KeyError, TypeError, AttributeError)
-_RESOLVER_ERRORS = (VerificationContextValidationError,) + _MISSING_BOUND_FIELD_ERRORS
+_RESOLVER_ERRORS = (
+    VerificationContextValidationError,
+    *_MISSING_BOUND_FIELD_ERRORS,
+)
 
 
 class Verdict(str, Enum):

--- a/src/qwed_new/core/verification_context.py
+++ b/src/qwed_new/core/verification_context.py
@@ -625,12 +625,58 @@ def _expected_document_proof_ref(document: Mapping[str, Any]) -> str:
     return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def compute_document_proof_ref(document: Mapping[str, Any]) -> str:
+    if not isinstance(document, Mapping):
+        raise VerificationContextValidationError(
+            "Verification Context document must be a JSON object"
+        )
+    try:
+        return _expected_document_proof_ref(document)
+    except VerificationContextValidationError:
+        raise
+    except Exception as exc:
+        raise VerificationContextValidationError(
+            "bound payload is missing required Verification Context fields"
+        ) from exc
+
+
+def resolve_document_proof_ref(document: Mapping[str, Any]) -> bool:
+    try:
+        if not isinstance(document, Mapping):
+            return False
+        if document.get("verdict") != Verdict.VERIFIED.value:
+            return False
+        expected = compute_document_proof_ref(document)
+        stored = document["context"]["evidence"]["proof_ref"]
+        return isinstance(stored, str) and stored == expected
+    except Exception:
+        return False
+
+
+def resolve_context_proof_ref(
+    formal_statement: str,
+    context: VerificationContext,
+    proof_ref: Optional[str],
+) -> bool:
+    if proof_ref is None:
+        return False
+    try:
+        return compute_context_proof_ref(formal_statement, context) == proof_ref
+    except VerificationContextValidationError:
+        return False
+
+
 def _validate_verified_commitment(document: Mapping[str, Any]) -> None:
     if document.get("verdict") != Verdict.VERIFIED.value:
         return
-    expected = _expected_document_proof_ref(document)
-    proof_ref = document["context"]["evidence"]["proof_ref"]
-    if proof_ref != expected:
+    expected = compute_document_proof_ref(document)
+    try:
+        proof_ref = document["context"]["evidence"]["proof_ref"]
+    except Exception as exc:
+        raise VerificationContextValidationError(
+            "context.evidence.proof_ref is required for VERIFIED"
+        ) from exc
+    if not isinstance(proof_ref, str) or proof_ref != expected:
         raise VerificationContextValidationError(
             "context.evidence.proof_ref does not resolve against the bound payload"
         )

--- a/tests/test_verification_context_model.py
+++ b/tests/test_verification_context_model.py
@@ -612,3 +612,36 @@ def test_context_proof_ref_resolver():
     assert resolve_context_proof_ref("x**2 - 4 = 0", context, expected)
     assert not resolve_context_proof_ref("x**2 - 4 = 0", context, DUMMY_PROOF_REF)
     assert not resolve_context_proof_ref("x**2 - 4 = 0", context, None)
+
+
+def test_context_resolver_rejects_non_string_proof_ref():
+    class AlwaysEqual:
+        def __eq__(self, other):
+            return True
+
+    context = _context()
+    assert not resolve_context_proof_ref("x**2 - 4 = 0", context, AlwaysEqual())
+    assert not resolve_context_proof_ref("x**2 - 4 = 0", context, 123)
+    assert not resolve_context_proof_ref("x**2 - 4 = 0", context, [])
+
+
+def test_context_resolver_rejects_malformed_context():
+    assert not resolve_context_proof_ref("x", {}, DUMMY_PROOF_REF)
+
+
+def test_compute_document_proof_ref_rejects_non_mapping():
+    with pytest.raises(VerificationContextValidationError):
+        compute_document_proof_ref([])
+
+
+def test_resolver_rejects_schema_invalid_document_even_if_commitment_matches():
+    minimal = {
+        "spec_version": "1.0",
+        "object": {"formal_statement": "x"},
+        "context": {"evidence": {"evidence": {}, "proof_ref": None}},
+        "verdict": "VERIFIED",
+    }
+    minimal["context"]["evidence"]["proof_ref"] = compute_document_proof_ref(minimal)
+    assert not resolve_document_proof_ref(minimal)
+    with pytest.raises(VerificationContextValidationError):
+        validate_document(minimal)

--- a/tests/test_verification_context_model.py
+++ b/tests/test_verification_context_model.py
@@ -645,3 +645,9 @@ def test_resolver_rejects_schema_invalid_document_even_if_commitment_matches():
     assert not resolve_document_proof_ref(minimal)
     with pytest.raises(VerificationContextValidationError):
         validate_document(minimal)
+
+
+def test_context_resolver_rejects_non_string_formal_statement():
+    context = _context()
+    expected = compute_context_proof_ref("x**2 - 4 = 0", context)
+    assert not resolve_context_proof_ref(1, context, expected)

--- a/tests/test_verification_context_model.py
+++ b/tests/test_verification_context_model.py
@@ -18,8 +18,11 @@ from qwed_new.core.verification_context import (
     _canonical_json,
     _es_number_to_string,
     compute_context_proof_ref,
+    compute_document_proof_ref,
     is_valid_document,
     load_schema,
+    resolve_context_proof_ref,
+    resolve_document_proof_ref,
     validate_document,
 )
 
@@ -482,3 +485,130 @@ def test_configuration_is_immutable():
     )
     with pytest.raises(TypeError):
         doc.context.proof.configuration["timeout_ms"] = 1
+
+
+def test_document_proof_ref_producer_resolver_parity():
+    doc = VerificationContextDocument.verified(
+        formal_statement="x**2 - 4 = 0",
+        context=_context(),
+    )
+    payload = doc.to_dict()
+    stored = payload["context"]["evidence"]["proof_ref"]
+    assert compute_document_proof_ref(payload) == stored
+    assert resolve_document_proof_ref(payload)
+
+
+def test_resolver_rejects_tampered_formal_statement():
+    doc = VerificationContextDocument.verified(
+        formal_statement="x**2 - 4 = 0",
+        context=_context(),
+    )
+    payload = doc.to_dict()
+    payload["object"]["formal_statement"] = "x**2 - 9 = 0"
+    assert not resolve_document_proof_ref(payload)
+    with pytest.raises(VerificationContextValidationError):
+        validate_document(payload)
+
+
+def test_resolver_rejects_tampered_admission():
+    doc = VerificationContextDocument.verified(
+        formal_statement="x**2 - 4 = 0",
+        context=_context(admission=Admission.ADMIT),
+    )
+    payload = doc.to_dict()
+    payload["context"]["decision"]["admission"] = "DENY"
+    assert not resolve_document_proof_ref(payload)
+    with pytest.raises(VerificationContextValidationError):
+        validate_document(payload)
+
+
+def test_resolver_rejects_tampered_evidence():
+    doc = VerificationContextDocument.verified(
+        formal_statement="x**2 - 4 = 0",
+        context=_context(),
+    )
+    payload = doc.to_dict()
+    payload["context"]["evidence"]["evidence"]["roots"] = [-3, 3]
+    assert not resolve_document_proof_ref(payload)
+    with pytest.raises(VerificationContextValidationError):
+        validate_document(payload)
+
+
+def test_resolver_rejects_tampered_proof_layer():
+    doc = VerificationContextDocument.verified(
+        formal_statement="x**2 - 4 = 0",
+        context=_context(),
+    )
+    payload = doc.to_dict()
+    payload["context"]["proof"]["verifier"] = "Z3"
+    assert not resolve_document_proof_ref(payload)
+    with pytest.raises(VerificationContextValidationError):
+        validate_document(payload)
+
+
+def test_document_proof_ref_fails_closed_on_non_roundtrip_integer():
+    doc = VerificationContextDocument.verified(
+        formal_statement="x**2 - 4 = 0",
+        context=_context(),
+    )
+    payload = doc.to_dict()
+    payload["context"]["evidence"]["evidence"]["value"] = 2**53 + 1
+    with pytest.raises(VerificationContextValidationError):
+        compute_document_proof_ref(payload)
+    assert not resolve_document_proof_ref(payload)
+
+
+def test_document_proof_ref_fails_closed_on_non_string_key():
+    doc = VerificationContextDocument.verified(
+        formal_statement="x**2 - 4 = 0",
+        context=_context(),
+    )
+    payload = doc.to_dict()
+    payload["context"]["evidence"]["evidence"] = {1: "x"}
+    with pytest.raises(VerificationContextValidationError):
+        compute_document_proof_ref(payload)
+    assert not resolve_document_proof_ref(payload)
+
+
+def test_document_proof_ref_fails_closed_on_unpaired_surrogate():
+    doc = VerificationContextDocument.verified(
+        formal_statement="x**2 - 4 = 0",
+        context=_context(),
+    )
+    payload = doc.to_dict()
+    payload["context"]["evidence"]["evidence"] = {"value": chr(0xD800)}
+    with pytest.raises(VerificationContextValidationError):
+        compute_document_proof_ref(payload)
+    assert not resolve_document_proof_ref(payload)
+
+
+def test_document_proof_ref_fails_closed_on_missing_bound_fields():
+    doc = VerificationContextDocument.verified(
+        formal_statement="x**2 - 4 = 0",
+        context=_context(),
+    )
+    payload = doc.to_dict()
+    del payload["context"]["evidence"]
+    with pytest.raises(VerificationContextValidationError):
+        compute_document_proof_ref(payload)
+    assert not resolve_document_proof_ref(payload)
+
+
+def test_resolver_returns_false_for_fail_closed_verdicts():
+    doc = VerificationContextDocument.unverifiable(
+        formal_statement="x**2 - 4 = 0",
+        context=_context(),
+    )
+    assert not resolve_document_proof_ref(doc.to_dict())
+
+
+def test_resolver_returns_false_for_non_mapping():
+    assert not resolve_document_proof_ref([])
+
+
+def test_context_proof_ref_resolver():
+    context = _context()
+    expected = compute_context_proof_ref("x**2 - 4 = 0", context)
+    assert resolve_context_proof_ref("x**2 - 4 = 0", context, expected)
+    assert not resolve_context_proof_ref("x**2 - 4 = 0", context, DUMMY_PROOF_REF)
+    assert not resolve_context_proof_ref("x**2 - 4 = 0", context, None)


### PR DESCRIPTION
## **User description**
Closes #304.

Adds the public Verification Context `proof_ref` generation/resolution surface required by spec v1.0 section 3.3.

Changes:
- Adds `compute_document_proof_ref` for raw Verification Context documents.
- Adds `resolve_document_proof_ref` for fail-closed commitment resolution of raw documents.
- Adds `resolve_context_proof_ref` for typed `VerificationContext` commitments.
- Keeps the bound payload normative:
  - `formal_statement` + complete `context`
  - excludes `context.evidence.proof_ref`
  - excludes `object.formalization`
- Keeps canonical encoding fail-closed:
  - RFC 8785 / UTF-16-BE key ordering
  - non-string object keys rejected
  - unpaired UTF-16 surrogates rejected
  - non-finite numbers rejected
  - non-round-trippable integers rejected

Verification:
- Producer/resolver parity tests added.
- Tampering tests added for formal statement, evidence, proof layer, and admission.
- Encoding-failure and missing-field fail-closed tests added.
- Full suite: 1938 passed, 102 skipped.
- ruff clean.
- mypy clean.


___

## **CodeAnt-AI Description**
Add public proof reference generation and verification for Verification Context documents

### What Changed
- Applications can generate proof references for raw Verification Context documents and typed contexts.
- Applications can check whether a stored proof reference matches the document’s formal statement and verification context.
- Verification rejects altered statements, decisions, evidence, proof details, missing fields, invalid values, and non-verified documents.
- Proof reference calculation now reports invalid or incomplete documents through validation errors instead of accepting them.

### Impact
`✅ Detects tampered verification documents`
`✅ Fail-closed proof reference checks`
`✅ Public proof reference validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document-level proof-reference computation and validation.
  * Added context-level proof-reference resolution to verify evidence integrity.

* **Bug Fixes**
  * Strengthened handling of missing, invalid, or tampered proof references.
  * Verification now fails safely when evidence or required document details are invalid.

* **Tests**
  * Added coverage for valid references, tampered documents, invalid evidence, missing fields, and failed verification outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->