### PR TITLE
feat: expose VerificationContext across SDK/API/CLI

### DIFF
--- a/docs/integration/qwed-security.md
+++ b/docs/integration/qwed-security.md
@@ -1,0 +1,56 @@
+# QWED Security Integration Contract v1.0
+
+This contract defines how the QWED Security GitHub App / GitHub Action must consume
+QWED Verification Context v1.0 documents.
+
+## Output envelope
+
+QWED Security surfaces should render this envelope:
+
+```json
+{
+  "verification_context": { },
+  "verdict": "VERIFIED | UNVERIFIABLE | BLOCKED",
+  "admission": "ADMIT | DENY",
+  "proof_ref": "sha256:<64-hex> or null",
+  "resolved": true
+}
+```
+
+`verification_context` MUST be a schema-valid Verification Context v1.0 document.
+
+## Fail-closed rules
+
+- Gate execution/shipping **exclusively** on `admission == "ADMIT"`.
+- `VERIFIED` requires a resolvable `proof_ref`. If `proof_ref` is missing,
+  malformed, or does not resolve, treat the result as fail-closed and `DENY`.
+- `UNVERIFIABLE` and `BLOCKED` MUST always map to `DENY`.
+- Schema validation failure MUST fail closed.
+- Canonical encoding failure MUST fail closed.
+- Never expose `UNVERIFIABLE` or `BLOCKED` as `ADMIT`.
+
+## QWED verification surfaces
+
+- API:
+  - `POST /verification-context/from-diagnostic`
+  - `POST /verification-context/validate`
+  - `POST /verification-context/resolve`
+- Python SDK:
+  - `QWEDClient.create_verification_context_from_diagnostic(...)`
+  - `QWEDClient.validate_verification_context(...)`
+  - `QWEDClient.resolve_verification_context(...)`
+- CLI:
+  - `qwed context validate <file>`
+  - `qwed context resolve <file>`
+  - `qwed context from-diagnostic --diagnostic-file <file> --query <query> --verifier <verifier>`
+
+## Conformance expectations for other language SDKs
+
+Other SDKs MUST:
+
+1. Validate Verification Context documents against the v1.0 JSON Schema.
+2. Derive and resolve `proof_ref` using the normative canonical encoding.
+3. Reject unpaired UTF-16 surrogates, non-string object keys, non-finite numbers,
+   and integers that do not round-trip through IEEE-754 doubles.
+4. Fail closed on any validation or resolution error.
+5. Never admit execution/shipping unless `admission == "ADMIT"`.

--- a/qwed_sdk/cli.py
+++ b/qwed_sdk/cli.py
@@ -2097,13 +2097,17 @@ def context_validate(path: str):
         validate_document,
     )
 
-    with open(path, encoding="utf-8") as handle:
-        document = json.load(handle)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            document = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        click.echo(json.dumps({"valid": False, "error": "invalid_document_file"}, indent=2))
+        raise SystemExit(1) from None
     try:
         validate_document(document)
-    except VerificationContextValidationError as exc:
-        click.echo(json.dumps({"valid": False, "error": str(exc)}, indent=2))
-        raise SystemExit(1)
+    except VerificationContextValidationError:
+        click.echo(json.dumps({"valid": False, "error": "validation_failed"}, indent=2))
+        raise SystemExit(1) from None
     click.echo(json.dumps({"valid": True}, indent=2))
 
 
@@ -2113,8 +2117,12 @@ def context_resolve(path: str):
     """Resolve the proof_ref commitment for a Verification Context document."""
     from qwed_new.core.verification_context import resolve_document_proof_ref
 
-    with open(path, encoding="utf-8") as handle:
-        document = json.load(handle)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            document = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        click.echo(json.dumps({"resolved": False, "error": "invalid_document_file"}, indent=2))
+        raise SystemExit(1) from None
     click.echo(json.dumps({"resolved": resolve_document_proof_ref(document)}, indent=2))
 
 
@@ -2133,30 +2141,49 @@ def context_from_diagnostic(
 ):
     """Create a Verification Context from a DiagnosticResult."""
     from qwed_new.core.diagnostics import DiagnosticResult
+    from qwed_new.core.verification_context import VerificationContextValidationError
     from qwed_new.core.verification_context_bridge import (
         verification_context_from_diagnostic_result,
     )
 
-    with open(diagnostic_file, encoding="utf-8") as handle:
-        diagnostic = json.load(handle)
     try:
-        result = DiagnosticResult.from_dict(diagnostic)
-    except ValueError as exc:
+        with open(diagnostic_file, encoding="utf-8") as handle:
+            diagnostic = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        click.echo(json.dumps({"valid": False, "error": "invalid_diagnostic_file"}, indent=2))
+        raise SystemExit(1) from None
+    if not isinstance(diagnostic, dict):
         result = DiagnosticResult.blocked(
             agent_message="Diagnostic result is malformed",
-            developer_fields={
-                "constraint_id": "verification_context.malformed_diagnostic",
-                "error": str(exc),
-            },
+            developer_fields={"constraint_id": "verification_context.malformed_diagnostic"},
         )
-    document = verification_context_from_diagnostic_result(
-        result,
-        formal_statement=query,
-        verifier=verifier,
-        verifier_version=verifier_version,
-        attestation_token=attestation_token,
-    )
-    document.validate()
+    else:
+        developer_fields = diagnostic.get("developer_fields", {})
+        if not isinstance(developer_fields, dict):
+            result = DiagnosticResult.blocked(
+                agent_message="Diagnostic result is malformed",
+                developer_fields={"constraint_id": "verification_context.malformed_diagnostic"},
+            )
+        else:
+            try:
+                result = DiagnosticResult.from_dict(diagnostic)
+            except (ValueError, TypeError, AttributeError):
+                result = DiagnosticResult.blocked(
+                    agent_message="Diagnostic result is malformed",
+                    developer_fields={"constraint_id": "verification_context.malformed_diagnostic"},
+                )
+    try:
+        document = verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=verifier,
+            verifier_version=verifier_version,
+            attestation_token=attestation_token,
+        )
+        document.validate()
+    except VerificationContextValidationError:
+        click.echo(json.dumps({"valid": False, "error": "verification_context_rejected"}, indent=2))
+        raise SystemExit(1) from None
     click.echo(json.dumps(document.to_dict(), indent=2))
 
 

--- a/qwed_sdk/cli.py
+++ b/qwed_sdk/cli.py
@@ -2104,7 +2104,7 @@ def context_validate(path: str):
     try:
         with open(path, encoding="utf-8") as handle:
             document = json.load(handle)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         click.echo(json.dumps({"valid": False, "error": "invalid_document_file"}, indent=2))
         raise SystemExit(1) from None
     try:
@@ -2124,7 +2124,7 @@ def context_resolve(path: str):
     try:
         with open(path, encoding="utf-8") as handle:
             document = json.load(handle)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         click.echo(json.dumps({"resolved": False, "error": "invalid_document_file"}, indent=2))
         raise SystemExit(1) from None
     click.echo(json.dumps({"resolved": resolve_document_proof_ref(document)}, indent=2))
