### PR TITLE
feat: emit VC v1.0 outputs from Docker action entrypoint

### DIFF
--- a/action_entrypoint.py
+++ b/action_entrypoint.py
@@ -99,18 +99,19 @@ def action_verify():
             print(f"❌ Unsupported engine: {engine}")
             sys.exit(1)
         
-        print(f"🔍 Verdict: {result.verified}")
-        print(f"📝 Explanation: {result.explanation}")
+        print(f"🔍 Verdict: {result.is_verified}")
+        explanation = result.result.get("explanation", "") if result.result else ""
+        print(f"📝 Explanation: {explanation}")
         
-        set_output("verified", str(result.verified).lower())
-        set_output("explanation", result.explanation)
-        set_output("badge_url", generate_badge_url(result.verified))
+        set_output("verified", str(result.is_verified).lower())
+        set_output("explanation", explanation)
+        set_output("badge_url", generate_badge_url(result.is_verified))
         
-        verdict = "VERIFIED" if result.verified else "UNVERIFIABLE"
-        admission = "ADMIT" if result.verified else "DENY"
-        _set_vc_outputs(verdict, admission, {"explanation": result.explanation}, engine)
+        verdict = "VERIFIED" if result.is_verified else "UNVERIFIABLE"
+        admission = "ADMIT" if result.is_verified else "DENY"
+        _set_vc_outputs(verdict, admission, {"explanation": explanation}, engine)
         
-        if not result.verified and get_env("FAIL_ON_FINDINGS", "true") == "true":
+        if not result.is_verified and get_env("FAIL_ON_FINDINGS", "true") == "true":
             sys.exit(1)
             
     except Exception as e:

--- a/action_entrypoint.py
+++ b/action_entrypoint.py
@@ -23,6 +23,7 @@ sys.path.insert(0, "/app")
 from qwed_sdk.guards.system_guard import SystemGuard
 from qwed_sdk.guards.config_guard import ConfigGuard
 from qwed_new.guards.process_guard import ProcessVerifier
+from qwed_new.core.verification_context import _canonical_json
 
 
 def get_env(name: str, default: str = "") -> str:
@@ -510,6 +511,11 @@ def _build_verification_context(
     evidence: dict,
     scan_type: str,
 ) -> dict:
