### PR TITLE
docs: align repository metadata and README with v7.0 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,38 @@
 <div align="center">
   <img src="assets/logo.png" alt="QWED Logo - AI Verification Engine" width="80" height="80">
-  <h1>QWED Protocol</h1>
-  <h3>Model-Agnostic Trust Boundary for AI Systems</h3>
+  <h1>QWED Verification</h1>
+  <h3>Reference implementation of the QWED Verification protocol and Verification Context v1.0</h3>
   
-  > **QWED Verification** - Production-grade deterministic trust boundary for LLMs, AI agents, and tool-driven systems. Works with **ANY LLM** - OpenAI, Anthropic, Gemini, Llama (via Ollama), or any local model. Detect and prevent AI hallucinations through multiple verification engines • agentic security guards • process determinism. **Your LLM, Your Choice, Our Verification.**
-  
-  <p>
-    <b>Don't fix the liar. Verify the lie.</b><br>
-    <i>QWED verifies outputs, processes, and tool interactions before they enter production.</i><br>
-    <i>For supported proof domains, hallucinations cannot bypass deterministic verification.</i>
-  </p>
+  QWED applies deterministic verification to AI outputs before production execution.
 
-  <p>
-    <b>If critical AI output cannot be verified, QWED can block it before production.</b>
-  </p>
+  Every verification returns a <code>DiagnosticResult</code>:
 
