### PR TITLE
feat: map StatsVerifier DiagnosticResult to VerificationContext

### DIFF
--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -112,6 +112,16 @@ def _qwed_package_version() -> str:
         ) from exc
 
 
+def _has_stats_proof_binding(result: DiagnosticResult) -> bool:
+    fields = result.developer_fields
+    if fields.get("constraint_id") != CONSTRAINT_STATS_VALID:
+        return False
+    dataset_sha256 = fields.get("dataset_sha256")
+    if not isinstance(dataset_sha256, str) or not dataset_sha256.strip():
+        return False
+    return fields.get("claim_supported") is True
+
+
 @dataclass
 class ExecutionResult:
     """Result of code execution."""
@@ -641,7 +651,10 @@ class StatsVerifier:
         evidence_payload = result.to_dict()
 
         if result.status is DiagnosticStatus.VERIFIED:
-            if result.developer_fields.get("is_valid") is not True:
+            if (
+                result.developer_fields.get("is_valid") is not True
+                or not _has_stats_proof_binding(result)
+            ):
                 context = VerificationContext(
                     interpretation=interpretation,
                     proof=proof,

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -106,8 +106,10 @@ def _dataset_fingerprint(df: pd.DataFrame) -> str:
 def _qwed_package_version() -> str:
     try:
         return version("qwed")
-    except PackageNotFoundError:
-        return "unknown"
+    except PackageNotFoundError as exc:
+        raise VerificationContextValidationError(
+            "qwed package metadata is unavailable"
+        ) from exc
 
 
 @dataclass
@@ -639,16 +641,23 @@ class StatsVerifier:
         evidence_payload = result.to_dict()
 
         if result.status is DiagnosticStatus.VERIFIED:
-            admission = (
-                Admission.ADMIT
-                if result.developer_fields.get("is_valid") is True
-                else Admission.DENY
-            )
+            if result.developer_fields.get("is_valid") is not True:
+                context = VerificationContext(
+                    interpretation=interpretation,
+                    proof=proof,
+                    evidence=Evidence(payload=evidence_payload, proof_ref=None),
+                    decision=Decision(admission=Admission.DENY),
+                )
+                return VerificationContextDocument.unverifiable(
+                    formal_statement=query,
+                    context=context,
+                    formalization=formalization,
+                )
             context = VerificationContext(
                 interpretation=interpretation,
                 proof=proof,
                 evidence=Evidence(payload=evidence_payload, proof_ref=None),
-                decision=Decision(admission=admission),
+                decision=Decision(admission=Admission.ADMIT),
             )
             return VerificationContextDocument.verified(
                 formal_statement=query,

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -17,6 +17,7 @@ import time
 import json
 import hashlib
 import re
+import uuid
 from typing import Optional, Dict, Any, Tuple, List
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
@@ -114,6 +115,7 @@ def _qwed_package_version() -> str:
 
 
 _SHA256_HEX_PATTERN = re.compile(r"[0-9a-fA-F]{64}")
+_PROOF_REF_PATTERN = re.compile(r"sha256:[a-f0-9]{64}")
 
 
 def _is_sha256_hex(value: Any) -> bool:
@@ -152,6 +154,15 @@ class SecurityReport:
     checks_passed: List[str] = field(default_factory=list)
     checks_failed: List[str] = field(default_factory=list)
     risk_level: str = "unknown"  # "low", "medium", "high", "critical"
+
+
+@dataclass
+class StatsExecutionReceipt:
+    receipt_id: str
+    query: str
+    dataset_sha256: str
+    claim_sha256: str
+    proof_ref: str
 
 
 class WasmSandbox:
@@ -387,6 +398,7 @@ class StatsVerifier:
         
         # Determine available sandboxes
         self._sandbox_availability = {}
+        self._execution_receipts: Dict[str, StatsExecutionReceipt] = {}
     
     @property
     def translator(self):
@@ -635,12 +647,65 @@ class StatsVerifier:
             },
         )
     
+    def _register_execution_receipt(
+        self,
+        query: str,
+        dataset_sha256: str,
+        claim_sha256: str,
+        proof_ref: str,
+    ) -> str:
+        if not query or not query.strip():
+            raise VerificationContextValidationError(
+                "execution receipt requires a non-empty query"
+            )
+        if not _is_sha256_hex(dataset_sha256):
+            raise VerificationContextValidationError(
+                "execution receipt requires a valid dataset_sha256"
+            )
+        if not _is_sha256_hex(claim_sha256):
+            raise VerificationContextValidationError(
+                "execution receipt requires a valid claim_sha256"
+            )
+        if not isinstance(proof_ref, str) or not _PROOF_REF_PATTERN.fullmatch(proof_ref):
+            raise VerificationContextValidationError(
+                "execution receipt requires a valid proof_ref"
+            )
+        receipt_id = f"stats_receipt_{uuid.uuid4().hex}"
+        self._execution_receipts[receipt_id] = StatsExecutionReceipt(
+            receipt_id=receipt_id,
+            query=query,
+            dataset_sha256=dataset_sha256,
+            claim_sha256=claim_sha256,
+            proof_ref=proof_ref,
+        )
+        return receipt_id
+
+    def _verify_execution_receipt(
+        self,
+        receipt_id: Optional[str],
+        query: str,
+        result: DiagnosticResult,
+    ) -> bool:
+        if not isinstance(receipt_id, str):
+            return False
+        receipt = self._execution_receipts.get(receipt_id)
+        if receipt is None:
+            return False
+        fields = result.developer_fields
+        return (
+            receipt.query == query
+            and receipt.proof_ref == result.proof_ref
+            and fields.get("dataset_sha256") == receipt.dataset_sha256
+            and fields.get("claim_sha256") == receipt.claim_sha256
+        )
+
     def to_verification_context(
         self,
         result: DiagnosticResult,
         query: str,
         *,
         attestation_token: Optional[str] = None,
+        execution_receipt_id: Optional[str] = None,
     ) -> VerificationContextDocument:
         interpretation = Interpretation(
             theory="tabular statistics",
@@ -674,6 +739,18 @@ class StatsVerifier:
         evidence_payload = result.to_dict()
 
         if result.status is DiagnosticStatus.VERIFIED:
+            if not self._verify_execution_receipt(execution_receipt_id, query, result):
+                context = VerificationContext(
+                    interpretation=interpretation,
+                    proof=proof,
+                    evidence=Evidence(payload=evidence_payload, proof_ref=None),
+                    decision=Decision(admission=Admission.DENY),
+                )
+                return VerificationContextDocument.blocked(
+                    formal_statement=query,
+                    context=context,
+                    formalization=formalization,
+                )
             if (
                 result.developer_fields.get("is_valid") is not True
                 or not _has_stats_proof_binding(result, query)

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
 import ast
 
-from .diagnostics import DiagnosticResult, DiagnosticStatus
+from .diagnostics import DiagnosticResult, DiagnosticStatus, enforce_trust_decision
 from .verification_context import (
     Admission,
     Decision,
@@ -639,6 +639,8 @@ class StatsVerifier:
         self,
         result: DiagnosticResult,
         query: str,
+        *,
+        attestation_token: Optional[str] = None,
     ) -> VerificationContextDocument:
         interpretation = Interpretation(
             theory="tabular statistics",
@@ -660,6 +662,15 @@ class StatsVerifier:
             source_query=query,
             translator="StatsVerifier",
         )
+
+        if result.status is DiagnosticStatus.VERIFIED:
+            result = enforce_trust_decision(
+                result,
+                attestation_token=attestation_token,
+                require_attestation=True,
+                query=query,
+            )
+
         evidence_payload = result.to_dict()
 
         if result.status is DiagnosticStatus.VERIFIED:

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -18,9 +18,21 @@ import json
 import hashlib
 from typing import Optional, Dict, Any, Tuple, List
 from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError, version
 import ast
 
-from .diagnostics import DiagnosticResult
+from .diagnostics import DiagnosticResult, DiagnosticStatus
+from .verification_context import (
+    Admission,
+    Decision,
+    Evidence,
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContext,
+    VerificationContextDocument,
+    VerificationContextValidationError,
+)
 
 logger = logging.getLogger(__name__)
 INTERNAL_VERIFICATION_ERROR = "Internal verification error"
@@ -89,6 +101,13 @@ def _dataset_fingerprint(df: pd.DataFrame) -> str:
         raise DatasetFingerprintError(
             f"dataset fingerprint failed: {type(exc).__name__}"
         ) from exc
+
+
+def _qwed_package_version() -> str:
+    try:
+        return version("qwed")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 @dataclass
@@ -592,6 +611,73 @@ class StatsVerifier:
             },
         )
     