@@ -2153,7 +2153,7 @@ def context_from_diagnostic(
     try:
         with open(diagnostic_file, encoding="utf-8") as handle:
             diagnostic = json.load(handle)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         click.echo(json.dumps({"valid": False, "error": "invalid_diagnostic_file"}, indent=2))
         raise SystemExit(1) from None
     if not isinstance(diagnostic, dict):

--- a/qwed_sdk/cli.py
+++ b/qwed_sdk/cli.py
@@ -2082,5 +2082,83 @@ def import_provider(url: str):
         sys.exit(1)
 
 
+@cli.group()
+def context():
+    """Verification Context v1.0 utilities."""
+    pass
+
+
+@context.command(name="validate")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False))
+def context_validate(path: str):
+    """Validate a Verification Context document."""
+    from qwed_new.core.verification_context import (
+        VerificationContextValidationError,
+        validate_document,
+    )
+
+    with open(path, encoding="utf-8") as handle:
+        document = json.load(handle)
+    try:
+        validate_document(document)
+    except VerificationContextValidationError as exc:
+        click.echo(json.dumps({"valid": False, "error": str(exc)}, indent=2))
+        raise SystemExit(1)
+    click.echo(json.dumps({"valid": True}, indent=2))
+
+
+@context.command(name="resolve")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False))
+def context_resolve(path: str):
+    """Resolve the proof_ref commitment for a Verification Context document."""
+    from qwed_new.core.verification_context import resolve_document_proof_ref
+
+    with open(path, encoding="utf-8") as handle:
+        document = json.load(handle)
+    click.echo(json.dumps({"resolved": resolve_document_proof_ref(document)}, indent=2))
+
+
+@context.command(name="from-diagnostic")
+@click.option("--diagnostic-file", required=True, type=click.Path(exists=True, dir_okay=False))
+@click.option("--query", required=True)
+@click.option("--verifier", required=True)
+@click.option("--verifier-version", default=None)
+@click.option("--attestation-token", default=None)
+def context_from_diagnostic(
+    diagnostic_file: str,
+    query: str,
+    verifier: str,
+    verifier_version: Optional[str],
+    attestation_token: Optional[str],
+):
+    """Create a Verification Context from a DiagnosticResult."""
+    from qwed_new.core.diagnostics import DiagnosticResult
+    from qwed_new.core.verification_context_bridge import (
+        verification_context_from_diagnostic_result,
+    )
+
+    with open(diagnostic_file, encoding="utf-8") as handle:
+        diagnostic = json.load(handle)
+    try:
+        result = DiagnosticResult.from_dict(diagnostic)
+    except ValueError as exc:
+        result = DiagnosticResult.blocked(
+            agent_message="Diagnostic result is malformed",
+            developer_fields={
+                "constraint_id": "verification_context.malformed_diagnostic",
+                "error": str(exc),
+            },
+        )
+    document = verification_context_from_diagnostic_result(
+        result,
+        formal_statement=query,
+        verifier=verifier,
+        verifier_version=verifier_version,
+        attestation_token=attestation_token,
+    )
+    document.validate()
+    click.echo(json.dumps(document.to_dict(), indent=2))
+
+
 if __name__ == '__main__':
     cli()

--- a/qwed_sdk/cli.py
+++ b/qwed_sdk/cli.py
@@ -2082,6 +2082,10 @@ def import_provider(url: str):
         sys.exit(1)
 
 
+_CONTEXT_MALFORMED_DIAGNOSTIC_MESSAGE = "Diagnostic result is malformed"
+_CONTEXT_MALFORMED_DIAGNOSTIC_CONSTRAINT = "verification_context.malformed_diagnostic"
+
+
 @cli.group()
 def context():
     """Verification Context v1.0 utilities."""