-  <p>
-    <b>🌐 Model Agnostic:</b> Local ($0) • Budget ($5/mo) • Premium ($100/mo) - You choose!
-  </p>
+  <b>VERIFIED</b> — proof established, evidence attached<br>
+  <b>UNVERIFIABLE</b> — proof could not be established<br>
+  <b>BLOCKED</b> — policy or rule rejected the action<br>
+
+  Admission: <b>ADMIT</b> | <b>DENY</b>
+
+  Verification Context v1.0 provides the canonical evidence and proof model.
+
+  <p><i>Don't fix the liar. Verify the lie.</i></p>
 
   [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/QWED-AI/qwed-verification?utm_source=badge)
   [![PyPI version](https://img.shields.io/pypi/v/qwed.svg)](https://pypi.org/project/qwed/)
   [![Docker Verified](https://img.shields.io/badge/Docker-Verified_Publisher-blue.svg?logo=docker&logoColor=white)](https://hub.docker.com/r/qwedai/qwed-verification)
   [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](LICENSE)
   [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11903/badge)](https://www.bestpractices.dev/projects/11903)
-  [![Snyk Security](https://img.shields.io/badge/Snyk-Monitored-4C4A73?logo=snyk&logoColor=white)](https://app.snyk.io)
   [![QWED Security](https://img.shields.io/badge/GitHub_Marketplace-QWED_Security_%E2%9C%93-2ea44f?style=flat&logo=github&logoColor=white)](https://github.com/marketplace/qwed-security)
-  [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=QWED-AI_qwed-verification&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=QWED-AI_qwed-verification)
   [![DOI](https://zenodo.org/badge/1115581942.svg)](https://doi.org/10.5281/zenodo.18111675)
-  [![GitHub stars](https://img.shields.io/github/stars/QWED-AI/qwed-verification?style=social)](https://github.com/QWED-AI/qwed-verification)
-
-  [![Also on GitLab](https://img.shields.io/badge/Also%20on-GitLab%20(Enterprise)-FC6D26?logo=gitlab&logoColor=white)](https://gitlab.com/qwed-ai/qwed-verification)
-
-  <a href="https://www.nvidia.com/en-us/startups/"><img src="./assets/badges/nvidia-inception.png" alt="NVIDIA Inception Program" height="40"></a>
-  <a href="https://github.com/developer-program"><img src="https://img.shields.io/badge/GitHub_Developer_Program-Member-4183C4?style=for-the-badge&logo=github&logoColor=white" alt="GitHub Developer Program" height="40"></a>
 
   <br>
-
-  **💖 Support QWED Development:**
-  
-  <a href="https://github.com/sponsors/QWED-AI"><img src="https://img.shields.io/github/sponsors/QWED-AI?style=for-the-badge&logo=githubsponsors&label=Sponsor&color=EA4AAA" alt="Sponsor QWED on GitHub"></a>
-
-  <br>
-  
-  [![Twitter](https://img.shields.io/badge/Twitter-@rahuldass29-1DA1F2?style=flat&logo=twitter&logoColor=white)](https://x.com/rahuldass29)
-  [![LinkedIn](https://img.shields.io/badge/LinkedIn-Rahul%20Dass-0077B5?style=flat&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/rahul-dass-23b370b0/)
-  [![Blog](https://img.shields.io/badge/Blog-Unreadable%20Code%20Benchmark-FF5722?style=flat&logo=docusaurus&logoColor=white)](https://docs.qwedai.com/blog/unreadable-code-agi-benchmark)
-
-  <br>
-  <a href="#-quick-start-install--verify-in-30-seconds">Quick Start</a> · 
-  <a href="#-first-time-setup-qwed-init">🆕 qwed init</a> ·
-  <a href="#-the-llm-hallucination-problem-why-ai-cant-be-trusted">The Problem</a> · 
-  <a href="#verification-engines-and-agent-security-guards">The Engines & Guards</a> ·
-  <a href="docs/INTEGRATION.md">🔌 Integration</a> ·
-  <a href="docs/QWED_LOCAL.md">⚡ QWEDLocal</a> ·
-  <a href="docs/CLI.md">🖥️ CLI</a> ·
-  <a href="docs/OLLAMA_INTEGRATION.md">🆓 Ollama (FREE!)</a> ·
-  <a href="https://docs.qwedai.com">📖 Full Documentation</a>
+  <a href="#-installation--quick-start">Quick Start</a> · 
+  <a href="#-first-time-setup-qwed-init">qwed init</a> ·
+  <a href="#verification-engines-and-agent-security-guards">Engines & Guards</a> ·
+  <a href="docs/INTEGRATION.md">Integration</a> ·
+  <a href="docs/QWED_LOCAL.md">QWEDLocal</a> ·
+  <a href="docs/CLI.md">CLI</a> ·
+  <a href="https://docs.qwedai.com">Full Documentation</a>
 </div>
 
 ---

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@
   <b>UNVERIFIABLE</b> — proof could not be established<br>
   <b>BLOCKED</b> — policy or rule rejected the action<br>
 
-  Admission: <b>ADMIT</b> | <b>DENY</b>
+  Admission: <b>ADMIT</b> | <b>BLOCKED</b>
 
-  Verification Context v1.0 provides the canonical evidence and proof model.
+  Verification Context v1.0 provides the canonical evidence and proof model
+  (admission: <b>ADMIT</b> | <b>DENY</b> at the protocol layer).
 
   <p><i>Don't fix the liar. Verify the lie.</i></p>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,25 @@
 [project]
 name = "qwed"
 version = "7.0.0"
-description = "The Deterministic Verification Protocol for AI - 11 verification engines for math, logic, code, SQL, facts, images, and more. Now with Agentic Security Guards."
+description = "Open-source AI verification infrastructure for deterministic verification of LLM outputs, tool calls, code, schemas, and agent state before production execution."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},
 ]
 license = {text = "Apache-2.0"}
 keywords = [
-    "ai",
-    "verification",
-    "llm",
-    "deterministic",
-    "symbolic",
-    "math",
-    "logic",
+    "ai-verification",
+    "llm-verification",
+    "deterministic-verification",
+    "verification-context",
+    "diagnostic-result",
+    "fail-closed",
+    "ai-safety",
     "code-security",
     "sql-validation",
-    "fact-checking"
+    "formal-verification",
+    "symbolic-reasoning",
+    "z3",
+    "sympy",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
This PR does not introduce new functionality. It aligns the repository's public-facing documentation with the architecture that shipped in the v7.x series, including Verification Context v1.0, DiagnosticResult, and the verification protocol.

## Changes

- **README title**: QWED Protocol -> QWED Verification with subtitle "Reference implementation of the QWED Verification protocol and Verification Context v1.0"
- **README opening**: Now shows the DiagnosticResult contract (VERIFIED / UNVERIFIABLE / BLOCKED + ADMIT / DENY) and Verification Context v1.0
- **README**: Removed pricing line, reduced badge wall
- **pyproject.toml**: Removed volatile "11 engines" count from description
- **pyproject.toml**: Updated keywords to reflect v7.0 architecture
- **GitHub description**: Updated to category + differentiator
- **GitHub topics**: Added verification-context, diagnostic-result, fail-closed; removed nlp, neurosymbolic-ai (inaccurate - QWED is deterministic, not NLP/neurosymbolic)

## Rationale

The README previously reflected pre-v7.0 architecture. With Verification Context v1.0, DiagnosticResult conformance, and the verification protocol now implemented and frozen, the public-facing repository should reflect this architecture.

This is the natural conclusion of the v7.x series:
1. Architecture freeze (ADRs, spec)
2. Implementation (engines, SDK, API, CLI)
3. QWED Security alignment
4. **Repository positioning (this PR)**

___

## **CodeAnt-AI Description**
Align repository messaging with the QWED Verification v7.0 architecture

### What Changed
- The README now presents QWED Verification as the reference implementation for Verification Context v1.0
- Documentation explains the `DiagnosticResult` outcomes—VERIFIED, UNVERIFIABLE, and BLOCKED—and the ADMIT/DENY decision
- Project metadata now describes deterministic verification for AI outputs, tool calls, code, schemas, and agent state
- Removed outdated pricing, engine-count, promotional badges, and inaccurate repository topics

### Impact
`✅ Clearer verification outcomes`
`✅ More accurate project positioning`
`✅ Easier discovery for AI verification users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