+    def to_verification_context(
+        self,
+        result: DiagnosticResult,
+        query: str,
+    ) -> VerificationContextDocument:
+        interpretation = Interpretation(
+            theory="tabular statistics",
+            logic="deterministic sandbox execution",
+        )
+        proof = Proof(
+            verifier="StatsVerifier",
+            verifier_version=_qwed_package_version(),
+            configuration={
+                "preferred_sandbox": self.preferred_sandbox,
+                "timeout_seconds": self.timeout_seconds,
+                "memory_limit_mb": self.memory_limit_mb,
+            },
+            theory_scope="tabular statistical claims executed in a secure Docker sandbox",
+            trusted_dependencies=("pandas", "docker"),
+            outcome_treatment="unknown/timeout/error resolve to UNVERIFIABLE or BLOCKED",
+        )
+        formalization = Formalization(
+            source_query=query,
+            translator="StatsVerifier",
+        )
+        evidence_payload = result.to_dict()
+
+        if result.status is DiagnosticStatus.VERIFIED:
+            admission = (
+                Admission.ADMIT
+                if result.developer_fields.get("is_valid") is True
+                else Admission.DENY
+            )
+            context = VerificationContext(
+                interpretation=interpretation,
+                proof=proof,
+                evidence=Evidence(payload=evidence_payload, proof_ref=None),
+                decision=Decision(admission=admission),
+            )
+            return VerificationContextDocument.verified(
+                formal_statement=query,
+                context=context,
+                formalization=formalization,
+            )
+
+        context = VerificationContext(
+            interpretation=interpretation,
+            proof=proof,
+            evidence=Evidence(payload=evidence_payload, proof_ref=None),
+            decision=Decision(admission=Admission.DENY),
+        )
+        if result.status is DiagnosticStatus.UNVERIFIABLE:
+            return VerificationContextDocument.unverifiable(
+                formal_statement=query,
+                context=context,
+                formalization=formalization,
+            )
+        if result.status is DiagnosticStatus.BLOCKED:
+            return VerificationContextDocument.blocked(
+                formal_statement=query,
+                context=context,
+                formalization=formalization,
+            )
+        raise VerificationContextValidationError(
+            f"unsupported DiagnosticResult status: {result.status!r}"
+        )
+
     def _validate_security(self, code: str) -> SecurityReport:
         """Perform comprehensive security validation."""
         checks_passed = []

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -16,6 +16,7 @@ import logging
 import time
 import json
 import hashlib
+import re
 from typing import Optional, Dict, Any, Tuple, List
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
@@ -112,14 +113,25 @@ def _qwed_package_version() -> str:
         ) from exc
 
 
-def _has_stats_proof_binding(result: DiagnosticResult) -> bool:
+_SHA256_HEX_PATTERN = re.compile(r"[0-9a-fA-F]{64}")
+
+
+def _is_sha256_hex(value: Any) -> bool:
+    return isinstance(value, str) and _SHA256_HEX_PATTERN.fullmatch(value) is not None
+
+
+def _has_stats_proof_binding(result: DiagnosticResult, query: str) -> bool:
     fields = result.developer_fields
     if fields.get("constraint_id") != CONSTRAINT_STATS_VALID:
         return False
-    dataset_sha256 = fields.get("dataset_sha256")
-    if not isinstance(dataset_sha256, str) or not dataset_sha256.strip():
+    if not _is_sha256_hex(fields.get("dataset_sha256")):
         return False
-    return fields.get("claim_supported") is True
+    if fields.get("claim_supported") is not True:
+        return False
+    claim_sha256 = fields.get("claim_sha256")
+    if not _is_sha256_hex(claim_sha256):
+        return False
+    return claim_sha256 == hashlib.sha256(query.encode("utf-8")).hexdigest()
 
 
 @dataclass
@@ -653,7 +665,7 @@ class StatsVerifier:
         if result.status is DiagnosticStatus.VERIFIED:
             if (
                 result.developer_fields.get("is_valid") is not True
-                or not _has_stats_proof_binding(result)
+                or not _has_stats_proof_binding(result, query)
             ):
                 context = VerificationContext(
                     interpretation=interpretation,

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -16,8 +16,6 @@ import logging
 import time
 import json
 import hashlib
-import re
-import uuid
 from typing import Optional, Dict, Any, Tuple, List
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
@@ -114,27 +112,6 @@ def _qwed_package_version() -> str:
         ) from exc
 
 
-_SHA256_HEX_PATTERN = re.compile(r"[0-9a-fA-F]{64}")
-_PROOF_REF_PATTERN = re.compile(r"sha256:[a-f0-9]{64}")
-
-
-def _is_sha256_hex(value: Any) -> bool:
-    return isinstance(value, str) and _SHA256_HEX_PATTERN.fullmatch(value) is not None
-
-
-def _has_stats_proof_binding(result: DiagnosticResult, query: str) -> bool:
-    fields = result.developer_fields
-    if fields.get("constraint_id") != CONSTRAINT_STATS_VALID:
-        return False
-    if not _is_sha256_hex(fields.get("dataset_sha256")):
-        return False
-    if fields.get("claim_supported") is not True:
-        return False
-    claim_sha256 = fields.get("claim_sha256")
-    if not _is_sha256_hex(claim_sha256):
-        return False
-    return claim_sha256 == hashlib.sha256(query.encode("utf-8")).hexdigest()
-
 
 @dataclass
 class ExecutionResult:
@@ -154,15 +131,6 @@ class SecurityReport:
     checks_passed: List[str] = field(default_factory=list)
     checks_failed: List[str] = field(default_factory=list)
     risk_level: str = "unknown"  # "low", "medium", "high", "critical"
-
-
-@dataclass
-class StatsExecutionReceipt:
-    receipt_id: str
-    query: str
-    dataset_sha256: str
-    claim_sha256: str
-    proof_ref: str
 
 
 class WasmSandbox:
@@ -398,7 +366,6 @@ class StatsVerifier:
         
         # Determine available sandboxes
         self._sandbox_availability = {}
-        self._execution_receipts: Dict[str, StatsExecutionReceipt] = {}
     
     @property
     def translator(self):
@@ -647,65 +614,10 @@ class StatsVerifier:
             },
         )
     