--- a/qwed_sdk/cli.py
+++ b/qwed_sdk/cli.py
@@ -2158,23 +2158,23 @@ def context_from_diagnostic(
         raise SystemExit(1) from None
     if not isinstance(diagnostic, dict):
         result = DiagnosticResult.blocked(
-            agent_message="Diagnostic result is malformed",
-            developer_fields={"constraint_id": "verification_context.malformed_diagnostic"},
+            agent_message=_CONTEXT_MALFORMED_DIAGNOSTIC_MESSAGE,
+            developer_fields={"constraint_id": _CONTEXT_MALFORMED_DIAGNOSTIC_CONSTRAINT},
         )
     else:
         developer_fields = diagnostic.get("developer_fields", {})
         if not isinstance(developer_fields, dict):
             result = DiagnosticResult.blocked(
-                agent_message="Diagnostic result is malformed",
-                developer_fields={"constraint_id": "verification_context.malformed_diagnostic"},
+                agent_message=_CONTEXT_MALFORMED_DIAGNOSTIC_MESSAGE,
+                developer_fields={"constraint_id": _CONTEXT_MALFORMED_DIAGNOSTIC_CONSTRAINT},
             )
         else:
             try:
                 result = DiagnosticResult.from_dict(diagnostic)
             except (ValueError, TypeError, AttributeError):
                 result = DiagnosticResult.blocked(
-                    agent_message="Diagnostic result is malformed",
-                    developer_fields={"constraint_id": "verification_context.malformed_diagnostic"},
+                    agent_message=_CONTEXT_MALFORMED_DIAGNOSTIC_MESSAGE,
+                    developer_fields={"constraint_id": _CONTEXT_MALFORMED_DIAGNOSTIC_CONSTRAINT},
                 )
     try:
         document = verification_context_from_diagnostic_result(
@@ -2187,6 +2187,9 @@ def context_from_diagnostic(
         document.validate()
     except VerificationContextValidationError:
         click.echo(json.dumps({"valid": False, "error": "verification_context_rejected"}, indent=2))
+        raise SystemExit(1) from None
+    except Exception:
+        click.echo(json.dumps({"valid": False, "error": "internal_error"}, indent=2))
         raise SystemExit(1) from None
     click.echo(json.dumps(document.to_dict(), indent=2))
 

--- a/qwed_sdk/client.py
+++ b/qwed_sdk/client.py
@@ -69,7 +69,44 @@ class QWEDClient:
     def health(self) -> Dict[str, Any]:
         """Check API health status."""
         return self._request("GET", "/health")
-    
+
+    def create_verification_context_from_diagnostic(
+        self,
+        diagnostic: Dict[str, Any],
+        query: str,
+        verifier: str,
+        verifier_version: Optional[str] = None,
+        attestation_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a schema-valid Verification Context from a DiagnosticResult."""
+        return self._request(
+            "POST",
+            "/verification-context/from-diagnostic",
+            json={
+                "diagnostic": diagnostic,
+                "query": query,
+                "verifier": verifier,
+                "verifier_version": verifier_version,
+                "attestation_token": attestation_token,
+            },
+        )
+
+    def validate_verification_context(self, document: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate a Verification Context document against the v1.0 schema."""
+        return self._request(
+            "POST",
+            "/verification-context/validate",
+            json={"document": document},
+        )
+
+    def resolve_verification_context(self, document: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve the proof_ref commitment for a Verification Context document."""
+        return self._request(
+            "POST",
+            "/verification-context/resolve",
+            json={"document": document},
+        )
+
     def verify(
         self,
         query: str,
@@ -423,7 +460,44 @@ class QWEDAsyncClient:
     async def health(self) -> Dict[str, Any]:
         """Check API health status."""
         return await self._request("GET", "/health")
-    
+
+    async def create_verification_context_from_diagnostic(
+        self,
+        diagnostic: Dict[str, Any],
+        query: str,
+        verifier: str,
+        verifier_version: Optional[str] = None,
+        attestation_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a schema-valid Verification Context from a DiagnosticResult."""
+        return await self._request(
+            "POST",
+            "/verification-context/from-diagnostic",
+            json={
+                "diagnostic": diagnostic,
+                "query": query,
+                "verifier": verifier,
+                "verifier_version": verifier_version,
+                "attestation_token": attestation_token,
+            },
+        )
+
+    async def validate_verification_context(self, document: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate a Verification Context document against the v1.0 schema."""
+        return await self._request(
+            "POST",
+            "/verification-context/validate",
+            json={"document": document},
+        )
+
+    async def resolve_verification_context(self, document: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve the proof_ref commitment for a Verification Context document."""
+        return await self._request(
+            "POST",
+            "/verification-context/resolve",
+            json={"document": document},
+        )
+
     async def verify(
         self,
         query: str,

--- a/src/qwed_new/__init__.py
+++ b/src/qwed_new/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 QWED Team
 # SPDX-License-Identifier: Apache-2.0
 
+__version__ = "7.0.0"

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -14,6 +14,7 @@ from qwed_new.core.diagnostics import (
     enforce_trust_decision,
     merge_diagnostic_result,
 )
+from qwed_new.api.verification_context_routes import router as verification_context_router
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -64,6 +65,7 @@ app.add_middleware(
 # Include routers
 app.include_router(auth_router)
 app.include_router(audit_router)
+app.include_router(verification_context_router)
 
 STARTUP_ALLOWED_PTH_FILES = {
     "__editable__.qwed_a2a-0.1.0.pth",

--- a/src/qwed_new/api/verification_context_routes.py
+++ b/src/qwed_new/api/verification_context_routes.py
@@ -1,12 +1,15 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlmodel import Session
+from sqlalchemy.exc import SQLAlchemyError
 from typing import Any, Dict, Optional
+import json
 
 from qwed_new.core.database import get_session
 from qwed_new.core.diagnostics import DiagnosticResult
 from qwed_new.core.models import VerificationLog
 from qwed_new.core.rate_limiter import check_rate_limit
+from qwed_new.core.security import redact_pii
 from qwed_new.core.tenant_context import TenantContext, get_current_tenant
 from qwed_new.core.verification_context import (
     VerificationContextValidationError,
@@ -16,7 +19,6 @@ from qwed_new.core.verification_context import (
 from qwed_new.core.verification_context_bridge import (
     verification_context_from_diagnostic_result,
 )
-import json
 
 router = APIRouter(prefix="/verification-context", tags=["VerificationContext"])
 
@@ -68,15 +70,19 @@ def _safe_commit_context_log(
             VerificationLog(
                 organization_id=tenant.organization_id,
                 user_id=getattr(tenant, "user_id", None),
-                query=query,
-                result=json.dumps(result),
+                query=redact_pii(query),
+                result=redact_pii(json.dumps(result)),
                 is_verified=is_verified,
                 domain="VERIFICATION_CONTEXT",
             )
         )
         session.commit()
-    except Exception:
+    except (TypeError, ValueError, SQLAlchemyError):
         session.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail="audit persistence failed",
+        ) from None
 
 
 @router.post(
@@ -111,7 +117,8 @@ def create_verification_context_from_diagnostic(
         tenant,
         payload.query,
         document_dict,
-        document_dict["verdict"] == "VERIFIED",
+        document_dict["verdict"] == "VERIFIED"
+        and document_dict["context"]["decision"]["admission"] == "ADMIT",
     )
     return document_dict
 
@@ -134,7 +141,7 @@ def validate_verification_context(
         tenant,
         "verification-context:validate",
         response,
-        response["valid"],
+        False,
     )
     return response
 
@@ -153,6 +160,6 @@ def resolve_verification_context(
         tenant,
         "verification-context:resolve",
         response,
-        response["resolved"],
+        False,
     )
     return response

--- a/src/qwed_new/api/verification_context_routes.py
+++ b/src/qwed_new/api/verification_context_routes.py
@@ -58,12 +58,12 @@ def _diagnostic_result_from_payload(diagnostic: Any) -> DiagnosticResult:
 
 def _safe_commit_context_log(
     session: Optional[Session],
-    tenant: Optional[TenantContext],
+    tenant: TenantContext,
     query: str,
     result: Dict[str, Any],
     is_verified: bool,
 ) -> None:
-    if session is None or tenant is None:
+    if session is None:
         return
     try:
         session.add(
@@ -87,15 +87,17 @@ def _safe_commit_context_log(
 
 @router.post(
     "/from-diagnostic",
-    responses={422: {"description": "Verification Context rejected"}},
+    responses={
+        422: {"description": "Verification Context rejected"},
+        500: {"description": "Audit persistence failed"},
+    },
 )
 def create_verification_context_from_diagnostic(
     payload: DiagnosticVerificationContextRequest,
-    tenant: Optional[TenantContext] = Depends(get_current_tenant),
+    tenant: TenantContext = Depends(get_current_tenant),
     session: Optional[Session] = Depends(get_session),
 ) -> Dict[str, Any]:
-    if tenant is not None:
-        check_rate_limit(tenant.api_key)
+    check_rate_limit(tenant.api_key)
     result = _diagnostic_result_from_payload(payload.diagnostic)
     try:
         document = verification_context_from_diagnostic_result(
@@ -123,14 +125,16 @@ def create_verification_context_from_diagnostic(
     return document_dict
 
 
-@router.post("/validate")
+@router.post(
+    "/validate",
+    responses={500: {"description": "Audit persistence failed"}},
+)
 def validate_verification_context(
     payload: VerificationContextDocumentRequest,
-    tenant: Optional[TenantContext] = Depends(get_current_tenant),
+    tenant: TenantContext = Depends(get_current_tenant),
     session: Optional[Session] = Depends(get_session),
 ) -> Dict[str, Any]:
-    if tenant is not None:
-        check_rate_limit(tenant.api_key)
+    check_rate_limit(tenant.api_key)
     try:
         validate_document(payload.document)
         response = {"valid": True}
@@ -146,14 +150,16 @@ def validate_verification_context(
     return response
 
 
-@router.post("/resolve")
+@router.post(
+    "/resolve",
+    responses={500: {"description": "Audit persistence failed"}},
+)
 def resolve_verification_context(
     payload: VerificationContextDocumentRequest,
-    tenant: Optional[TenantContext] = Depends(get_current_tenant),
+    tenant: TenantContext = Depends(get_current_tenant),
     session: Optional[Session] = Depends(get_session),
 ) -> Dict[str, Any]:
-    if tenant is not None:
-        check_rate_limit(tenant.api_key)
+    check_rate_limit(tenant.api_key)
     response = {"resolved": resolve_document_proof_ref(payload.document)}
     _safe_commit_context_log(
         session,

--- a/src/qwed_new/api/verification_context_routes.py
+++ b/src/qwed_new/api/verification_context_routes.py
@@ -1,0 +1,73 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import Any, Dict, Optional
+
+from qwed_new.core.diagnostics import DiagnosticResult
+from qwed_new.core.verification_context import (
+    VerificationContextValidationError,
+    resolve_document_proof_ref,
+    validate_document,
+)
+from qwed_new.core.verification_context_bridge import (
+    verification_context_from_diagnostic_result,
+)
+
+router = APIRouter(prefix="/verification-context", tags=["VerificationContext"])
+
+
+class DiagnosticVerificationContextRequest(BaseModel):
+    query: str = Field(min_length=1)
+    verifier: str = Field(min_length=1)
+    diagnostic: Dict[str, Any]
+    verifier_version: Optional[str] = None
+    attestation_token: Optional[str] = None
+
+
+class VerificationContextDocumentRequest(BaseModel):
+    document: Dict[str, Any]
+
+
+@router.post("/from-diagnostic")
+def create_verification_context_from_diagnostic(
+    payload: DiagnosticVerificationContextRequest,
+) -> Dict[str, Any]:
+    try:
+        result = DiagnosticResult.from_dict(payload.diagnostic)
+    except ValueError as exc:
+        result = DiagnosticResult.blocked(
+            agent_message="Diagnostic result is malformed",
+            developer_fields={
+                "constraint_id": "verification_context.malformed_diagnostic",
+                "error": str(exc),
+            },
+        )
+    try:
+        document = verification_context_from_diagnostic_result(
+            result,
+            formal_statement=payload.query,
+            verifier=payload.verifier,
+            verifier_version=payload.verifier_version,
+            attestation_token=payload.attestation_token,
+        )
+        document.validate()
+        return document.to_dict()
+    except VerificationContextValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.post("/validate")
+def validate_verification_context(
+    payload: VerificationContextDocumentRequest,
+) -> Dict[str, Any]:
+    try:
+        validate_document(payload.document)
+        return {"valid": True}
+    except VerificationContextValidationError as exc:
+        return {"valid": False, "error": str(exc)}
+
+
+@router.post("/resolve")
+def resolve_verification_context(
+    payload: VerificationContextDocumentRequest,
+) -> Dict[str, Any]:
+    return {"resolved": resolve_document_proof_ref(payload.document)}

--- a/src/qwed_new/api/verification_context_routes.py
+++ b/src/qwed_new/api/verification_context_routes.py
@@ -1,8 +1,10 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from typing import Any, Dict, Optional
 
 from qwed_new.core.diagnostics import DiagnosticResult
+from qwed_new.core.rate_limiter import check_rate_limit
+from qwed_new.core.tenant_context import TenantContext, get_current_tenant
 from qwed_new.core.verification_context import (
     VerificationContextValidationError,
     resolve_document_proof_ref,
@@ -12,7 +14,19 @@ from qwed_new.core.verification_context_bridge import (
     verification_context_from_diagnostic_result,
 )
 
-router = APIRouter(prefix="/verification-context", tags=["VerificationContext"])
+
+def _authenticated_verification_context_tenant(
+    tenant: TenantContext = Depends(get_current_tenant),
+) -> TenantContext:
+    check_rate_limit(tenant.api_key)
+    return tenant
+
+
+router = APIRouter(
+    prefix="/verification-context",
+    tags=["VerificationContext"],
+    dependencies=[Depends(_authenticated_verification_context_tenant)],
+)
 
 
 class DiagnosticVerificationContextRequest(BaseModel):
@@ -27,20 +41,35 @@ class VerificationContextDocumentRequest(BaseModel):
     document: Dict[str, Any]
 
 
-@router.post("/from-diagnostic")
+def _malformed_diagnostic_result() -> DiagnosticResult:
+    return DiagnosticResult.blocked(
+        agent_message="Diagnostic result is malformed",
+        developer_fields={
+            "constraint_id": "verification_context.malformed_diagnostic",
+        },
+    )
+
+
+def _diagnostic_result_from_payload(diagnostic: Any) -> DiagnosticResult:
+    if not isinstance(diagnostic, dict):
+        return _malformed_diagnostic_result()
+    developer_fields = diagnostic.get("developer_fields", {})
+    if not isinstance(developer_fields, dict):
+        return _malformed_diagnostic_result()
+    try:
+        return DiagnosticResult.from_dict(diagnostic)
+    except (ValueError, TypeError, AttributeError):
+        return _malformed_diagnostic_result()
+
+
+@router.post(
+    "/from-diagnostic",
+    responses={422: {"description": "Verification Context rejected"}},
+)
 def create_verification_context_from_diagnostic(
     payload: DiagnosticVerificationContextRequest,
 ) -> Dict[str, Any]:
-    try:
-        result = DiagnosticResult.from_dict(payload.diagnostic)
-    except ValueError as exc:
-        result = DiagnosticResult.blocked(
-            agent_message="Diagnostic result is malformed",
-            developer_fields={
-                "constraint_id": "verification_context.malformed_diagnostic",
-                "error": str(exc),
-            },
-        )
+    result = _diagnostic_result_from_payload(payload.diagnostic)
     try:
         document = verification_context_from_diagnostic_result(
             result,
@@ -51,8 +80,11 @@ def create_verification_context_from_diagnostic(
         )
         document.validate()
         return document.to_dict()
-    except VerificationContextValidationError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except VerificationContextValidationError:
+        raise HTTPException(
+            status_code=422,
+            detail="verification context rejected",
+        ) from None
 
 
 @router.post("/validate")
@@ -62,8 +94,8 @@ def validate_verification_context(
     try:
         validate_document(payload.document)
         return {"valid": True}
-    except VerificationContextValidationError as exc:
-        return {"valid": False, "error": str(exc)}
+    except VerificationContextValidationError:
+        return {"valid": False, "error": "validation_failed"}
 
 
 @router.post("/resolve")

--- a/src/qwed_new/api/verification_context_routes.py
+++ b/src/qwed_new/api/verification_context_routes.py
@@ -20,7 +20,19 @@ from qwed_new.core.verification_context_bridge import (
     verification_context_from_diagnostic_result,
 )
 
-router = APIRouter(prefix="/verification-context", tags=["VerificationContext"])
+
+def _enforce_tenant_access(
+    tenant: TenantContext = Depends(get_current_tenant),
+) -> TenantContext:
+    check_rate_limit(tenant.api_key)
+    return tenant
+
+
+router = APIRouter(
+    prefix="/verification-context",
+    tags=["VerificationContext"],
+    dependencies=[Depends(_enforce_tenant_access)],
+)
 
 
 class DiagnosticVerificationContextRequest(BaseModel):
@@ -94,10 +106,9 @@ def _safe_commit_context_log(
 )
 def create_verification_context_from_diagnostic(
     payload: DiagnosticVerificationContextRequest,
-    tenant: TenantContext = Depends(get_current_tenant),
+    tenant: TenantContext = Depends(_enforce_tenant_access),
     session: Optional[Session] = Depends(get_session),
 ) -> Dict[str, Any]:
-    check_rate_limit(tenant.api_key)
     result = _diagnostic_result_from_payload(payload.diagnostic)
     try:
         document = verification_context_from_diagnostic_result(
@@ -131,10 +142,9 @@ def create_verification_context_from_diagnostic(
 )
 def validate_verification_context(
     payload: VerificationContextDocumentRequest,
-    tenant: TenantContext = Depends(get_current_tenant),
+    tenant: TenantContext = Depends(_enforce_tenant_access),
     session: Optional[Session] = Depends(get_session),
 ) -> Dict[str, Any]:
-    check_rate_limit(tenant.api_key)
     try:
         validate_document(payload.document)
         response = {"valid": True}
@@ -156,10 +166,9 @@ def validate_verification_context(
 )
 def resolve_verification_context(
     payload: VerificationContextDocumentRequest,
-    tenant: TenantContext = Depends(get_current_tenant),
+    tenant: TenantContext = Depends(_enforce_tenant_access),
     session: Optional[Session] = Depends(get_session),
 ) -> Dict[str, Any]:
-    check_rate_limit(tenant.api_key)
     response = {"resolved": resolve_document_proof_ref(payload.document)}
     _safe_commit_context_log(
         session,

--- a/src/qwed_new/api/verification_context_routes.py
+++ b/src/qwed_new/api/verification_context_routes.py
@@ -1,8 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+from sqlmodel import Session
 from typing import Any, Dict, Optional
 
+from qwed_new.core.database import get_session
 from qwed_new.core.diagnostics import DiagnosticResult
+from qwed_new.core.models import VerificationLog
 from qwed_new.core.rate_limiter import check_rate_limit
 from qwed_new.core.tenant_context import TenantContext, get_current_tenant
 from qwed_new.core.verification_context import (
@@ -13,20 +16,9 @@ from qwed_new.core.verification_context import (
 from qwed_new.core.verification_context_bridge import (
     verification_context_from_diagnostic_result,
 )
+import json
 
-
-def _authenticated_verification_context_tenant(
-    tenant: TenantContext = Depends(get_current_tenant),
-) -> TenantContext:
-    check_rate_limit(tenant.api_key)
-    return tenant
-
-
-router = APIRouter(
-    prefix="/verification-context",
-    tags=["VerificationContext"],
-    dependencies=[Depends(_authenticated_verification_context_tenant)],
-)
+router = APIRouter(prefix="/verification-context", tags=["VerificationContext"])
 
 
 class DiagnosticVerificationContextRequest(BaseModel):
@@ -62,13 +54,42 @@ def _diagnostic_result_from_payload(diagnostic: Any) -> DiagnosticResult:
         return _malformed_diagnostic_result()
 
 
+def _safe_commit_context_log(
+    session: Optional[Session],
+    tenant: Optional[TenantContext],
+    query: str,
+    result: Dict[str, Any],
+    is_verified: bool,
+) -> None:
+    if session is None or tenant is None:
+        return
+    try:
+        session.add(
+            VerificationLog(
+                organization_id=tenant.organization_id,
+                user_id=getattr(tenant, "user_id", None),
+                query=query,
+                result=json.dumps(result),
+                is_verified=is_verified,
+                domain="VERIFICATION_CONTEXT",
+            )
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+
+
 @router.post(
     "/from-diagnostic",
     responses={422: {"description": "Verification Context rejected"}},
 )
 def create_verification_context_from_diagnostic(
     payload: DiagnosticVerificationContextRequest,
+    tenant: Optional[TenantContext] = Depends(get_current_tenant),
+    session: Optional[Session] = Depends(get_session),
 ) -> Dict[str, Any]:
+    if tenant is not None:
+        check_rate_limit(tenant.api_key)
     result = _diagnostic_result_from_payload(payload.diagnostic)
     try:
         document = verification_context_from_diagnostic_result(
@@ -79,27 +100,59 @@ def create_verification_context_from_diagnostic(
             attestation_token=payload.attestation_token,
         )
         document.validate()
-        return document.to_dict()
+        document_dict = document.to_dict()
     except VerificationContextValidationError:
         raise HTTPException(
             status_code=422,
             detail="verification context rejected",
         ) from None
+    _safe_commit_context_log(
+        session,
+        tenant,
+        payload.query,
+        document_dict,
+        document_dict["verdict"] == "VERIFIED",
+    )
+    return document_dict
 
 
 @router.post("/validate")
 def validate_verification_context(
     payload: VerificationContextDocumentRequest,
+    tenant: Optional[TenantContext] = Depends(get_current_tenant),
+    session: Optional[Session] = Depends(get_session),
 ) -> Dict[str, Any]:
+    if tenant is not None:
+        check_rate_limit(tenant.api_key)
     try:
         validate_document(payload.document)
-        return {"valid": True}
+        response = {"valid": True}
     except VerificationContextValidationError:
-        return {"valid": False, "error": "validation_failed"}
+        response = {"valid": False, "error": "validation_failed"}
+    _safe_commit_context_log(
+        session,
+        tenant,
+        "verification-context:validate",
+        response,
+        response["valid"],
+    )
+    return response
 
 
 @router.post("/resolve")
 def resolve_verification_context(
     payload: VerificationContextDocumentRequest,
+    tenant: Optional[TenantContext] = Depends(get_current_tenant),
+    session: Optional[Session] = Depends(get_session),
 ) -> Dict[str, Any]:
-    return {"resolved": resolve_document_proof_ref(payload.document)}
+    if tenant is not None:
+        check_rate_limit(tenant.api_key)
+    response = {"resolved": resolve_document_proof_ref(payload.document)}
+    _safe_commit_context_log(
+        session,
+        tenant,
+        "verification-context:resolve",
+        response,
+        response["resolved"],
+    )
+    return response

--- a/src/qwed_new/core/verification_context_bridge.py
+++ b/src/qwed_new/core/verification_context_bridge.py
@@ -30,10 +30,10 @@ def _resolved_verifier_version(verifier_version: Optional[str]) -> str:
         return verifier_version
     try:
         return version("qwed")
-    except PackageNotFoundError as exc:
-        raise VerificationContextValidationError(
-            "qwed package metadata is unavailable"
-        ) from exc
+    except PackageNotFoundError:
+        from qwed_new import __version__ as qwed_version
+
+        return qwed_version
 
 
 def verification_context_from_diagnostic_result(
@@ -43,7 +43,6 @@ def verification_context_from_diagnostic_result(
     verifier: str,
     verifier_version: Optional[str] = None,
     attestation_token: Optional[str] = None,
-    require_attestation: bool = True,
 ) -> VerificationContextDocument:
     if not isinstance(formal_statement, str) or not formal_statement.strip():
         raise VerificationContextValidationError(
@@ -54,11 +53,19 @@ def verification_context_from_diagnostic_result(
             "verifier must be a non-empty string"
         )
 
+    if not isinstance(result.developer_fields, dict):
+        result = DiagnosticResult.blocked(
+            agent_message="Diagnostic result is malformed",
+            developer_fields={
+                "constraint_id": "verification_context.malformed_developer_fields",
+            },
+        )
+
     if result.status is DiagnosticStatus.VERIFIED:
         result = enforce_trust_decision(
             result,
             attestation_token=attestation_token,
-            require_attestation=require_attestation,
+            require_attestation=True,
             query=formal_statement,
         )
 

--- a/src/qwed_new/core/verification_context_bridge.py
+++ b/src/qwed_new/core/verification_context_bridge.py
@@ -1,0 +1,115 @@
+from importlib.metadata import PackageNotFoundError, version
+from typing import Optional
+
+from .diagnostics import (
+    AdmissionDecision,
+    DiagnosticResult,
+    DiagnosticStatus,
+    admission_decision,
+    enforce_trust_decision,
+)
+from .verification_context import (
+    Admission,
+    Decision,
+    Evidence,
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContext,
+    VerificationContextDocument,
+    VerificationContextValidationError,
+)
+
+
+def _resolved_verifier_version(verifier_version: Optional[str]) -> str:
+    if verifier_version is not None:
+        if not verifier_version.strip():
+            raise VerificationContextValidationError(
+                "verifier_version must be non-empty"
+            )
+        return verifier_version
+    try:
+        return version("qwed")
+    except PackageNotFoundError as exc:
+        raise VerificationContextValidationError(
+            "qwed package metadata is unavailable"
+        ) from exc
+
+
+def verification_context_from_diagnostic_result(
+    result: DiagnosticResult,
+    *,
+    formal_statement: str,
+    verifier: str,
+    verifier_version: Optional[str] = None,
+    attestation_token: Optional[str] = None,
+    require_attestation: bool = True,
+) -> VerificationContextDocument:
+    if not isinstance(formal_statement, str) or not formal_statement.strip():
+        raise VerificationContextValidationError(
+            "formal_statement must be a non-empty string"
+        )
+    if not isinstance(verifier, str) or not verifier.strip():
+        raise VerificationContextValidationError(
+            "verifier must be a non-empty string"
+        )
+
+    if result.status is DiagnosticStatus.VERIFIED:
+        result = enforce_trust_decision(
+            result,
+            attestation_token=attestation_token,
+            require_attestation=require_attestation,
+            query=formal_statement,
+        )
+
+    interpretation = Interpretation(theory=f"{verifier} verification")
+    proof = Proof(
+        verifier=verifier,
+        verifier_version=_resolved_verifier_version(verifier_version),
+        outcome_treatment="unknown/timeout/error resolve to UNVERIFIABLE or BLOCKED",
+    )
+    formalization = Formalization(
+        source_query=formal_statement,
+        translator=verifier,
+    )
+    evidence_payload = result.to_dict()
+
+    if result.status is DiagnosticStatus.VERIFIED:
+        admission = (
+            Admission.ADMIT
+            if admission_decision(result) is AdmissionDecision.ADMIT
+            else Admission.DENY
+        )
+        context = VerificationContext(
+            interpretation=interpretation,
+            proof=proof,
+            evidence=Evidence(payload=evidence_payload, proof_ref=None),
+            decision=Decision(admission=admission),
+        )
+        return VerificationContextDocument.verified(
+            formal_statement=formal_statement,
+            context=context,
+            formalization=formalization,
+        )
+
+    context = VerificationContext(
+        interpretation=interpretation,
+        proof=proof,
+        evidence=Evidence(payload=evidence_payload, proof_ref=None),
+        decision=Decision(admission=Admission.DENY),
+    )
+    if result.status is DiagnosticStatus.UNVERIFIABLE:
+        return VerificationContextDocument.unverifiable(
+            formal_statement=formal_statement,
+            context=context,
+            formalization=formalization,
+        )
+    if result.status is DiagnosticStatus.BLOCKED:
+        return VerificationContextDocument.blocked(
+            formal_statement=formal_statement,
+            context=context,
+            formalization=formalization,
+        )
+    raise VerificationContextValidationError(
+        f"unsupported DiagnosticResult status: {result.status!r}"
+    )

--- a/tests/test_verification_context_api.py
+++ b/tests/test_verification_context_api.py
@@ -13,12 +13,18 @@ def test_from_diagnostic_malformed_diagnostic_fails_closed():
         verifier="TestVerifier",
         diagnostic={"status": "VERIFIED"},
     )
-    document = create_verification_context_from_diagnostic(payload)
+    document = create_verification_context_from_diagnostic(
+        payload,
+        tenant=None,
+        session=None,
+    )
     assert document["verdict"] == "BLOCKED"
     assert document["context"]["evidence"]["proof_ref"] is None
     assert document["context"]["decision"]["admission"] == "DENY"
     assert validate_verification_context(
-        VerificationContextDocumentRequest(document=document)
+        VerificationContextDocumentRequest(document=document),
+        tenant=None,
+        session=None,
     ) == {"valid": True}
 
 
@@ -33,7 +39,11 @@ def test_from_diagnostic_verified_without_attestation_fails_closed():
             "proof_ref": "sha256:" + "a" * 64,
         },
     )
-    document = create_verification_context_from_diagnostic(payload)
+    document = create_verification_context_from_diagnostic(
+        payload,
+        tenant=None,
+        session=None,
+    )
     assert document["verdict"] == "BLOCKED"
     assert document["context"]["evidence"]["proof_ref"] is None
     assert document["context"]["decision"]["admission"] == "DENY"
@@ -42,12 +52,16 @@ def test_from_diagnostic_verified_without_attestation_fails_closed():
 def test_validate_and_resolve_fail_closed_for_invalid_document():
     document = {"spec_version": "1.0"}
     validation = validate_verification_context(
-        VerificationContextDocumentRequest(document=document)
+        VerificationContextDocumentRequest(document=document),
+        tenant=None,
+        session=None,
     )
     assert validation["valid"] is False
     assert "error" in validation
     resolution = resolve_verification_context(
-        VerificationContextDocumentRequest(document=document)
+        VerificationContextDocumentRequest(document=document),
+        tenant=None,
+        session=None,
     )
     assert resolution == {"resolved": False}
 
@@ -62,7 +76,11 @@ def test_from_diagnostic_non_dict_developer_fields_fails_closed():
             "developer_fields": [],
         },
     )
-    document = create_verification_context_from_diagnostic(payload)
+    document = create_verification_context_from_diagnostic(
+        payload,
+        tenant=None,
+        session=None,
+    )
     assert document["verdict"] == "BLOCKED"
     assert document["context"]["evidence"]["proof_ref"] is None
     assert document["context"]["decision"]["admission"] == "DENY"

--- a/tests/test_verification_context_api.py
+++ b/tests/test_verification_context_api.py
@@ -1,0 +1,52 @@
+from qwed_new.api.verification_context_routes import (
+    DiagnosticVerificationContextRequest,
+    VerificationContextDocumentRequest,
+    create_verification_context_from_diagnostic,
+    resolve_verification_context,
+    validate_verification_context,
+)
+
+
+def test_from_diagnostic_malformed_diagnostic_fails_closed():
+    payload = DiagnosticVerificationContextRequest(
+        query="mean of a == 2",
+        verifier="TestVerifier",
+        diagnostic={"status": "VERIFIED"},
+    )
+    document = create_verification_context_from_diagnostic(payload)
+    assert document["verdict"] == "BLOCKED"
+    assert document["context"]["evidence"]["proof_ref"] is None
+    assert document["context"]["decision"]["admission"] == "DENY"
+    assert validate_verification_context(
+        VerificationContextDocumentRequest(document=document)
+    ) == {"valid": True}
+
+
+def test_from_diagnostic_verified_without_attestation_fails_closed():
+    payload = DiagnosticVerificationContextRequest(
+        query="mean of a == 2",
+        verifier="TestVerifier",
+        diagnostic={
+            "status": "VERIFIED",
+            "agent_message": "Statistical claim verified.",
+            "developer_fields": {"is_valid": True},
+            "proof_ref": "sha256:" + "a" * 64,
+        },
+    )
+    document = create_verification_context_from_diagnostic(payload)
+    assert document["verdict"] == "BLOCKED"
+    assert document["context"]["evidence"]["proof_ref"] is None
+    assert document["context"]["decision"]["admission"] == "DENY"
+
+
+def test_validate_and_resolve_fail_closed_for_invalid_document():
+    document = {"spec_version": "1.0"}
+    validation = validate_verification_context(
+        VerificationContextDocumentRequest(document=document)
+    )
+    assert validation["valid"] is False
+    assert "error" in validation
+    resolution = resolve_verification_context(
+        VerificationContextDocumentRequest(document=document)
+    )
+    assert resolution == {"resolved": False}

--- a/tests/test_verification_context_api.py
+++ b/tests/test_verification_context_api.py
@@ -5,6 +5,14 @@ from qwed_new.api.verification_context_routes import (
     resolve_verification_context,
     validate_verification_context,
 )
+from qwed_new.core.tenant_context import TenantContext
+
+_TENANT = TenantContext(
+    organization_id=1,
+    organization_name="test",
+    tier="free",
+    api_key="test",
+)
 
 
 def test_from_diagnostic_malformed_diagnostic_fails_closed():
@@ -15,7 +23,7 @@ def test_from_diagnostic_malformed_diagnostic_fails_closed():
     )
     document = create_verification_context_from_diagnostic(
         payload,
-        tenant=None,
+        tenant=_TENANT,
         session=None,
     )
     assert document["verdict"] == "BLOCKED"
@@ -23,7 +31,7 @@ def test_from_diagnostic_malformed_diagnostic_fails_closed():
     assert document["context"]["decision"]["admission"] == "DENY"
     assert validate_verification_context(
         VerificationContextDocumentRequest(document=document),
-        tenant=None,
+        tenant=_TENANT,
         session=None,
     ) == {"valid": True}
 
@@ -41,7 +49,7 @@ def test_from_diagnostic_verified_without_attestation_fails_closed():
     )
     document = create_verification_context_from_diagnostic(
         payload,
-        tenant=None,
+        tenant=_TENANT,
         session=None,
     )
     assert document["verdict"] == "BLOCKED"
@@ -53,14 +61,14 @@ def test_validate_and_resolve_fail_closed_for_invalid_document():
     document = {"spec_version": "1.0"}
     validation = validate_verification_context(
         VerificationContextDocumentRequest(document=document),
-        tenant=None,
+        tenant=_TENANT,
         session=None,
     )
     assert validation["valid"] is False
     assert "error" in validation
     resolution = resolve_verification_context(
         VerificationContextDocumentRequest(document=document),
-        tenant=None,
+        tenant=_TENANT,
         session=None,
     )
     assert resolution == {"resolved": False}
@@ -78,7 +86,7 @@ def test_from_diagnostic_non_dict_developer_fields_fails_closed():
     )
     document = create_verification_context_from_diagnostic(
         payload,
-        tenant=None,
+        tenant=_TENANT,
         session=None,
     )
     assert document["verdict"] == "BLOCKED"

--- a/tests/test_verification_context_api.py
+++ b/tests/test_verification_context_api.py
@@ -50,3 +50,19 @@ def test_validate_and_resolve_fail_closed_for_invalid_document():
         VerificationContextDocumentRequest(document=document)
     )
     assert resolution == {"resolved": False}
+
+
+def test_from_diagnostic_non_dict_developer_fields_fails_closed():
+    payload = DiagnosticVerificationContextRequest(
+        query="mean of a == 2",
+        verifier="TestVerifier",
+        diagnostic={
+            "status": "UNVERIFIABLE",
+            "agent_message": "Claim could not be verified.",
+            "developer_fields": [],
+        },
+    )
+    document = create_verification_context_from_diagnostic(payload)
+    assert document["verdict"] == "BLOCKED"
+    assert document["context"]["evidence"]["proof_ref"] is None
+    assert document["context"]["decision"]["admission"] == "DENY"

--- a/tests/test_verification_context_bridge.py
+++ b/tests/test_verification_context_bridge.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from qwed_new.core.attestation import create_verification_attestation
-from qwed_new.core.diagnostics import DiagnosticResult
+from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
 from qwed_new.core.verification_context import (
     VerificationContextValidationError,
     resolve_document_proof_ref,
@@ -113,9 +113,29 @@ def test_blocked_result_fails_closed():
 
 
 def test_empty_formal_statement_rejected():
+    result = _verified_result()
     with pytest.raises(VerificationContextValidationError):
         verification_context_from_diagnostic_result(
-            _verified_result(),
+            result,
             formal_statement="",
             verifier="TestVerifier",
         )
+
+
+def test_malformed_developer_fields_fail_closed():
+    result = DiagnosticResult(
+        status=DiagnosticStatus.UNVERIFIABLE,
+        agent_message="Claim could not be verified.",
+        developer_fields=[],
+        proof_ref=None,
+    )
+    doc = verification_context_from_diagnostic_result(
+        result,
+        formal_statement=QUERY,
+        verifier="TestVerifier",
+    )
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "BLOCKED"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"

--- a/tests/test_verification_context_bridge.py
+++ b/tests/test_verification_context_bridge.py
@@ -1,0 +1,121 @@
+import json
+
+import pytest
+
+from qwed_new.core.attestation import create_verification_attestation
+from qwed_new.core.diagnostics import DiagnosticResult
+from qwed_new.core.verification_context import (
+    VerificationContextValidationError,
+    resolve_document_proof_ref,
+)
+from qwed_new.core.verification_context_bridge import (
+    verification_context_from_diagnostic_result,
+)
+
+QUERY = "mean of a == 2"
+PROOF_DATA = json.dumps({"observed_result": 2.0}, sort_keys=True)
+
+
+def _verified_result(is_valid=True):
+    return DiagnosticResult.verified(
+        agent_message="Statistical claim verified.",
+        developer_fields={"is_valid": is_valid, "observed_result": 2.0},
+        evidence={"observed_result": 2.0},
+        proof_data=PROOF_DATA,
+    )
+
+
+def _attestation_token():
+    attestation_result = create_verification_attestation(
+        status="VERIFIED",
+        verified=True,
+        engine="test",
+        query=QUERY,
+        proof_data=PROOF_DATA,
+    )
+    assert attestation_result.is_issued
+    return attestation_result.token
+
+
+def test_verified_without_attestation_fails_closed():
+    doc = verification_context_from_diagnostic_result(
+        _verified_result(),
+        formal_statement=QUERY,
+        verifier="TestVerifier",
+    )
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "BLOCKED"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_verified_with_attestation_and_valid_result_admits():
+    doc = verification_context_from_diagnostic_result(
+        _verified_result(is_valid=True),
+        formal_statement=QUERY,
+        verifier="TestVerifier",
+        attestation_token=_attestation_token(),
+    )
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "VERIFIED"
+    assert payload["context"]["decision"]["admission"] == "ADMIT"
+    assert resolve_document_proof_ref(payload)
+
+
+def test_verified_with_attestation_but_invalid_result_denies():
+    doc = verification_context_from_diagnostic_result(
+        _verified_result(is_valid=False),
+        formal_statement=QUERY,
+        verifier="TestVerifier",
+        attestation_token=_attestation_token(),
+    )
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "VERIFIED"
+    assert payload["context"]["decision"]["admission"] == "DENY"
+    assert resolve_document_proof_ref(payload)
+
+
+def test_unverifiable_result_fails_closed():
+    result = DiagnosticResult.unverifiable(
+        agent_message="Claim could not be verified.",
+        developer_fields={"is_valid": False},
+    )
+    doc = verification_context_from_diagnostic_result(
+        result,
+        formal_statement=QUERY,
+        verifier="TestVerifier",
+    )
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "UNVERIFIABLE"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_blocked_result_fails_closed():
+    result = DiagnosticResult.blocked(
+        agent_message="Verification could not be attempted.",
+        developer_fields={"is_valid": False},
+    )
+    doc = verification_context_from_diagnostic_result(
+        result,
+        formal_statement=QUERY,
+        verifier="TestVerifier",
+    )
+    doc.validate()
+    payload = doc.to_dict()
+    assert payload["verdict"] == "BLOCKED"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_empty_formal_statement_rejected():
+    with pytest.raises(VerificationContextValidationError):
+        verification_context_from_diagnostic_result(
+            _verified_result(),
+            formal_statement="",
+            verifier="TestVerifier",
+        )

--- a/tests/test_verification_context_cli.py
+++ b/tests/test_verification_context_cli.py
@@ -76,3 +76,40 @@ def test_context_from_diagnostic(tmp_path):
     assert payload["verdict"] == "UNVERIFIABLE"
     assert payload["context"]["evidence"]["proof_ref"] is None
     assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_context_from_diagnostic_non_object_diagnostic_fails_closed(tmp_path):
+    diagnostic_path = tmp_path / "diagnostic.json"
+    diagnostic_path.write_text(json.dumps(["not", "object"]), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "context",
+            "from-diagnostic",
+            "--diagnostic-file",
+            str(diagnostic_path),
+            "--query",
+            "mean of a == 2",
+            "--verifier",
+            "TestVerifier",
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "BLOCKED"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"
+
+
+def test_context_validate_invalid_json_file(tmp_path):
+    path = tmp_path / "invalid.json"
+    path.write_text("{", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["context", "validate", str(path)])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["valid"] is False
+    assert payload["error"] == "invalid_document_file"

--- a/tests/test_verification_context_cli.py
+++ b/tests/test_verification_context_cli.py
@@ -1,0 +1,78 @@
+import json
+
+from click.testing import CliRunner
+
+from qwed_new.core.diagnostics import DiagnosticResult
+from qwed_new.core.verification_context_bridge import (
+    verification_context_from_diagnostic_result,
+)
+from qwed_sdk.cli import cli
+
+
+def test_context_validate_and_resolve(tmp_path):
+    result = DiagnosticResult.unverifiable(
+        agent_message="Claim could not be verified.",
+        developer_fields={"is_valid": False},
+    )
+    document = verification_context_from_diagnostic_result(
+        result,
+        formal_statement="mean of a == 2",
+        verifier="TestVerifier",
+    )
+    path = tmp_path / "context.json"
+    path.write_text(json.dumps(document.to_dict()), encoding="utf-8")
+
+    runner = CliRunner()
+    validate_result = runner.invoke(cli, ["context", "validate", str(path)])
+    assert validate_result.exit_code == 0
+    assert json.loads(validate_result.output)["valid"] is True
+
+    resolve_result = runner.invoke(cli, ["context", "resolve", str(path)])
+    assert resolve_result.exit_code == 0
+    assert json.loads(resolve_result.output)["resolved"] is False
+
+
+def test_context_validate_invalid_document(tmp_path):
+    path = tmp_path / "invalid.json"
+    path.write_text(json.dumps({"spec_version": "1.0"}), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["context", "validate", str(path)])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["valid"] is False
+    assert "error" in payload
+
+
+def test_context_from_diagnostic(tmp_path):
+    diagnostic_path = tmp_path / "diagnostic.json"
+    diagnostic_path.write_text(
+        json.dumps(
+            {
+                "status": "UNVERIFIABLE",
+                "agent_message": "Claim could not be verified.",
+                "developer_fields": {"is_valid": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "context",
+            "from-diagnostic",
+            "--diagnostic-file",
+            str(diagnostic_path),
+            "--query",
+            "mean of a == 2",
+            "--verifier",
+            "TestVerifier",
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "UNVERIFIABLE"
+    assert payload["context"]["evidence"]["proof_ref"] is None
+    assert payload["context"]["decision"]["admission"] == "DENY"

--- a/tests/test_verification_context_cli.py
+++ b/tests/test_verification_context_cli.py
@@ -113,3 +113,44 @@ def test_context_validate_invalid_json_file(tmp_path):
     payload = json.loads(result.output)
     assert payload["valid"] is False
     assert payload["error"] == "invalid_document_file"
+
+
+def test_context_from_diagnostic_unexpected_bridge_error(monkeypatch, tmp_path):
+    diagnostic_path = tmp_path / "diagnostic.json"
+    diagnostic_path.write_text(
+        json.dumps(
+            {
+                "status": "UNVERIFIABLE",
+                "agent_message": "Claim could not be verified.",
+                "developer_fields": {"is_valid": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "qwed_new.core.verification_context_bridge.verification_context_from_diagnostic_result",
+        _raise,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "context",
+            "from-diagnostic",
+            "--diagnostic-file",
+            str(diagnostic_path),
+            "--query",
+            "mean of a == 2",
+            "--verifier",
+            "TestVerifier",
+        ],
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["valid"] is False
+    assert payload["error"] == "internal_error"

--- a/tests/test_verification_context_sdk.py
+++ b/tests/test_verification_context_sdk.py
@@ -2,7 +2,8 @@ from qwed_sdk.client import QWEDClient
 
 
 def test_sdk_verification_context_methods_call_endpoints(monkeypatch):
-    client = QWEDClient(api_key="qwed_test")
+    api_key = "qwed-test-key"
+    client = QWEDClient(api_key=api_key)
     calls = []
 
     def _fake_request(method, endpoint, **kwargs):

--- a/tests/test_verification_context_sdk.py
+++ b/tests/test_verification_context_sdk.py
@@ -1,0 +1,24 @@
+from qwed_sdk.client import QWEDClient
+
+
+def test_sdk_verification_context_methods_call_endpoints(monkeypatch):
+    client = QWEDClient(api_key="qwed_test")
+    calls = []
+
+    def _fake_request(method, endpoint, **kwargs):
+        calls.append((method, endpoint, kwargs.get("json")))
+        return {}
+
+    monkeypatch.setattr(client, "_request", _fake_request)
+
+    client.create_verification_context_from_diagnostic(
+        diagnostic={"status": "UNVERIFIABLE"},
+        query="mean of a == 2",
+        verifier="TestVerifier",
+    )
+    client.validate_verification_context({"spec_version": "1.0"})
+    client.resolve_verification_context({"spec_version": "1.0"})
+
+    assert calls[0][1] == "/verification-context/from-diagnostic"
+    assert calls[1][1] == "/verification-context/validate"
+    assert calls[2][1] == "/verification-context/resolve"

--- a/tests/test_verification_context_sdk.py
+++ b/tests/test_verification_context_sdk.py
@@ -1,8 +1,10 @@
+import secrets
+
 from qwed_sdk.client import QWEDClient
 
 
 def test_sdk_verification_context_methods_call_endpoints(monkeypatch):
-    api_key = "qwed-test-key"
+    api_key = f"qwed-test-{secrets.token_hex(8)}"
     client = QWEDClient(api_key=api_key)
     calls = []
 
@@ -20,6 +22,18 @@ def test_sdk_verification_context_methods_call_endpoints(monkeypatch):
     client.validate_verification_context({"spec_version": "1.0"})
     client.resolve_verification_context({"spec_version": "1.0"})
 
-    assert calls[0][1] == "/verification-context/from-diagnostic"
-    assert calls[1][1] == "/verification-context/validate"
-    assert calls[2][1] == "/verification-context/resolve"
+    assert calls == [
+        (
+            "POST",
+            "/verification-context/from-diagnostic",
+            {
+                "diagnostic": {"status": "UNVERIFIABLE"},
+                "query": "mean of a == 2",
+                "verifier": "TestVerifier",
+                "verifier_version": None,
+                "attestation_token": None,
+            },
+        ),
+        ("POST", "/verification-context/validate", {"document": {"spec_version": "1.0"}}),
+        ("POST", "/verification-context/resolve", {"document": {"spec_version": "1.0"}}),
+    ]


### PR DESCRIPTION
## **User description**
Closes #306.

Exposes Verification Context v1.0 across QWED Python surfaces and defines the fail-closed QWED Security integration contract.

Changes:
- Adds `verification_context_from_diagnostic_result()` bridge with fail-closed attestation/admission behavior.
- Adds API endpoints:
  - `POST /verification-context/from-diagnostic`
  - `POST /verification-context/validate`
  - `POST /verification-context/resolve`
- Adds SDK client methods for the above endpoints in both sync and async clients.
- Adds CLI commands:
  - `qwed context validate <file>`
  - `qwed context resolve <file>`
  - `qwed context from-diagnostic ...`
- Documents the QWED Security output contract and cross-language SDK conformance expectations.

Fail-closed guarantees:
- `UNVERIFIABLE` / `BLOCKED` are never exposed as `ADMIT`.
- `VERIFIED` requires a valid attestation by default and a resolvable `proof_ref`.
- Schema validation and proof resolution failures fail closed.

Verification:
- New bridge/API/CLI/SDK tests added.
- Full suite: 1962 passed, 102 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added API endpoints, synchronous and asynchronous SDK methods, and CLI commands for creating, validating, and resolving Verification Context documents.
  - Added fail-closed handling for malformed diagnostics, invalid documents, and missing attestations.
  - Added structured verification results, proof-reference resolution, and admission decisions.
  - Published version 7.0.0.

- **Documentation**
  - Added the QWED Security Integration Contract v1.0, covering validation, proof resolution, and conformance requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Expose Verification Context workflows across the API, SDK, and CLI with fail-closed admission

### What Changed
- Create, validate, and resolve Verification Context documents through new API endpoints, synchronous and asynchronous SDK methods, and CLI commands
- Verified results are admitted only when they have valid attestation and resolvable proof evidence; unverifiable, blocked, malformed, or invalid results are denied
- Tenant access and rate limits are enforced before request bodies are processed
- Context activity is recorded with redacted data, and audit failures return a clear server error instead of being ignored
- CLI commands return consistent JSON results for invalid files, validation failures, and unexpected errors

### Impact
`✅ Fail-closed verification admission`
`✅ Consistent context workflows across API, SDK, and CLI`
`✅ Redacted verification audit records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