+    configuration: dict = {"action": get_env("ACTION", "verify")}
+    paths = get_env("PATHS", "")
+    if paths:
+        configuration["paths"] = paths
+
     return {
         "spec_version": "1.0",
         "object": {
@@ -523,10 +529,7 @@ def _build_verification_context(
             "proof": {
                 "verifier": "QWED Action",
                 "verifier_version": "3.1.0",
-                "configuration": {
-                    "action": get_env("ACTION", "verify"),
-                    "paths": get_env("PATHS", "."),
-                },
+                "configuration": configuration,
                 "theory_scope": f"QWED {scan_type} verification",
                 "trusted_dependencies": ("qwed-verification",),
                 "outcome_treatment": "unknown/timeout/error resolve to UNVERIFIABLE or BLOCKED",
@@ -553,8 +556,8 @@ def _compute_vc_proof_ref(formal_statement: str, context: dict) -> str:
         "formal_statement": formal_statement,
         "context": bound_context,
     }
-    canonical = json.dumps(bound, sort_keys=True, separators=(",", ":"))
-    return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()}"
+    canonical = _canonical_json(bound)
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
 
 
 def _set_vc_outputs(verdict: str, admission: str, evidence: dict, scan_type: str):

--- a/action_entrypoint.py
+++ b/action_entrypoint.py
@@ -10,6 +10,7 @@ Supports:
 import os
 import sys
 import json
+import hashlib
 from pathlib import Path
 
 try:
@@ -104,6 +105,11 @@ def action_verify():
         set_output("explanation", result.explanation)
         set_output("badge_url", generate_badge_url(result.verified))
         
+        verdict = "VERIFIED" if result.verified else "UNVERIFIABLE"
+        admission = "ADMIT" if result.verified else "DENY"
+        proof_ref = f"sha256:{hashlib.sha256(result.explanation.encode()).hexdigest()}" if result.verified else ""
+        _set_vc_outputs(verdict, admission, proof_ref, {"explanation": result.explanation}, engine)
+        
         if not result.verified and get_env("FAIL_ON_FINDINGS", "true") == "true":
             sys.exit(1)
             
@@ -182,6 +188,11 @@ def action_scan_secrets():
     set_output("findings_count", str(len(findings)))
     set_output("badge_url", generate_badge_url(len(findings) == 0))
     
+    verdict = "VERIFIED" if len(findings) == 0 else "UNVERIFIABLE"
+    admission = "ADMIT" if len(findings) == 0 else "DENY"
+    proof_ref = f"sha256:{hashlib.sha256(str(len(findings)).encode()).hexdigest()}" if len(findings) == 0 else ""
+    _set_vc_outputs(verdict, admission, proof_ref, {"findings_count": len(findings)}, "secrets")
+    
     if findings and get_env("FAIL_ON_FINDINGS", "true") == "true":
         sys.exit(1)
 
@@ -254,6 +265,11 @@ def action_scan_code():
     set_output("findings_count", str(len(findings)))
     set_output("badge_url", generate_badge_url(len(findings) == 0))
     
+    verdict = "VERIFIED" if len(findings) == 0 else "UNVERIFIABLE"
+    admission = "ADMIT" if len(findings) == 0 else "DENY"
+    proof_ref = f"sha256:{hashlib.sha256(str(len(findings)).encode()).hexdigest()}" if len(findings) == 0 else ""
+    _set_vc_outputs(verdict, admission, proof_ref, {"findings_count": len(findings)}, "code")
+    
     if findings and get_env("FAIL_ON_FINDINGS", "true") == "true":
         sys.exit(1)
 
@@ -301,6 +317,11 @@ def action_verify_shell():
     set_output("verified", "true" if len(findings) == 0 else "false")
     set_output("findings_count", str(len(findings)))
     set_output("badge_url", generate_badge_url(len(findings) == 0))
+    
+    verdict = "VERIFIED" if len(findings) == 0 else "UNVERIFIABLE"
+    admission = "ADMIT" if len(findings) == 0 else "DENY"
+    proof_ref = f"sha256:{hashlib.sha256(str(len(findings)).encode()).hexdigest()}" if len(findings) == 0 else ""
+    _set_vc_outputs(verdict, admission, proof_ref, {"findings_count": len(findings)}, "shell")
     
     if findings and get_env("FAIL_ON_FINDINGS", "true") == "true":
         sys.exit(1)
@@ -371,6 +392,11 @@ def action_verify_process():
     set_output("irac_score", f"{irac_result['score']:.4f}")
     set_output("process_rate", f"{milestone_result['process_rate']:.4f}")
     set_output("findings", json.dumps(findings))
+    
+    verdict = "VERIFIED" if authorized else "UNVERIFIABLE"
+    admission = "ADMIT" if authorized else "DENY"
+    proof_ref = f"sha256:{hashlib.sha256(json.dumps(findings).encode()).hexdigest()}" if authorized else ""
+    _set_vc_outputs(verdict, admission, proof_ref, {"irac_score": irac_result["score"], "process_rate": milestone_result["process_rate"]}, "process")
     
     if not authorized and get_env("FAIL_ON_FINDINGS", "true") == "true":
         sys.exit(1)
@@ -470,6 +496,57 @@ def generate_badge_url(passed: bool) -> str:
         return "https://img.shields.io/badge/QWED-verified-brightgreen?logo=data:image/svg+xml;base64,..."
     else:
         return "https://img.shields.io/badge/QWED-failed-red?logo=data:image/svg+xml;base64,..."
+
+
+# ============== VERIFICATION CONTEXT v1.0 ==============
+def _build_verification_context(
+    verdict: str,
+    admission: str,
+    proof_ref: str,
+    evidence: dict,
+    scan_type: str,
+) -> dict:
+    return {
+        "spec_version": "1.0",
+        "object": {
+            "formal_statement": f"QWED {scan_type} scan passed with no security findings",
+        },
+        "context": {
+            "interpretation": {
+                "theory": f"QWED {scan_type} security scan",
+                "logic": "deterministic pattern matching",
+            },
+            "proof": {
+                "verifier": "QWED Action",
+                "verifier_version": "3.1.0",
+                "configuration": {
+                    "action": get_env("ACTION", "verify"),
+                    "paths": get_env("PATHS", "."),
+                },
+                "theory_scope": f"QWED {scan_type} security scan",
+                "trusted_dependencies": ("qwed-verification",),
+                "outcome_treatment": "unknown/timeout/error resolve to UNVERIFIABLE or BLOCKED",
+            },
+            "evidence": {
+                "evidence": evidence,
+                "proof_ref": proof_ref,
+            },
+            "decision": {
+                "admission": admission,
+            },
+        },
+        "verdict": verdict,
+    }
+
+
+def _set_vc_outputs(verdict: str, admission: str, proof_ref: str, evidence: dict, scan_type: str):
+    output_format = get_env("OUTPUT_FORMAT", "text")
+    set_output("verdict", verdict)
+    set_output("admission", admission)
+    set_output("proof_ref", proof_ref)
+    if output_format in ("verification-context", "json"):
+        vc = _build_verification_context(verdict, admission, proof_ref, evidence, scan_type)
+        set_output("verification_context", json.dumps(vc, separators=(",", ":")))
 
 
 # ============== MAIN ==============

--- a/action_entrypoint.py
+++ b/action_entrypoint.py
@@ -107,8 +107,7 @@ def action_verify():
         
         verdict = "VERIFIED" if result.verified else "UNVERIFIABLE"
         admission = "ADMIT" if result.verified else "DENY"
-        proof_ref = f"sha256:{hashlib.sha256(result.explanation.encode()).hexdigest()}" if result.verified else ""
-        _set_vc_outputs(verdict, admission, proof_ref, {"explanation": result.explanation}, engine)
+        _set_vc_outputs(verdict, admission, {"explanation": result.explanation}, engine)
         
         if not result.verified and get_env("FAIL_ON_FINDINGS", "true") == "true":
             sys.exit(1)
@@ -190,8 +189,7 @@ def action_scan_secrets():
     
     verdict = "VERIFIED" if len(findings) == 0 else "UNVERIFIABLE"
     admission = "ADMIT" if len(findings) == 0 else "DENY"
-    proof_ref = f"sha256:{hashlib.sha256(str(len(findings)).encode()).hexdigest()}" if len(findings) == 0 else ""
-    _set_vc_outputs(verdict, admission, proof_ref, {"findings_count": len(findings)}, "secrets")
+    _set_vc_outputs(verdict, admission, {"findings_count": len(findings)}, "secrets")
     
     if findings and get_env("FAIL_ON_FINDINGS", "true") == "true":
         sys.exit(1)
@@ -267,8 +265,7 @@ def action_scan_code():
     
     verdict = "VERIFIED" if len(findings) == 0 else "UNVERIFIABLE"
     admission = "ADMIT" if len(findings) == 0 else "DENY"
-    proof_ref = f"sha256:{hashlib.sha256(str(len(findings)).encode()).hexdigest()}" if len(findings) == 0 else ""
-    _set_vc_outputs(verdict, admission, proof_ref, {"findings_count": len(findings)}, "code")
+    _set_vc_outputs(verdict, admission, {"findings_count": len(findings)}, "code")
     
     if findings and get_env("FAIL_ON_FINDINGS", "true") == "true":
         sys.exit(1)
@@ -320,8 +317,7 @@ def action_verify_shell():
     
     verdict = "VERIFIED" if len(findings) == 0 else "UNVERIFIABLE"
     admission = "ADMIT" if len(findings) == 0 else "DENY"
-    proof_ref = f"sha256:{hashlib.sha256(str(len(findings)).encode()).hexdigest()}" if len(findings) == 0 else ""
-    _set_vc_outputs(verdict, admission, proof_ref, {"findings_count": len(findings)}, "shell")
+    _set_vc_outputs(verdict, admission, {"findings_count": len(findings)}, "shell")
     
     if findings and get_env("FAIL_ON_FINDINGS", "true") == "true":
         sys.exit(1)
@@ -395,8 +391,7 @@ def action_verify_process():
     
     verdict = "VERIFIED" if authorized else "UNVERIFIABLE"
     admission = "ADMIT" if authorized else "DENY"
-    proof_ref = f"sha256:{hashlib.sha256(json.dumps(findings).encode()).hexdigest()}" if authorized else ""
-    _set_vc_outputs(verdict, admission, proof_ref, {"irac_score": irac_result["score"], "process_rate": milestone_result["process_rate"]}, "process")
+    _set_vc_outputs(verdict, admission, {"irac_score": irac_result["score"], "process_rate": milestone_result["process_rate"]}, "process")
     
     if not authorized and get_env("FAIL_ON_FINDINGS", "true") == "true":
         sys.exit(1)
@@ -499,21 +494,30 @@ def generate_badge_url(passed: bool) -> str:
 
 
 # ============== VERIFICATION CONTEXT v1.0 ==============
+def _formal_statement_for(scan_type: str, verdict: str) -> str:
+    if verdict == "VERIFIED":
+        return f"QWED {scan_type} verification passed with no findings"
+    elif verdict == "UNVERIFIABLE":
+        return f"QWED {scan_type} verification detected findings and was not admitted"
+    else:
+        return f"QWED {scan_type} verification was blocked"
+
+
 def _build_verification_context(
     verdict: str,
     admission: str,
-    proof_ref: str,
+    proof_ref,
     evidence: dict,
     scan_type: str,
 ) -> dict:
     return {
         "spec_version": "1.0",
         "object": {
-            "formal_statement": f"QWED {scan_type} scan passed with no security findings",
+            "formal_statement": _formal_statement_for(scan_type, verdict),
         },
         "context": {
             "interpretation": {
-                "theory": f"QWED {scan_type} security scan",
+                "theory": f"QWED {scan_type} verification",
                 "logic": "deterministic pattern matching",
             },
             "proof": {
@@ -523,7 +527,7 @@ def _build_verification_context(
                     "action": get_env("ACTION", "verify"),
                     "paths": get_env("PATHS", "."),
                 },
-                "theory_scope": f"QWED {scan_type} security scan",
+                "theory_scope": f"QWED {scan_type} verification",
                 "trusted_dependencies": ("qwed-verification",),
                 "outcome_treatment": "unknown/timeout/error resolve to UNVERIFIABLE or BLOCKED",
             },
@@ -539,11 +543,34 @@ def _build_verification_context(
     }
 
 
-def _set_vc_outputs(verdict: str, admission: str, proof_ref: str, evidence: dict, scan_type: str):
+def _compute_vc_proof_ref(formal_statement: str, context: dict) -> str:
+    bound_context: dict = {k: v for k, v in context.items() if k != "proof_ref"}
+    if "evidence" in bound_context:
+        bound_context["evidence"] = {
+            k: v for k, v in bound_context["evidence"].items() if k != "proof_ref"
+        }
+    bound = {
+        "formal_statement": formal_statement,
+        "context": bound_context,
+    }
+    canonical = json.dumps(bound, sort_keys=True, separators=(",", ":"))
+    return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()}"
+
+
+def _set_vc_outputs(verdict: str, admission: str, evidence: dict, scan_type: str):
     output_format = get_env("OUTPUT_FORMAT", "text")
+    formal_statement = _formal_statement_for(scan_type, verdict)
+
+    if verdict == "VERIFIED":
+        vc_for_hash = _build_verification_context(verdict, admission, None, evidence, scan_type)
+        proof_ref = _compute_vc_proof_ref(formal_statement, vc_for_hash["context"])
+    else:
+        proof_ref = None
+
     set_output("verdict", verdict)
     set_output("admission", admission)
-    set_output("proof_ref", proof_ref)
+    set_output("proof_ref", proof_ref if proof_ref is not None else "")
+
     if output_format in ("verification-context", "json"):
         vc = _build_verification_context(verdict, admission, proof_ref, evidence, scan_type)
         set_output("verification_context", json.dumps(vc, separators=(",", ":")))


### PR DESCRIPTION
Closes QWED-AI/qwed-verification-action#9.

Adds Verification Context v1.0 output support to the Docker action entrypoint.

## Changes

- Added `_build_verification_context()` helper that builds a VC v1.0 document
- Added `_set_vc_outputs()` helper that sets `verdict`, `admission`, `proof_ref`, and `verification_context` outputs via `GITHUB_OUTPUT`
- Updated all 5 action modes (`verify`, `scan-secrets`, `scan-code`, `verify-shell`, `verify-process`) to emit VC v1.0 outputs
- `verification_context` output is emitted when `output_format=verification-context` or `output_format=json`

## VC v1.0 contract

| Output | Values |
|---|---|
| `verdict` | `VERIFIED` / `UNVERIFIABLE` / `BLOCKED` |
| `admission` | `ADMIT` / `DENY` |
| `proof_ref` | `sha256:<64-hex>` or empty |
| `verification_context` | Full VC v1.0 JSON document |
| `verified` | `true` only when `verdict=VERIFIED` and `admission=ADMIT` |

## Fail-closed

- `UNVERIFIABLE` / `BLOCKED` always produce `admission: DENY`
- `proof_ref` is empty when not `VERIFIED`

## Related

- QWED-AI/qwed-verification-action#9 (Docker image VC v1.0 output support)
- QWED-AI/qwed-verification-action#8 (action.yml VC v1.0 contract)

___

## **CodeAnt-AI Description**
Emit Verification Context v1.0 results from every Docker action mode

### What Changed
- All verification and scanning modes now report a standard verdict, admission decision, and proof reference.
- Successful checks include a SHA-256 proof reference; failed or unverifiable checks deny admission and leave the proof reference empty.
- Verification Context v1.0 JSON is available when the output format is `verification-context` or `json`, including scan evidence and configuration details.

### Impact
`✅ Consistent results across all action modes`
`✅ Fail-closed admission decisions for findings`
`✅ Machine-readable verification evidence`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added SHA-256 verification proof references.
- Verification and scan results now include verdicts, admission decisions, and proof references.
- Added optional, versioned verification-context output containing scan metadata, verification details, supporting evidence, and admission decisions.
- Verification results now provide clearer, more complete information for validation and review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->