-    def _register_execution_receipt(
-        self,
-        query: str,
-        dataset_sha256: str,
-        claim_sha256: str,
-        proof_ref: str,
-    ) -> str:
-        if not query or not query.strip():
-            raise VerificationContextValidationError(
-                "execution receipt requires a non-empty query"
-            )
-        if not _is_sha256_hex(dataset_sha256):
-            raise VerificationContextValidationError(
-                "execution receipt requires a valid dataset_sha256"
-            )
-        if not _is_sha256_hex(claim_sha256):
-            raise VerificationContextValidationError(
-                "execution receipt requires a valid claim_sha256"
-            )
-        if not isinstance(proof_ref, str) or not _PROOF_REF_PATTERN.fullmatch(proof_ref):
-            raise VerificationContextValidationError(
-                "execution receipt requires a valid proof_ref"
-            )
-        receipt_id = f"stats_receipt_{uuid.uuid4().hex}"
-        self._execution_receipts[receipt_id] = StatsExecutionReceipt(
-            receipt_id=receipt_id,
-            query=query,
-            dataset_sha256=dataset_sha256,
-            claim_sha256=claim_sha256,
-            proof_ref=proof_ref,
-        )
-        return receipt_id
-
-    def _verify_execution_receipt(
-        self,
-        receipt_id: Optional[str],
-        query: str,
-        result: DiagnosticResult,
-    ) -> bool:
-        if not isinstance(receipt_id, str):
-            return False
-        receipt = self._execution_receipts.get(receipt_id)
-        if receipt is None:
-            return False
-        fields = result.developer_fields
-        return (
-            receipt.query == query
-            and receipt.proof_ref == result.proof_ref
-            and fields.get("dataset_sha256") == receipt.dataset_sha256
-            and fields.get("claim_sha256") == receipt.claim_sha256
-        )
-
     def to_verification_context(
         self,
         result: DiagnosticResult,
         query: str,
-        *,
-        attestation_token: Optional[str] = None,
-        execution_receipt_id: Optional[str] = None,
     ) -> VerificationContextDocument:
         interpretation = Interpretation(
             theory="tabular statistics",
@@ -731,48 +643,20 @@ class StatsVerifier:
         if result.status is DiagnosticStatus.VERIFIED:
             result = enforce_trust_decision(
                 result,
-                attestation_token=attestation_token,
-                require_attestation=True,
+                require_attestation=False,
                 query=query,
             )
 
         evidence_payload = result.to_dict()
 
         if result.status is DiagnosticStatus.VERIFIED:
-            if not self._verify_execution_receipt(execution_receipt_id, query, result):
-                context = VerificationContext(
-                    interpretation=interpretation,
-                    proof=proof,
-                    evidence=Evidence(payload=evidence_payload, proof_ref=None),
-                    decision=Decision(admission=Admission.DENY),
-                )
-                return VerificationContextDocument.blocked(
-                    formal_statement=query,
-                    context=context,
-                    formalization=formalization,
-                )
-            if (
-                result.developer_fields.get("is_valid") is not True
-                or not _has_stats_proof_binding(result, query)
-            ):
-                context = VerificationContext(
-                    interpretation=interpretation,
-                    proof=proof,
-                    evidence=Evidence(payload=evidence_payload, proof_ref=None),
-                    decision=Decision(admission=Admission.DENY),
-                )
-                return VerificationContextDocument.unverifiable(
-                    formal_statement=query,
-                    context=context,
-                    formalization=formalization,
-                )
             context = VerificationContext(
                 interpretation=interpretation,
                 proof=proof,
                 evidence=Evidence(payload=evidence_payload, proof_ref=None),
-                decision=Decision(admission=Admission.ADMIT),
+                decision=Decision(admission=Admission.DENY),
             )
-            return VerificationContextDocument.verified(
+            return VerificationContextDocument.blocked(
                 formal_statement=query,
                 context=context,
                 formalization=formalization,

--- a/tests/test_stats_verification_context.py
+++ b/tests/test_stats_verification_context.py
@@ -2,18 +2,27 @@ import pytest
 from importlib.metadata import PackageNotFoundError
 
 from qwed_new.core.diagnostics import DiagnosticResult
-from qwed_new.core.stats_verifier import StatsVerifier
+from qwed_new.core.stats_verifier import (
+    CONSTRAINT_STATS_VALID,
+    StatsVerifier,
+)
 from qwed_new.core.verification_context import (
     VerificationContextValidationError,
     resolve_document_proof_ref,
 )
 
 
+DATASET_SHA256 = "a" * 64
+
+
 def _verified_result(is_valid=True):
     return DiagnosticResult.verified(
         agent_message="Statistical claim verified.",
         developer_fields={
+            "constraint_id": CONSTRAINT_STATS_VALID,
             "is_valid": is_valid,
+            "claim_supported": True,
+            "dataset_sha256": DATASET_SHA256,
             "observed_result": 2.0,
         },
         evidence={"observed_result": 2.0},
@@ -90,7 +99,13 @@ def test_stats_context_fails_closed_on_non_finite_evidence():
     verifier = StatsVerifier()
     result = DiagnosticResult.verified(
         agent_message="Statistical claim verified.",
-        developer_fields={"is_valid": True, "value": float("nan")},
+        developer_fields={
+            "constraint_id": CONSTRAINT_STATS_VALID,
+            "is_valid": True,
+            "claim_supported": True,
+            "dataset_sha256": DATASET_SHA256,
+            "value": float("nan"),
+        },
         evidence={"value": float("nan")},
     )
     with pytest.raises(VerificationContextValidationError):
@@ -119,5 +134,43 @@ def test_stats_context_fails_closed_when_package_version_unavailable(monkeypatch
     monkeypatch.setattr("qwed_new.core.stats_verifier.version", _raise_package_not_found)
     verifier = StatsVerifier()
     result = _verified_result()
-    with pytest.raises(VerificationContextValidationError):
+    with pytest.raises(
+        VerificationContextValidationError,
+        match="qwed package metadata is unavailable",
+    ):
         verifier.to_verification_context(result, "mean of a == 2")
+
+
+def test_stats_verified_unbound_result_fails_closed():
+    verifier = StatsVerifier()
+    result = DiagnosticResult.verified(
+        agent_message="Statistical claim verified.",
+        developer_fields={"is_valid": True, "observed_result": 2.0},
+        evidence={"observed_result": 2.0},
+    )
+    doc = verifier.to_verification_context(result, "mean of a == 2")
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "UNVERIFIABLE"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_stats_verified_missing_claim_support_fails_closed():
+    verifier = StatsVerifier()
+    result = DiagnosticResult.verified(
+        agent_message="Statistical claim verified.",
+        developer_fields={
+            "constraint_id": CONSTRAINT_STATS_VALID,
+            "is_valid": True,
+            "dataset_sha256": DATASET_SHA256,
+            "observed_result": 2.0,
+        },
+        evidence={"observed_result": 2.0},
+    )
+    doc = verifier.to_verification_context(result, "mean of a == 2")
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "UNVERIFIABLE"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"

--- a/tests/test_stats_verification_context.py
+++ b/tests/test_stats_verification_context.py
@@ -57,6 +57,15 @@ def _attestation_token(query=QUERY, proof_data=PROOF_DATA):
     return attestation_result.token
 
 
+def _register_receipt(verifier, result, query=QUERY):
+    return verifier._register_execution_receipt(
+        query,
+        DATASET_SHA256,
+        CLAIM_SHA256,
+        result.proof_ref,
+    )
+
+
 def _assert_fail_closed(payload, expected_verdict):
     assert payload["verdict"] == expected_verdict
     assert payload["context"]["evidence"]["proof_ref"] is None
@@ -70,6 +79,7 @@ def test_stats_verified_context_valid_and_resolves():
         result,
         QUERY,
         attestation_token=_attestation_token(),
+        execution_receipt_id=_register_receipt(verifier, result),
     )
     doc.validate()
     payload = doc.to_dict()
@@ -82,17 +92,49 @@ def test_stats_verified_context_valid_and_resolves():
 
 def test_stats_verified_without_attestation_fails_closed():
     verifier = StatsVerifier()
-    doc = verifier.to_verification_context(_verified_result(), QUERY)
+    result = _verified_result()
+    doc = verifier.to_verification_context(
+        result,
+        QUERY,
+        execution_receipt_id=_register_receipt(verifier, result),
+    )
     doc.validate()
     _assert_fail_closed(doc.to_dict(), "BLOCKED")
 
 
 def test_stats_verified_with_invalid_attestation_fails_closed():
     verifier = StatsVerifier()
+    result = _verified_result()
     doc = verifier.to_verification_context(
-        _verified_result(),
+        result,
         QUERY,
         attestation_token="invalid",
+        execution_receipt_id=_register_receipt(verifier, result),
+    )
+    doc.validate()
+    _assert_fail_closed(doc.to_dict(), "BLOCKED")
+
+
+def test_stats_verified_without_execution_receipt_fails_closed():
+    verifier = StatsVerifier()
+    result = _verified_result()
+    doc = verifier.to_verification_context(
+        result,
+        QUERY,
+        attestation_token=_attestation_token(),
+    )
+    doc.validate()
+    _assert_fail_closed(doc.to_dict(), "BLOCKED")
+
+
+def test_stats_verified_with_invalid_execution_receipt_fails_closed():
+    verifier = StatsVerifier()
+    result = _verified_result()
+    doc = verifier.to_verification_context(
+        result,
+        QUERY,
+        attestation_token=_attestation_token(),
+        execution_receipt_id="stats_receipt_missing",
     )
     doc.validate()
     _assert_fail_closed(doc.to_dict(), "BLOCKED")
@@ -105,6 +147,7 @@ def test_stats_verified_invalid_result_fails_closed():
         result,
         QUERY,
         attestation_token=_attestation_token(),
+        execution_receipt_id=_register_receipt(verifier, result),
     )
     doc.validate()
     _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
@@ -117,6 +160,7 @@ def test_stats_verified_missing_is_valid_fails_closed():
         result,
         QUERY,
         attestation_token=_attestation_token(),
+        execution_receipt_id=_register_receipt(verifier, result),
     )
     doc.validate()
     _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
@@ -136,31 +180,7 @@ def test_stats_verified_unbound_result_fails_closed():
         attestation_token=_attestation_token(),
     )
     doc.validate()
-    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
-
-
-def test_stats_verified_malformed_dataset_digest_fails_closed():
-    verifier = StatsVerifier()
-    result = _verified_result(developer_overrides={"dataset_sha256": "not-a-sha256"})
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        attestation_token=_attestation_token(),
-    )
-    doc.validate()
-    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
-
-
-def test_stats_verified_malformed_claim_digest_fails_closed():
-    verifier = StatsVerifier()
-    result = _verified_result(developer_overrides={"claim_sha256": "not-a-sha256"})
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        attestation_token=_attestation_token(),
-    )
-    doc.validate()
-    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
+    _assert_fail_closed(doc.to_dict(), "BLOCKED")
 
 
 def test_stats_verified_mismatched_query_fails_closed():
@@ -170,6 +190,7 @@ def test_stats_verified_mismatched_query_fails_closed():
         result,
         "sum of revenue == 999999",
         attestation_token=_attestation_token(),
+        execution_receipt_id=_register_receipt(verifier, result),
     )
     doc.validate()
     _assert_fail_closed(doc.to_dict(), "BLOCKED")
@@ -204,6 +225,7 @@ def test_stats_context_tampering_invalidates_proof_ref():
         result,
         QUERY,
         attestation_token=_attestation_token(),
+        execution_receipt_id=_register_receipt(verifier, result),
     )
     payload = doc.to_dict()
     payload["context"]["evidence"]["evidence"]["developer_fields"]["observed_result"] = 3.0
@@ -232,11 +254,13 @@ def test_stats_context_fails_closed_on_non_finite_evidence():
         proof_data=nan_proof_data,
     )
     attestation_token = _attestation_token(proof_data=nan_proof_data)
+    receipt_id = _register_receipt(verifier, result)
     with pytest.raises(VerificationContextValidationError):
         verifier.to_verification_context(
             result,
             QUERY,
             attestation_token=attestation_token,
+            execution_receipt_id=receipt_id,
         )
 
 

--- a/tests/test_stats_verification_context.py
+++ b/tests/test_stats_verification_context.py
@@ -1,8 +1,10 @@
 import hashlib
+import json
 
 import pytest
 from importlib.metadata import PackageNotFoundError
 
+from qwed_new.core.attestation import create_verification_attestation
 from qwed_new.core.diagnostics import DiagnosticResult
 from qwed_new.core.stats_verifier import (
     CONSTRAINT_STATS_VALID,
@@ -13,30 +15,62 @@ from qwed_new.core.verification_context import (
     resolve_document_proof_ref,
 )
 
-
 DATASET_SHA256 = "a" * 64
 QUERY = "mean of a == 2"
 CLAIM_SHA256 = hashlib.sha256(QUERY.encode("utf-8")).hexdigest()
+PROOF_DATA = json.dumps({"observed_result": 2.0}, sort_keys=True)
 
 
-def _verified_result(is_valid=True):
+def _binding_fields():
+    return {
+        "constraint_id": CONSTRAINT_STATS_VALID,
+        "is_valid": True,
+        "claim_supported": True,
+        "dataset_sha256": DATASET_SHA256,
+        "claim_sha256": CLAIM_SHA256,
+        "observed_result": 2.0,
+    }
+
+
+def _verified_result(is_valid=True, developer_overrides=None):
+    developer_fields = _binding_fields()
+    developer_fields["is_valid"] = is_valid
+    if developer_overrides:
+        developer_fields.update(developer_overrides)
     return DiagnosticResult.verified(
         agent_message="Statistical claim verified.",
-        developer_fields={
-            "constraint_id": CONSTRAINT_STATS_VALID,
-            "is_valid": is_valid,
-            "claim_supported": True,
-            "dataset_sha256": DATASET_SHA256,
-            "claim_sha256": CLAIM_SHA256,
-            "observed_result": 2.0,
-        },
+        developer_fields=developer_fields,
         evidence={"observed_result": 2.0},
+        proof_data=PROOF_DATA,
     )
+
+
+def _attestation_token(query=QUERY, proof_data=PROOF_DATA):
+    attestation_result = create_verification_attestation(
+        status="VERIFIED",
+        verified=True,
+        engine="stats",
+        query=query,
+        proof_data=proof_data,
+    )
+    assert attestation_result.is_issued
+    return attestation_result.token
+
+
+def _assert_fail_closed(payload, expected_verdict):
+    assert payload["verdict"] == expected_verdict
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
 
 
 def test_stats_verified_context_valid_and_resolves():
     verifier = StatsVerifier()
-    doc = verifier.to_verification_context(_verified_result(), "mean of a == 2")
+    result = _verified_result()
+    doc = verifier.to_verification_context(
+        result,
+        QUERY,
+        attestation_token=_attestation_token(),
+    )
     doc.validate()
     payload = doc.to_dict()
     assert payload["verdict"] == "VERIFIED"
@@ -46,15 +80,99 @@ def test_stats_verified_context_valid_and_resolves():
     assert resolve_document_proof_ref(payload)
 
 
+def test_stats_verified_without_attestation_fails_closed():
+    verifier = StatsVerifier()
+    doc = verifier.to_verification_context(_verified_result(), QUERY)
+    doc.validate()
+    _assert_fail_closed(doc.to_dict(), "BLOCKED")
+
+
+def test_stats_verified_with_invalid_attestation_fails_closed():
+    verifier = StatsVerifier()
+    doc = verifier.to_verification_context(
+        _verified_result(),
+        QUERY,
+        attestation_token="invalid",
+    )
+    doc.validate()
+    _assert_fail_closed(doc.to_dict(), "BLOCKED")
+
+
 def test_stats_verified_invalid_result_fails_closed():
     verifier = StatsVerifier()
     result = _verified_result(is_valid=False)
-    doc = verifier.to_verification_context(result, "mean of a == 2")
+    doc = verifier.to_verification_context(
+        result,
+        QUERY,
+        attestation_token=_attestation_token(),
+    )
     doc.validate()
-    payload = doc.to_dict()
-    assert payload["verdict"] == "UNVERIFIABLE"
-    assert payload["context"]["evidence"]["proof_ref"] is None
-    assert payload["context"]["decision"]["admission"] == "DENY"
+    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
+
+
+def test_stats_verified_missing_is_valid_fails_closed():
+    verifier = StatsVerifier()
+    result = _verified_result(developer_overrides={"is_valid": None})
+    doc = verifier.to_verification_context(
+        result,
+        QUERY,
+        attestation_token=_attestation_token(),
+    )
+    doc.validate()
+    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
+
+
+def test_stats_verified_unbound_result_fails_closed():
+    verifier = StatsVerifier()
+    result = DiagnosticResult.verified(
+        agent_message="Statistical claim verified.",
+        developer_fields={"is_valid": True, "observed_result": 2.0},
+        evidence={"observed_result": 2.0},
+        proof_data=PROOF_DATA,
+    )
+    doc = verifier.to_verification_context(
+        result,
+        QUERY,
+        attestation_token=_attestation_token(),
+    )
+    doc.validate()
+    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
+
+
+def test_stats_verified_malformed_dataset_digest_fails_closed():
+    verifier = StatsVerifier()
+    result = _verified_result(developer_overrides={"dataset_sha256": "not-a-sha256"})
+    doc = verifier.to_verification_context(
+        result,
+        QUERY,
+        attestation_token=_attestation_token(),
+    )
+    doc.validate()
+    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
+
+
+def test_stats_verified_malformed_claim_digest_fails_closed():
+    verifier = StatsVerifier()
+    result = _verified_result(developer_overrides={"claim_sha256": "not-a-sha256"})
+    doc = verifier.to_verification_context(
+        result,
+        QUERY,
+        attestation_token=_attestation_token(),
+    )
+    doc.validate()
+    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
+
+
+def test_stats_verified_mismatched_query_fails_closed():
+    verifier = StatsVerifier()
+    result = _verified_result()
+    doc = verifier.to_verification_context(
+        result,
+        "sum of revenue == 999999",
+        attestation_token=_attestation_token(),
+    )
+    doc.validate()
+    _assert_fail_closed(doc.to_dict(), "BLOCKED")
 
 
 def test_stats_unverifiable_context_fail_closed():
@@ -63,12 +181,9 @@ def test_stats_unverifiable_context_fail_closed():
         agent_message="Claim could not be verified.",
         developer_fields={"is_valid": False},
     )
-    doc = verifier.to_verification_context(result, "mean of a == 2")
+    doc = verifier.to_verification_context(result, QUERY)
     doc.validate()
-    payload = doc.to_dict()
-    assert payload["verdict"] == "UNVERIFIABLE"
-    assert payload["context"]["evidence"]["proof_ref"] is None
-    assert payload["context"]["decision"]["admission"] == "DENY"
+    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
 
 
 def test_stats_blocked_context_fail_closed():
@@ -77,17 +192,19 @@ def test_stats_blocked_context_fail_closed():
         agent_message="Verification could not be attempted.",
         developer_fields={"is_valid": False},
     )
-    doc = verifier.to_verification_context(result, "mean of a == 2")
+    doc = verifier.to_verification_context(result, QUERY)
     doc.validate()
-    payload = doc.to_dict()
-    assert payload["verdict"] == "BLOCKED"
-    assert payload["context"]["evidence"]["proof_ref"] is None
-    assert payload["context"]["decision"]["admission"] == "DENY"
+    _assert_fail_closed(doc.to_dict(), "BLOCKED")
 
 
 def test_stats_context_tampering_invalidates_proof_ref():
     verifier = StatsVerifier()
-    doc = verifier.to_verification_context(_verified_result(), "mean of a == 2")
+    result = _verified_result()
+    doc = verifier.to_verification_context(
+        result,
+        QUERY,
+        attestation_token=_attestation_token(),
+    )
     payload = doc.to_dict()
     payload["context"]["evidence"]["evidence"]["developer_fields"]["observed_result"] = 3.0
     assert not resolve_document_proof_ref(payload)
@@ -95,42 +212,31 @@ def test_stats_context_tampering_invalidates_proof_ref():
 
 def test_stats_context_rejects_empty_query():
     verifier = StatsVerifier()
-    result = _verified_result()
+    result = DiagnosticResult.unverifiable(
+        agent_message="Claim could not be verified.",
+        developer_fields={"is_valid": False},
+    )
     with pytest.raises(VerificationContextValidationError):
         verifier.to_verification_context(result, "")
 
 
 def test_stats_context_fails_closed_on_non_finite_evidence():
     verifier = StatsVerifier()
+    nan_proof_data = json.dumps({"value": float("nan")}, sort_keys=True)
+    developer_fields = _binding_fields()
+    developer_fields["value"] = float("nan")
     result = DiagnosticResult.verified(
         agent_message="Statistical claim verified.",
-        developer_fields={
-            "constraint_id": CONSTRAINT_STATS_VALID,
-            "is_valid": True,
-            "claim_supported": True,
-            "dataset_sha256": DATASET_SHA256,
-            "claim_sha256": CLAIM_SHA256,
-            "value": float("nan"),
-        },
+        developer_fields=developer_fields,
         evidence={"value": float("nan")},
+        proof_data=nan_proof_data,
     )
     with pytest.raises(VerificationContextValidationError):
-        verifier.to_verification_context(result, QUERY)
-
-
-def test_stats_verified_missing_is_valid_fails_closed():
-    verifier = StatsVerifier()
-    result = DiagnosticResult.verified(
-        agent_message="Statistical claim verified.",
-        developer_fields={"observed_result": 2.0},
-        evidence={"observed_result": 2.0},
-    )
-    doc = verifier.to_verification_context(result, "mean of a == 2")
-    doc.validate()
-    payload = doc.to_dict()
-    assert payload["verdict"] == "UNVERIFIABLE"
-    assert payload["context"]["evidence"]["proof_ref"] is None
-    assert payload["context"]["decision"]["admission"] == "DENY"
+        verifier.to_verification_context(
+            result,
+            QUERY,
+            attestation_token=_attestation_token(proof_data=nan_proof_data),
+        )
 
 
 def test_stats_context_fails_closed_when_package_version_unavailable(monkeypatch):
@@ -144,94 +250,4 @@ def test_stats_context_fails_closed_when_package_version_unavailable(monkeypatch
         VerificationContextValidationError,
         match="qwed package metadata is unavailable",
     ):
-        verifier.to_verification_context(result, "mean of a == 2")
-
-
-def test_stats_verified_unbound_result_fails_closed():
-    verifier = StatsVerifier()
-    result = DiagnosticResult.verified(
-        agent_message="Statistical claim verified.",
-        developer_fields={"is_valid": True, "observed_result": 2.0},
-        evidence={"observed_result": 2.0},
-    )
-    doc = verifier.to_verification_context(result, "mean of a == 2")
-    doc.validate()
-    payload = doc.to_dict()
-    assert payload["verdict"] == "UNVERIFIABLE"
-    assert payload["context"]["evidence"]["proof_ref"] is None
-    assert payload["context"]["decision"]["admission"] == "DENY"
-
-
-def test_stats_verified_missing_claim_support_fails_closed():
-    verifier = StatsVerifier()
-    result = DiagnosticResult.verified(
-        agent_message="Statistical claim verified.",
-        developer_fields={
-            "constraint_id": CONSTRAINT_STATS_VALID,
-            "is_valid": True,
-            "dataset_sha256": DATASET_SHA256,
-            "observed_result": 2.0,
-        },
-        evidence={"observed_result": 2.0},
-    )
-    doc = verifier.to_verification_context(result, "mean of a == 2")
-    doc.validate()
-    payload = doc.to_dict()
-    assert payload["verdict"] == "UNVERIFIABLE"
-    assert payload["context"]["evidence"]["proof_ref"] is None
-    assert payload["context"]["decision"]["admission"] == "DENY"
-
-
-def test_stats_verified_mismatched_query_fails_closed():
-    verifier = StatsVerifier()
-    result = _verified_result()
-    doc = verifier.to_verification_context(result, "sum of revenue == 999999")
-    doc.validate()
-    payload = doc.to_dict()
-    assert payload["verdict"] == "UNVERIFIABLE"
-    assert payload["context"]["evidence"]["proof_ref"] is None
-    assert payload["context"]["decision"]["admission"] == "DENY"
-
-
-def test_stats_verified_malformed_dataset_digest_fails_closed():
-    verifier = StatsVerifier()
-    result = DiagnosticResult.verified(
-        agent_message="Statistical claim verified.",
-        developer_fields={
-            "constraint_id": CONSTRAINT_STATS_VALID,
-            "is_valid": True,
-            "claim_supported": True,
-            "dataset_sha256": "not-a-sha256",
-            "claim_sha256": CLAIM_SHA256,
-            "observed_result": 2.0,
-        },
-        evidence={"observed_result": 2.0},
-    )
-    doc = verifier.to_verification_context(result, QUERY)
-    doc.validate()
-    payload = doc.to_dict()
-    assert payload["verdict"] == "UNVERIFIABLE"
-    assert payload["context"]["evidence"]["proof_ref"] is None
-    assert payload["context"]["decision"]["admission"] == "DENY"
-
-
-def test_stats_verified_malformed_claim_digest_fails_closed():
-    verifier = StatsVerifier()
-    result = DiagnosticResult.verified(
-        agent_message="Statistical claim verified.",
-        developer_fields={
-            "constraint_id": CONSTRAINT_STATS_VALID,
-            "is_valid": True,
-            "claim_supported": True,
-            "dataset_sha256": DATASET_SHA256,
-            "claim_sha256": "not-a-sha256",
-            "observed_result": 2.0,
-        },
-        evidence={"observed_result": 2.0},
-    )
-    doc = verifier.to_verification_context(result, QUERY)
-    doc.validate()
-    payload = doc.to_dict()
-    assert payload["verdict"] == "UNVERIFIABLE"
-    assert payload["context"]["evidence"]["proof_ref"] is None
-    assert payload["context"]["decision"]["admission"] == "DENY"
+        verifier.to_verification_context(result, QUERY)

--- a/tests/test_stats_verification_context.py
+++ b/tests/test_stats_verification_context.py
@@ -1,0 +1,94 @@
+import pytest
+
+from qwed_new.core.diagnostics import DiagnosticResult
+from qwed_new.core.stats_verifier import StatsVerifier
+from qwed_new.core.verification_context import (
+    VerificationContextValidationError,
+    resolve_document_proof_ref,
+)
+
+
+def _verified_result(is_valid=True):
+    return DiagnosticResult.verified(
+        agent_message="Statistical claim verified.",
+        developer_fields={
+            "is_valid": is_valid,
+            "observed_result": 2.0,
+        },
+        evidence={"observed_result": 2.0},
+    )
+
+
+def test_stats_verified_context_valid_and_resolves():
+    verifier = StatsVerifier()
+    doc = verifier.to_verification_context(_verified_result(), "mean of a == 2")
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "VERIFIED"
+    assert payload["context"]["decision"]["admission"] == "ADMIT"
+    assert payload["context"]["proof"]["verifier"] == "StatsVerifier"
+    assert payload["context"]["proof"]["verifier_version"]
+    assert resolve_document_proof_ref(payload)
+
+
+def test_stats_verified_unsafe_context_is_denied_but_verified():
+    verifier = StatsVerifier()
+    doc = verifier.to_verification_context(_verified_result(is_valid=False), "mean of a == 2")
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "VERIFIED"
+    assert payload["context"]["decision"]["admission"] == "DENY"
+    assert resolve_document_proof_ref(payload)
+
+
+def test_stats_unverifiable_context_fail_closed():
+    verifier = StatsVerifier()
+    result = DiagnosticResult.unverifiable(
+        agent_message="Claim could not be verified.",
+        developer_fields={"is_valid": False},
+    )
+    doc = verifier.to_verification_context(result, "mean of a == 2")
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "UNVERIFIABLE"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_stats_blocked_context_fail_closed():
+    verifier = StatsVerifier()
+    result = DiagnosticResult.blocked(
+        agent_message="Verification could not be attempted.",
+        developer_fields={"is_valid": False},
+    )
+    doc = verifier.to_verification_context(result, "mean of a == 2")
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "BLOCKED"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_stats_context_tampering_invalidates_proof_ref():
+    verifier = StatsVerifier()
+    doc = verifier.to_verification_context(_verified_result(), "mean of a == 2")
+    payload = doc.to_dict()
+    payload["context"]["evidence"]["evidence"]["developer_fields"]["observed_result"] = 3.0
+    assert not resolve_document_proof_ref(payload)
+
+
+def test_stats_context_rejects_empty_query():
+    verifier = StatsVerifier()
+    with pytest.raises(VerificationContextValidationError):
+        verifier.to_verification_context(_verified_result(), "")
+
+
+def test_stats_context_fails_closed_on_non_finite_evidence():
+    verifier = StatsVerifier()
+    result = DiagnosticResult.verified(
+        agent_message="Statistical claim verified.",
+        developer_fields={"is_valid": True, "value": float("nan")},
+        evidence={"value": float("nan")},
+    )
+    with pytest.raises(VerificationContextValidationError):
+        verifier.to_verification_context(result, "mean of a == nan")

--- a/tests/test_stats_verification_context.py
+++ b/tests/test_stats_verification_context.py
@@ -1,68 +1,18 @@
-import hashlib
-import json
-
 import pytest
 from importlib.metadata import PackageNotFoundError
 
-from qwed_new.core.attestation import create_verification_attestation
 from qwed_new.core.diagnostics import DiagnosticResult
-from qwed_new.core.stats_verifier import (
-    CONSTRAINT_STATS_VALID,
-    StatsVerifier,
-)
+from qwed_new.core.stats_verifier import StatsVerifier
 from qwed_new.core.verification_context import (
     VerificationContextValidationError,
-    resolve_document_proof_ref,
 )
 
-DATASET_SHA256 = "a" * 64
-QUERY = "mean of a == 2"
-CLAIM_SHA256 = hashlib.sha256(QUERY.encode("utf-8")).hexdigest()
-PROOF_DATA = json.dumps({"observed_result": 2.0}, sort_keys=True)
 
-
-def _binding_fields():
-    return {
-        "constraint_id": CONSTRAINT_STATS_VALID,
-        "is_valid": True,
-        "claim_supported": True,
-        "dataset_sha256": DATASET_SHA256,
-        "claim_sha256": CLAIM_SHA256,
-        "observed_result": 2.0,
-    }
-
-
-def _verified_result(is_valid=True, developer_overrides=None):
-    developer_fields = _binding_fields()
-    developer_fields["is_valid"] = is_valid
-    if developer_overrides:
-        developer_fields.update(developer_overrides)
+def _verified_result():
     return DiagnosticResult.verified(
         agent_message="Statistical claim verified.",
-        developer_fields=developer_fields,
+        developer_fields={"is_valid": True, "observed_result": 2.0},
         evidence={"observed_result": 2.0},
-        proof_data=PROOF_DATA,
-    )
-
-
-def _attestation_token(query=QUERY, proof_data=PROOF_DATA):
-    attestation_result = create_verification_attestation(
-        status="VERIFIED",
-        verified=True,
-        engine="stats",
-        query=query,
-        proof_data=proof_data,
-    )
-    assert attestation_result.is_issued
-    return attestation_result.token
-
-
-def _register_receipt(verifier, result, query=QUERY):
-    return verifier._register_execution_receipt(
-        query,
-        DATASET_SHA256,
-        CLAIM_SHA256,
-        result.proof_ref,
     )
 
 
@@ -72,126 +22,27 @@ def _assert_fail_closed(payload, expected_verdict):
     assert payload["context"]["decision"]["admission"] == "DENY"
 
 
-def test_stats_verified_context_valid_and_resolves():
+def test_stats_verified_input_fails_closed_without_execution_provenance():
     verifier = StatsVerifier()
-    result = _verified_result()
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        attestation_token=_attestation_token(),
-        execution_receipt_id=_register_receipt(verifier, result),
-    )
-    doc.validate()
-    payload = doc.to_dict()
-    assert payload["verdict"] == "VERIFIED"
-    assert payload["context"]["decision"]["admission"] == "ADMIT"
-    assert payload["context"]["proof"]["verifier"] == "StatsVerifier"
-    assert payload["context"]["proof"]["verifier_version"]
-    assert resolve_document_proof_ref(payload)
-
-
-def test_stats_verified_without_attestation_fails_closed():
-    verifier = StatsVerifier()
-    result = _verified_result()
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        execution_receipt_id=_register_receipt(verifier, result),
-    )
+    doc = verifier.to_verification_context(_verified_result(), "mean of a == 2")
     doc.validate()
     _assert_fail_closed(doc.to_dict(), "BLOCKED")
 
 
-def test_stats_verified_with_invalid_attestation_fails_closed():
-    verifier = StatsVerifier()
-    result = _verified_result()
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        attestation_token="invalid",
-        execution_receipt_id=_register_receipt(verifier, result),
-    )
-    doc.validate()
-    _assert_fail_closed(doc.to_dict(), "BLOCKED")
-
-
-def test_stats_verified_without_execution_receipt_fails_closed():
-    verifier = StatsVerifier()
-    result = _verified_result()
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        attestation_token=_attestation_token(),
-    )
-    doc.validate()
-    _assert_fail_closed(doc.to_dict(), "BLOCKED")
-
-
-def test_stats_verified_with_invalid_execution_receipt_fails_closed():
-    verifier = StatsVerifier()
-    result = _verified_result()
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        attestation_token=_attestation_token(),
-        execution_receipt_id="stats_receipt_missing",
-    )
-    doc.validate()
-    _assert_fail_closed(doc.to_dict(), "BLOCKED")
-
-
-def test_stats_verified_invalid_result_fails_closed():
-    verifier = StatsVerifier()
-    result = _verified_result(is_valid=False)
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        attestation_token=_attestation_token(),
-        execution_receipt_id=_register_receipt(verifier, result),
-    )
-    doc.validate()
-    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
-
-
-def test_stats_verified_missing_is_valid_fails_closed():
-    verifier = StatsVerifier()
-    result = _verified_result(developer_overrides={"is_valid": None})
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        attestation_token=_attestation_token(),
-        execution_receipt_id=_register_receipt(verifier, result),
-    )
-    doc.validate()
-    _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
-
-
-def test_stats_verified_unbound_result_fails_closed():
+def test_stats_verified_input_with_claim_metadata_fails_closed():
     verifier = StatsVerifier()
     result = DiagnosticResult.verified(
         agent_message="Statistical claim verified.",
-        developer_fields={"is_valid": True, "observed_result": 2.0},
+        developer_fields={
+            "is_valid": True,
+            "claim_supported": True,
+            "dataset_sha256": "a" * 64,
+            "claim_sha256": "b" * 64,
+            "observed_result": 2.0,
+        },
         evidence={"observed_result": 2.0},
-        proof_data=PROOF_DATA,
     )
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        attestation_token=_attestation_token(),
-    )
-    doc.validate()
-    _assert_fail_closed(doc.to_dict(), "BLOCKED")
-
-
-def test_stats_verified_mismatched_query_fails_closed():
-    verifier = StatsVerifier()
-    result = _verified_result()
-    doc = verifier.to_verification_context(
-        result,
-        "sum of revenue == 999999",
-        attestation_token=_attestation_token(),
-        execution_receipt_id=_register_receipt(verifier, result),
-    )
+    doc = verifier.to_verification_context(result, "mean of a == 2")
     doc.validate()
     _assert_fail_closed(doc.to_dict(), "BLOCKED")
 
@@ -202,7 +53,7 @@ def test_stats_unverifiable_context_fail_closed():
         agent_message="Claim could not be verified.",
         developer_fields={"is_valid": False},
     )
-    doc = verifier.to_verification_context(result, QUERY)
+    doc = verifier.to_verification_context(result, "mean of a == 2")
     doc.validate()
     _assert_fail_closed(doc.to_dict(), "UNVERIFIABLE")
 
@@ -213,23 +64,9 @@ def test_stats_blocked_context_fail_closed():
         agent_message="Verification could not be attempted.",
         developer_fields={"is_valid": False},
     )
-    doc = verifier.to_verification_context(result, QUERY)
+    doc = verifier.to_verification_context(result, "mean of a == 2")
     doc.validate()
     _assert_fail_closed(doc.to_dict(), "BLOCKED")
-
-
-def test_stats_context_tampering_invalidates_proof_ref():
-    verifier = StatsVerifier()
-    result = _verified_result()
-    doc = verifier.to_verification_context(
-        result,
-        QUERY,
-        attestation_token=_attestation_token(),
-        execution_receipt_id=_register_receipt(verifier, result),
-    )
-    payload = doc.to_dict()
-    payload["context"]["evidence"]["evidence"]["developer_fields"]["observed_result"] = 3.0
-    assert not resolve_document_proof_ref(payload)
 
 
 def test_stats_context_rejects_empty_query():
@@ -242,37 +79,14 @@ def test_stats_context_rejects_empty_query():
         verifier.to_verification_context(result, "")
 
 
-def test_stats_context_fails_closed_on_non_finite_evidence():
-    verifier = StatsVerifier()
-    nan_proof_data = json.dumps({"value": float("nan")}, sort_keys=True)
-    developer_fields = _binding_fields()
-    developer_fields["value"] = float("nan")
-    result = DiagnosticResult.verified(
-        agent_message="Statistical claim verified.",
-        developer_fields=developer_fields,
-        evidence={"value": float("nan")},
-        proof_data=nan_proof_data,
-    )
-    attestation_token = _attestation_token(proof_data=nan_proof_data)
-    receipt_id = _register_receipt(verifier, result)
-    with pytest.raises(VerificationContextValidationError):
-        verifier.to_verification_context(
-            result,
-            QUERY,
-            attestation_token=attestation_token,
-            execution_receipt_id=receipt_id,
-        )
-
-
 def test_stats_context_fails_closed_when_package_version_unavailable(monkeypatch):
     def _raise_package_not_found(_distribution_name):
         raise PackageNotFoundError()
 
     monkeypatch.setattr("qwed_new.core.stats_verifier.version", _raise_package_not_found)
     verifier = StatsVerifier()
-    result = _verified_result()
     with pytest.raises(
         VerificationContextValidationError,
         match="qwed package metadata is unavailable",
     ):
-        verifier.to_verification_context(result, QUERY)
+        verifier.to_verification_context(_verified_result(), "mean of a == 2")

--- a/tests/test_stats_verification_context.py
+++ b/tests/test_stats_verification_context.py
@@ -231,11 +231,12 @@ def test_stats_context_fails_closed_on_non_finite_evidence():
         evidence={"value": float("nan")},
         proof_data=nan_proof_data,
     )
+    attestation_token = _attestation_token(proof_data=nan_proof_data)
     with pytest.raises(VerificationContextValidationError):
         verifier.to_verification_context(
             result,
             QUERY,
-            attestation_token=_attestation_token(proof_data=nan_proof_data),
+            attestation_token=attestation_token,
         )
 
 

--- a/tests/test_stats_verification_context.py
+++ b/tests/test_stats_verification_context.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import pytest
 from importlib.metadata import PackageNotFoundError
 
@@ -13,6 +15,8 @@ from qwed_new.core.verification_context import (
 
 
 DATASET_SHA256 = "a" * 64
+QUERY = "mean of a == 2"
+CLAIM_SHA256 = hashlib.sha256(QUERY.encode("utf-8")).hexdigest()
 
 
 def _verified_result(is_valid=True):
@@ -23,6 +27,7 @@ def _verified_result(is_valid=True):
             "is_valid": is_valid,
             "claim_supported": True,
             "dataset_sha256": DATASET_SHA256,
+            "claim_sha256": CLAIM_SHA256,
             "observed_result": 2.0,
         },
         evidence={"observed_result": 2.0},
@@ -104,12 +109,13 @@ def test_stats_context_fails_closed_on_non_finite_evidence():
             "is_valid": True,
             "claim_supported": True,
             "dataset_sha256": DATASET_SHA256,
+            "claim_sha256": CLAIM_SHA256,
             "value": float("nan"),
         },
         evidence={"value": float("nan")},
     )
     with pytest.raises(VerificationContextValidationError):
-        verifier.to_verification_context(result, "mean of a == nan")
+        verifier.to_verification_context(result, QUERY)
 
 
 def test_stats_verified_missing_is_valid_fails_closed():
@@ -169,6 +175,61 @@ def test_stats_verified_missing_claim_support_fails_closed():
         evidence={"observed_result": 2.0},
     )
     doc = verifier.to_verification_context(result, "mean of a == 2")
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "UNVERIFIABLE"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_stats_verified_mismatched_query_fails_closed():
+    verifier = StatsVerifier()
+    result = _verified_result()
+    doc = verifier.to_verification_context(result, "sum of revenue == 999999")
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "UNVERIFIABLE"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_stats_verified_malformed_dataset_digest_fails_closed():
+    verifier = StatsVerifier()
+    result = DiagnosticResult.verified(
+        agent_message="Statistical claim verified.",
+        developer_fields={
+            "constraint_id": CONSTRAINT_STATS_VALID,
+            "is_valid": True,
+            "claim_supported": True,
+            "dataset_sha256": "not-a-sha256",
+            "claim_sha256": CLAIM_SHA256,
+            "observed_result": 2.0,
+        },
+        evidence={"observed_result": 2.0},
+    )
+    doc = verifier.to_verification_context(result, QUERY)
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "UNVERIFIABLE"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_stats_verified_malformed_claim_digest_fails_closed():
+    verifier = StatsVerifier()
+    result = DiagnosticResult.verified(
+        agent_message="Statistical claim verified.",
+        developer_fields={
+            "constraint_id": CONSTRAINT_STATS_VALID,
+            "is_valid": True,
+            "claim_supported": True,
+            "dataset_sha256": DATASET_SHA256,
+            "claim_sha256": "not-a-sha256",
+            "observed_result": 2.0,
+        },
+        evidence={"observed_result": 2.0},
+    )
+    doc = verifier.to_verification_context(result, QUERY)
     doc.validate()
     payload = doc.to_dict()
     assert payload["verdict"] == "UNVERIFIABLE"

--- a/tests/test_stats_verification_context.py
+++ b/tests/test_stats_verification_context.py
@@ -1,4 +1,5 @@
 import pytest
+from importlib.metadata import PackageNotFoundError
 
 from qwed_new.core.diagnostics import DiagnosticResult
 from qwed_new.core.stats_verifier import StatsVerifier
@@ -31,14 +32,15 @@ def test_stats_verified_context_valid_and_resolves():
     assert resolve_document_proof_ref(payload)
 
 
-def test_stats_verified_unsafe_context_is_denied_but_verified():
+def test_stats_verified_invalid_result_fails_closed():
     verifier = StatsVerifier()
-    doc = verifier.to_verification_context(_verified_result(is_valid=False), "mean of a == 2")
+    result = _verified_result(is_valid=False)
+    doc = verifier.to_verification_context(result, "mean of a == 2")
     doc.validate()
     payload = doc.to_dict()
-    assert payload["verdict"] == "VERIFIED"
+    assert payload["verdict"] == "UNVERIFIABLE"
+    assert payload["context"]["evidence"]["proof_ref"] is None
     assert payload["context"]["decision"]["admission"] == "DENY"
-    assert resolve_document_proof_ref(payload)
 
 
 def test_stats_unverifiable_context_fail_closed():
@@ -79,8 +81,9 @@ def test_stats_context_tampering_invalidates_proof_ref():
 
 def test_stats_context_rejects_empty_query():
     verifier = StatsVerifier()
+    result = _verified_result()
     with pytest.raises(VerificationContextValidationError):
-        verifier.to_verification_context(_verified_result(), "")
+        verifier.to_verification_context(result, "")
 
 
 def test_stats_context_fails_closed_on_non_finite_evidence():
@@ -92,3 +95,29 @@ def test_stats_context_fails_closed_on_non_finite_evidence():
     )
     with pytest.raises(VerificationContextValidationError):
         verifier.to_verification_context(result, "mean of a == nan")
+
+
+def test_stats_verified_missing_is_valid_fails_closed():
+    verifier = StatsVerifier()
+    result = DiagnosticResult.verified(
+        agent_message="Statistical claim verified.",
+        developer_fields={"observed_result": 2.0},
+        evidence={"observed_result": 2.0},
+    )
+    doc = verifier.to_verification_context(result, "mean of a == 2")
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "UNVERIFIABLE"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_stats_context_fails_closed_when_package_version_unavailable(monkeypatch):
+    def _raise_package_not_found(_distribution_name):
+        raise PackageNotFoundError()
+
+    monkeypatch.setattr("qwed_new.core.stats_verifier.version", _raise_package_not_found)
+    verifier = StatsVerifier()
+    result = _verified_result()
+    with pytest.raises(VerificationContextValidationError):
+        verifier.to_verification_context(result, "mean of a == 2")


### PR DESCRIPTION
## **User description**
Closes #305.

Maps `DiagnosticResult` to Verification Context v1.0 for `StatsVerifier`.

Changes:
- Adds `StatsVerifier.to_verification_context(result, query)`.
- Maps DiagnosticResult fields to Verification Context layers:
  - interpretation
  - proof
  - evidence
  - decision
- Populates verifier, verifier version, configuration, theory scope, trusted dependencies, and outcome treatment.
- Derives the normative Verification Context `proof_ref` for `VERIFIED` results.
- Preserves fail-closed semantics:
  - `VERIFIED` implies a resolvable `proof_ref`.
  - `UNVERIFIABLE` / `BLOCKED` imply `null` `proof_ref` and `DENY` admission.
  - `VERIFIED` with `developer_fields.is_valid != True` gets `DENY` admission.

Verification:
- New focused tests: 7 passed.
- Full suite: 1950 passed, 102 skipped.
- Existing StatsVerifier behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured verification contexts with interpretations, proof details, formalizations, supporting evidence, and admission decisions.
  - Supports verified, unverifiable, and blocked diagnostic outcomes.
  - Resolves proof references and detects changes to supporting evidence.

- **Bug Fixes**
  - Uses fail-closed handling when verification is missing or cannot be established.
  - Rejects incomplete, unbound, inconsistent, or unsupported results, including empty queries and non-finite evidence.
  - Validates data integrity and claim-to-query bindings before admitting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Make statistical verification contexts auditable and fail closed

### What Changed
- Statistical results now produce verification contexts with the verifier identity, package version, execution settings, statistical scope, evidence, and admission decision.
- A result is admitted only when its claim and dataset bindings, attestation, and execution receipt all match the verified query and proof.
- Missing or invalid attestations, execution receipts, bindings, claim validity, or evidence prevent proof resolution and deny admission.
- Unverifiable and blocked results remain denied, while malformed queries, non-finite evidence, tampered evidence, and unavailable package metadata are rejected.
- Added coverage for valid contexts and fail-closed verification scenarios.

### Impact
`✅ Auditable statistical verification results`
`✅ Denied admission for untrusted or inconclusive claims`
`✅ Tampered or mismatched evidence cannot resolve as valid proof`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
