### PR TITLE
feat: add to_verification_context to all 11 remaining verifiers

### DIFF
--- a/src/qwed_new/core/code_verifier.py
+++ b/src/qwed_new/core/code_verifier.py
@@ -1092,7 +1092,7 @@ class CodeVerifier:
             evidence=evidence,
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/code_verifier.py
+++ b/src/qwed_new/core/code_verifier.py
@@ -13,6 +13,13 @@ import re
 
 from .diagnostics import DiagnosticResult
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 
 @dataclass
 class SecurityIssue:
@@ -43,6 +50,16 @@ CONSTRAINT_CODE_SAFE = "code_verifier.code_safe"
 CONSTRAINT_CODE_UNSAFE = "code_verifier.code_unsafe"
 CONSTRAINT_EMPTY_BATCH = "code_verifier.empty_batch"
 CONSTRAINT_BATCH_BLOCKED = "code_verifier.batch_blocked"
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class CodeVerifier:
@@ -1087,3 +1104,4 @@ class CodeVerifier:
             developer_fields=batch_fields,
             evidence=evidence,
         )
+

--- a/src/qwed_new/core/code_verifier.py
+++ b/src/qwed_new/core/code_verifier.py
@@ -1092,12 +1092,13 @@ class CodeVerifier:
             evidence=evidence,
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="CodeVerifier",
         )
 

--- a/src/qwed_new/core/code_verifier.py
+++ b/src/qwed_new/core/code_verifier.py
@@ -46,14 +46,6 @@ CONSTRAINT_CODE_UNSAFE = "code_verifier.code_unsafe"
 CONSTRAINT_EMPTY_BATCH = "code_verifier.empty_batch"
 CONSTRAINT_BATCH_BLOCKED = "code_verifier.batch_blocked"
 
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
 
 
 

--- a/src/qwed_new/core/code_verifier.py
+++ b/src/qwed_new/core/code_verifier.py
@@ -13,12 +13,7 @@ import re
 
 from .diagnostics import DiagnosticResult
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .verification_context import VerificationContextDocument
 
 
 @dataclass
@@ -1104,4 +1099,15 @@ class CodeVerifier:
             developer_fields=batch_fields,
             evidence=evidence,
         )
+
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="CodeVerifier",
+        )
+
+
 

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -273,14 +273,6 @@ class CircuitBreaker:
             for name, health in self._engines.items()
         }
 
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
 
 
 

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -964,12 +964,13 @@ class ConsensusVerifier:
         if self.circuit_breaker:
             self.circuit_breaker._engines.clear()
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="ConsensusVerifier",
         )
 

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -21,6 +21,13 @@ import threading
 
 from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 
 logger = logging.getLogger(__name__)
 SECURE_EXECUTION_REQUIRED = "SECURE_EXECUTION_REQUIRED"
@@ -270,6 +277,16 @@ class CircuitBreaker:
             }
             for name, health in self._engines.items()
         }
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class ConsensusVerifier:
@@ -963,3 +980,4 @@ class ConsensusVerifier:
 
 # Global singleton
 consensus_verifier = ConsensusVerifier()
+

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -964,7 +964,7 @@ class ConsensusVerifier:
         if self.circuit_breaker:
             self.circuit_breaker._engines.clear()
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -21,12 +21,7 @@ import threading
 
 from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .verification_context import VerificationContextDocument
 
 
 logger = logging.getLogger(__name__)
@@ -977,7 +972,18 @@ class ConsensusVerifier:
         if self.circuit_breaker:
             self.circuit_breaker._engines.clear()
 
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="ConsensusVerifier",
+        )
+
+
 
 # Global singleton
 consensus_verifier = ConsensusVerifier()
+
 

--- a/src/qwed_new/core/dsl_logic_verifier.py
+++ b/src/qwed_new/core/dsl_logic_verifier.py
@@ -16,6 +16,13 @@ from z3 import Solver, sat, unsat
 from qwed_new.core.dsl import parse_and_validate, compile_to_z3
 from qwed_new.core.translator import TranslationLayer
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -29,6 +36,16 @@ class DSLVerificationResult:
     error: Optional[str] = None
     rejection_reason: Optional[str] = None  # Human-readable explanation for UNSAT
     provider_used: Optional[str] = None
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class DSLLogicVerifier:
@@ -607,3 +624,4 @@ if __name__ == "__main__":
     
     print("\n" + "=" * 60)
     print("Demo complete!")
+

--- a/src/qwed_new/core/dsl_logic_verifier.py
+++ b/src/qwed_new/core/dsl_logic_verifier.py
@@ -16,12 +16,8 @@ from z3 import Solver, sat, unsat
 from qwed_new.core.dsl import parse_and_validate, compile_to_z3
 from qwed_new.core.translator import TranslationLayer
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .diagnostics import DiagnosticResult
+from .verification_context import VerificationContextDocument
 
 logger = logging.getLogger(__name__)
 
@@ -36,16 +32,6 @@ class DSLVerificationResult:
     error: Optional[str] = None
     rejection_reason: Optional[str] = None  # Human-readable explanation for UNSAT
     provider_used: Optional[str] = None
-
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
-
 
 
 class DSLLogicVerifier:
@@ -565,6 +551,16 @@ class DSLLogicVerifier:
             verification_result.dsl_code = dsl_code
         return verification_result
 
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="DSLLogicVerifier",
+        )
+
+
 
 # Singleton for convenience
 _dsl_verifier = None
@@ -624,4 +620,5 @@ if __name__ == "__main__":
     
     print("\n" + "=" * 60)
     print("Demo complete!")
+
 

--- a/src/qwed_new/core/dsl_logic_verifier.py
+++ b/src/qwed_new/core/dsl_logic_verifier.py
@@ -551,7 +551,7 @@ class DSLLogicVerifier:
             verification_result.dsl_code = dsl_code
         return verification_result
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/dsl_logic_verifier.py
+++ b/src/qwed_new/core/dsl_logic_verifier.py
@@ -551,12 +551,13 @@ class DSLLogicVerifier:
             verification_result.dsl_code = dsl_code
         return verification_result
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="DSLLogicVerifier",
         )
 

--- a/src/qwed_new/core/fact_verifier.py
+++ b/src/qwed_new/core/fact_verifier.py
@@ -624,12 +624,13 @@ class FactVerifier:
         """Tokenize text into lowercase words."""
         return set(re.findall(r'\b[a-zA-Z]+\b', text.lower()))
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="FactVerifier",
         )
 
@@ -727,12 +728,13 @@ class BatchFactVerifier:
             extra_evidence=extra_evidence,
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="BatchFactVerifier",
         )
 

--- a/src/qwed_new/core/fact_verifier.py
+++ b/src/qwed_new/core/fact_verifier.py
@@ -727,4 +727,13 @@ class BatchFactVerifier:
             extra_evidence=extra_evidence,
         )
 
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="BatchFactVerifier",
+        )
+
 

--- a/src/qwed_new/core/fact_verifier.py
+++ b/src/qwed_new/core/fact_verifier.py
@@ -624,7 +624,7 @@ class FactVerifier:
         """Tokenize text into lowercase words."""
         return set(re.findall(r'\b[a-zA-Z]+\b', text.lower()))
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
@@ -728,7 +728,7 @@ class BatchFactVerifier:
             extra_evidence=extra_evidence,
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/fact_verifier.py
+++ b/src/qwed_new/core/fact_verifier.py
@@ -25,12 +25,7 @@ from qwed_new.core.diagnostics import (
     aggregate_batch_diagnostic,
 )
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .verification_context import VerificationContextDocument
 
 logger = logging.getLogger(__name__)
 
@@ -59,16 +54,6 @@ class FactVerificationResult:
     citations: List[Citation] = field(default_factory=list)
     methods_used: List[str] = field(default_factory=list)
     scores: Dict[str, float] = field(default_factory=dict)
-
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
-
 
 
 class FactVerifier:
@@ -639,19 +624,20 @@ class FactVerifier:
         """Tokenize text into lowercase words."""
         return set(re.findall(r'\b[a-zA-Z]+\b', text.lower()))
 
-
-# =============================================================================
-# Batch Verification
-# =============================================================================
-
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
-            verifier=self.__class__.__name__,
+            verifier="FactVerifier",
         )
+
+
+
+# =============================================================================
+# Batch Verification
+# =============================================================================
 
 
 class BatchFactVerifier:
@@ -740,4 +726,5 @@ class BatchFactVerifier:
             },
             extra_evidence=extra_evidence,
         )
+
 

--- a/src/qwed_new/core/fact_verifier.py
+++ b/src/qwed_new/core/fact_verifier.py
@@ -25,6 +25,13 @@ from qwed_new.core.diagnostics import (
     aggregate_batch_diagnostic,
 )
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 logger = logging.getLogger(__name__)
 
 CONSTRAINT_FACT_BATCH_VERIFIED = "fact_verifier.batch_verified"
@@ -52,6 +59,16 @@ class FactVerificationResult:
     citations: List[Citation] = field(default_factory=list)
     methods_used: List[str] = field(default_factory=list)
     scores: Dict[str, float] = field(default_factory=dict)
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class FactVerifier:
@@ -627,6 +644,16 @@ class FactVerifier:
 # Batch Verification
 # =============================================================================
 
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
+
 class BatchFactVerifier:
     """
     Batch verification for multiple claims against a single context.
@@ -713,3 +740,4 @@ class BatchFactVerifier:
             },
             extra_evidence=extra_evidence,
         )
+

--- a/src/qwed_new/core/graph_fact_verifier.py
+++ b/src/qwed_new/core/graph_fact_verifier.py
@@ -31,12 +31,7 @@ import re
 
 from qwed_new.core.diagnostics import DiagnosticResult, AdvisoryCheck
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .verification_context import VerificationContextDocument
 
 
 def _word_boundary_contained(a: str, b: str) -> bool:
@@ -598,4 +593,15 @@ class GraphFactVerifier:
                 "graph_result": graph_result.to_dict(),
             }
         )
+
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="GraphFactVerifier",
+        )
+
+
 

--- a/src/qwed_new/core/graph_fact_verifier.py
+++ b/src/qwed_new/core/graph_fact_verifier.py
@@ -31,6 +31,13 @@ import re
 
 from qwed_new.core.diagnostics import DiagnosticResult, AdvisoryCheck
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 
 def _word_boundary_contained(a: str, b: str) -> bool:
     """True if a is a word-boundary-delimited substring of b."""
@@ -84,6 +91,16 @@ class FactResult:
     context_triples: List[Triple]
     matches: List[MatchResult]
     explanation: str
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class GraphFactVerifier:
@@ -581,3 +598,4 @@ class GraphFactVerifier:
                 "graph_result": graph_result.to_dict(),
             }
         )
+

--- a/src/qwed_new/core/graph_fact_verifier.py
+++ b/src/qwed_new/core/graph_fact_verifier.py
@@ -586,7 +586,7 @@ class GraphFactVerifier:
             }
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/graph_fact_verifier.py
+++ b/src/qwed_new/core/graph_fact_verifier.py
@@ -87,14 +87,6 @@ class FactResult:
     matches: List[MatchResult]
     explanation: str
 
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
 
 
 

--- a/src/qwed_new/core/graph_fact_verifier.py
+++ b/src/qwed_new/core/graph_fact_verifier.py
@@ -586,12 +586,13 @@ class GraphFactVerifier:
             }
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="GraphFactVerifier",
         )
 

--- a/src/qwed_new/core/image_verifier.py
+++ b/src/qwed_new/core/image_verifier.py
@@ -598,12 +598,13 @@ class ImageVerifier:
             extra_evidence=extra_evidence,
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="ImageVerifier",
         )
 
@@ -700,12 +701,13 @@ class MultiVLMVerifier:
             }
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="MultiVLMVerifier",
         )
 

--- a/src/qwed_new/core/image_verifier.py
+++ b/src/qwed_new/core/image_verifier.py
@@ -24,6 +24,13 @@ from qwed_new.core.diagnostics import (
     aggregate_batch_diagnostic,
 )
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 _INCONCLUSIVE_MSG = "Image verification inconclusive"
 
 _CONSTRAINT_IMAGE_BATCH_VERIFIED = "image_verifier.batch_verified"
@@ -52,6 +59,16 @@ class ImageVerificationResult:
     reasoning: str
     analysis: Dict[str, Any] = field(default_factory=dict)
     methods_used: List[str] = field(default_factory=list)
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class ImageVerifier:
@@ -601,6 +618,16 @@ class ImageVerifier:
 # Multi-VLM Consensus Verifier
 # =============================================================================
 
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
+
 class MultiVLMVerifier:
     """
     Verifies image claims using multiple VLM providers for consensus.
@@ -686,3 +713,4 @@ class MultiVLMVerifier:
                 "vlm_count": len(vlm_results),
             }
         )
+

--- a/src/qwed_new/core/image_verifier.py
+++ b/src/qwed_new/core/image_verifier.py
@@ -700,4 +700,13 @@ class MultiVLMVerifier:
             }
         )
 
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="MultiVLMVerifier",
+        )
+
 

--- a/src/qwed_new/core/image_verifier.py
+++ b/src/qwed_new/core/image_verifier.py
@@ -24,12 +24,7 @@ from qwed_new.core.diagnostics import (
     aggregate_batch_diagnostic,
 )
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .verification_context import VerificationContextDocument
 
 _INCONCLUSIVE_MSG = "Image verification inconclusive"
 
@@ -59,16 +54,6 @@ class ImageVerificationResult:
     reasoning: str
     analysis: Dict[str, Any] = field(default_factory=dict)
     methods_used: List[str] = field(default_factory=list)
-
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
-
 
 
 class ImageVerifier:
@@ -613,19 +598,20 @@ class ImageVerifier:
             extra_evidence=extra_evidence,
         )
 
-
-# =============================================================================
-# Multi-VLM Consensus Verifier
-# =============================================================================
-
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
-            verifier=self.__class__.__name__,
+            verifier="ImageVerifier",
         )
+
+
+
+# =============================================================================
+# Multi-VLM Consensus Verifier
+# =============================================================================
 
 
 class MultiVLMVerifier:
@@ -713,4 +699,5 @@ class MultiVLMVerifier:
                 "vlm_count": len(vlm_results),
             }
         )
+
 

--- a/src/qwed_new/core/image_verifier.py
+++ b/src/qwed_new/core/image_verifier.py
@@ -598,7 +598,7 @@ class ImageVerifier:
             extra_evidence=extra_evidence,
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
@@ -701,7 +701,7 @@ class MultiVLMVerifier:
             }
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/logic_verifier.py
+++ b/src/qwed_new/core/logic_verifier.py
@@ -40,14 +40,6 @@ class QuantifiedFormula:
     bound_vars: List[Tuple[str, str]]  # [(name, type), ...]
     body: str  # The formula body
 
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
 
 
 

--- a/src/qwed_new/core/logic_verifier.py
+++ b/src/qwed_new/core/logic_verifier.py
@@ -15,12 +15,7 @@ import logging
 
 from qwed_new.core.diagnostics import DiagnosticResult
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .verification_context import VerificationContextDocument
 
 logger = logging.getLogger(__name__)
 
@@ -968,4 +963,15 @@ class LogicVerifier:
                 _PIPELINE_ERROR_MSG,
                 {"constraint_id": _CONSTRAINT_ID_EXECUTION_ERROR, "error_type": type(exc).__name__},
             )
+
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="LogicVerifier",
+        )
+
+
 

--- a/src/qwed_new/core/logic_verifier.py
+++ b/src/qwed_new/core/logic_verifier.py
@@ -956,7 +956,7 @@ class LogicVerifier:
                 {"constraint_id": _CONSTRAINT_ID_EXECUTION_ERROR, "error_type": type(exc).__name__},
             )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/logic_verifier.py
+++ b/src/qwed_new/core/logic_verifier.py
@@ -956,12 +956,13 @@ class LogicVerifier:
                 {"constraint_id": _CONSTRAINT_ID_EXECUTION_ERROR, "error_type": type(exc).__name__},
             )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="LogicVerifier",
         )
 

--- a/src/qwed_new/core/logic_verifier.py
+++ b/src/qwed_new/core/logic_verifier.py
@@ -15,6 +15,13 @@ import logging
 
 from qwed_new.core.diagnostics import DiagnosticResult
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 logger = logging.getLogger(__name__)
 
 # ------------------------------------------------------------------
@@ -37,6 +44,16 @@ class QuantifiedFormula:
     quantifier: str  # "forall", "exists"
     bound_vars: List[Tuple[str, str]]  # [(name, type), ...]
     body: str  # The formula body
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class LogicVerifier:
@@ -951,3 +968,4 @@ class LogicVerifier:
                 _PIPELINE_ERROR_MSG,
                 {"constraint_id": _CONSTRAINT_ID_EXECUTION_ERROR, "error_type": type(exc).__name__},
             )
+

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -25,12 +25,7 @@ import time
 
 from qwed_new.core.diagnostics import DiagnosticResult, AdvisoryCheck
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .verification_context import VerificationContextDocument
 
 logger = logging.getLogger(__name__)
 
@@ -766,4 +761,15 @@ Format as a numbered list."""
             "size": len(self._cache),
             "max_size": self._cache_max_size
         }
+
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="ReasoningVerifier",
+        )
+
+
 

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -754,7 +754,7 @@ Format as a numbered list."""
             "max_size": self._cache_max_size
         }
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -754,12 +754,13 @@ Format as a numbered list."""
             "max_size": self._cache_max_size
         }
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="ReasoningVerifier",
         )
 

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -61,14 +61,6 @@ class ChainOfThoughtStep:
     output_value: Optional[Any] = None
     confidence: float = 1.0
 
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
 
 
 

--- a/src/qwed_new/core/reasoning_verifier.py
+++ b/src/qwed_new/core/reasoning_verifier.py
@@ -25,6 +25,13 @@ import time
 
 from qwed_new.core.diagnostics import DiagnosticResult, AdvisoryCheck
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -58,6 +65,16 @@ class ChainOfThoughtStep:
     input_values: List[Any] = field(default_factory=list)
     output_value: Optional[Any] = None
     confidence: float = 1.0
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class ReasoningVerifier:
@@ -749,3 +766,4 @@ Format as a numbered list."""
             "size": len(self._cache),
             "max_size": self._cache_max_size
         }
+

--- a/src/qwed_new/core/schema_verifier.py
+++ b/src/qwed_new/core/schema_verifier.py
@@ -26,12 +26,7 @@ import json
 
 from qwed_new.core.diagnostics import DiagnosticResult
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .verification_context import VerificationContextDocument
 
 
 @dataclass
@@ -1571,4 +1566,15 @@ class SchemaVerifier:
             evidence=ucp_evidence,
             proof_data=proof_data,
         )
+
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="SchemaVerifier",
+        )
+
+
 

--- a/src/qwed_new/core/schema_verifier.py
+++ b/src/qwed_new/core/schema_verifier.py
@@ -173,14 +173,6 @@ _UCP_TOTAL_PRECISION = 400
 # Max entries in the per-instance schema-shape cache before it is cleared.
 _SHAPE_CACHE_MAX = 128
 
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
 
 
 

--- a/src/qwed_new/core/schema_verifier.py
+++ b/src/qwed_new/core/schema_verifier.py
@@ -1559,7 +1559,7 @@ class SchemaVerifier:
             proof_data=proof_data,
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/schema_verifier.py
+++ b/src/qwed_new/core/schema_verifier.py
@@ -1559,12 +1559,13 @@ class SchemaVerifier:
             proof_data=proof_data,
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="SchemaVerifier",
         )
 

--- a/src/qwed_new/core/schema_verifier.py
+++ b/src/qwed_new/core/schema_verifier.py
@@ -26,6 +26,13 @@ import json
 
 from qwed_new.core.diagnostics import DiagnosticResult
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 
 @dataclass
 class SchemaIssue:
@@ -170,6 +177,16 @@ _UCP_TOTAL_PRECISION = 400
 
 # Max entries in the per-instance schema-shape cache before it is cleared.
 _SHAPE_CACHE_MAX = 128
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class SchemaVerifier:
@@ -1554,3 +1571,4 @@ class SchemaVerifier:
             evidence=ucp_evidence,
             proof_data=proof_data,
         )
+

--- a/src/qwed_new/core/sql_verifier.py
+++ b/src/qwed_new/core/sql_verifier.py
@@ -808,7 +808,7 @@ class SQLVerifier:
             developer_fields=batch_fields,
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/sql_verifier.py
+++ b/src/qwed_new/core/sql_verifier.py
@@ -78,14 +78,6 @@ class SecurityViolation(Exception):
     """Raised when a security policy is violated."""
     pass
 
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
 
 
 

--- a/src/qwed_new/core/sql_verifier.py
+++ b/src/qwed_new/core/sql_verifier.py
@@ -18,12 +18,7 @@ from dataclasses import dataclass
 
 from .diagnostics import DiagnosticResult
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .verification_context import VerificationContextDocument
 
 
 CONSTRAINT_PARSE_ERROR = "sql_verifier.parse_error"
@@ -820,4 +815,15 @@ class SQLVerifier:
             ),
             developer_fields=batch_fields,
         )
+
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="SQLVerifier",
+        )
+
+
 

--- a/src/qwed_new/core/sql_verifier.py
+++ b/src/qwed_new/core/sql_verifier.py
@@ -18,6 +18,13 @@ from dataclasses import dataclass
 
 from .diagnostics import DiagnosticResult
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 
 CONSTRAINT_PARSE_ERROR = "sql_verifier.parse_error"
 CONSTRAINT_EXECUTION_ERROR = "sql_verifier.execution_error"
@@ -75,6 +82,16 @@ class ComplexityMetrics:
 class SecurityViolation(Exception):
     """Raised when a security policy is violated."""
     pass
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class SQLVerifier:
@@ -803,3 +820,4 @@ class SQLVerifier:
             ),
             developer_fields=batch_fields,
         )
+

--- a/src/qwed_new/core/sql_verifier.py
+++ b/src/qwed_new/core/sql_verifier.py
@@ -808,12 +808,13 @@ class SQLVerifier:
             developer_fields=batch_fields,
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="SQLVerifier",
         )
 

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -19,14 +19,6 @@ from .verification_context import VerificationContextDocument
 
 CONSTRAINT_SYNTAX_ERROR = "symbolic_verifier.syntax_error"
 
-def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
-        """Map a DiagnosticResult to a Verification Context v1.0 document."""
-        from .verification_context_bridge import verification_context_from_diagnostic_result
-        return verification_context_from_diagnostic_result(
-            result,
-            formal_statement=query,
-            verifier=self.__class__.__name__,
-        )
 
 
 

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -926,7 +926,7 @@ class SymbolicVerifier:
             },
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -926,12 +926,13 @@ class SymbolicVerifier:
             },
         )
 
-    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+    def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: str = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""
         from .verification_context_bridge import verification_context_from_diagnostic_result
         return verification_context_from_diagnostic_result(
             result,
             formal_statement=query,
+            attestation_token=attestation_token,
             verifier="SymbolicVerifier",
         )
 

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -15,7 +15,24 @@ import sys
 
 from .diagnostics import AdvisoryCheck, DiagnosticResult, DiagnosticStatus
 
+from .verification_context import (
+    Formalization,
+    Interpretation,
+    Proof,
+    VerificationContextDocument,
+)
+
 CONSTRAINT_SYNTAX_ERROR = "symbolic_verifier.syntax_error"
+
+def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier=self.__class__.__name__,
+        )
+
 
 
 class SymbolicVerifier:
@@ -927,3 +944,4 @@ class SymbolicVerifier:
 def create_symbolic_verifier(**kwargs) -> SymbolicVerifier:
     """Create a SymbolicVerifier instance."""
     return SymbolicVerifier(**kwargs)
+

--- a/src/qwed_new/core/symbolic_verifier.py
+++ b/src/qwed_new/core/symbolic_verifier.py
@@ -15,12 +15,7 @@ import sys
 
 from .diagnostics import AdvisoryCheck, DiagnosticResult, DiagnosticStatus
 
-from .verification_context import (
-    Formalization,
-    Interpretation,
-    Proof,
-    VerificationContextDocument,
-)
+from .verification_context import VerificationContextDocument
 
 CONSTRAINT_SYNTAX_ERROR = "symbolic_verifier.syntax_error"
 
@@ -939,9 +934,20 @@ class SymbolicVerifier:
             },
         )
 
+    def to_verification_context(self, result: "DiagnosticResult", query: str) -> "VerificationContextDocument":
+        """Map a DiagnosticResult to a Verification Context v1.0 document."""
+        from .verification_context_bridge import verification_context_from_diagnostic_result
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=query,
+            verifier="SymbolicVerifier",
+        )
+
+
 
 # Factory function for easy access
 def create_symbolic_verifier(**kwargs) -> SymbolicVerifier:
     """Create a SymbolicVerifier instance."""
     return SymbolicVerifier(**kwargs)
+
 

--- a/tests/test_verifier_vc_mappings.py
+++ b/tests/test_verifier_vc_mappings.py
@@ -1,0 +1,118 @@
+"""Tests for to_verification_context on all verifiers."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+
+from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
+from qwed_new.core.verification_context import Verdict
+
+
+def _unverifiable_result():
+    return DiagnosticResult.unverifiable(
+        agent_message="Test unverifiable",
+        developer_fields={"test": True},
+    )
+
+
+def _blocked_result():
+    return DiagnosticResult.blocked(
+        agent_message="Test blocked",
+        developer_fields={"test": True},
+    )
+
+
+class TestCodeVerifierVC:
+    def test_to_verification_context_unverifiable(self):
+        from qwed_new.core.code_verifier import CodeVerifier
+        v = CodeVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE
+
+    def test_to_verification_context_blocked(self):
+        from qwed_new.core.code_verifier import CodeVerifier
+        v = CodeVerifier()
+        vc = v.to_verification_context(_blocked_result(), "test query")
+        assert vc.verdict == Verdict.BLOCKED
+
+
+class TestConsensusVerifierVC:
+    def test_to_verification_context(self):
+        from qwed_new.core.consensus_verifier import ConsensusVerifier
+        v = ConsensusVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE
+
+
+class TestFactVerifierVC:
+    def test_to_verification_context(self):
+        from qwed_new.core.fact_verifier import FactVerifier
+        v = FactVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE
+
+
+class TestGraphFactVerifierVC:
+    def test_to_verification_context(self):
+        from qwed_new.core.graph_fact_verifier import GraphFactVerifier
+        v = GraphFactVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE
+
+
+class TestImageVerifierVC:
+    def test_to_verification_context(self):
+        from qwed_new.core.image_verifier import ImageVerifier
+        v = ImageVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE
+
+
+class TestLogicVerifierVC:
+    def test_to_verification_context(self):
+        from qwed_new.core.logic_verifier import LogicVerifier
+        v = LogicVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE
+
+
+class TestReasoningVerifierVC:
+    def test_to_verification_context(self):
+        from qwed_new.core.reasoning_verifier import ReasoningVerifier
+        v = ReasoningVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE
+
+
+class TestSchemaVerifierVC:
+    def test_to_verification_context(self):
+        from qwed_new.core.schema_verifier import SchemaVerifier
+        v = SchemaVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE
+
+
+class TestSQLVerifierVC:
+    def test_to_verification_context(self):
+        from qwed_new.core.sql_verifier import SQLVerifier
+        v = SQLVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE
+
+
+class TestSymbolicVerifierVC:
+    def test_to_verification_context(self):
+        from qwed_new.core.symbolic_verifier import SymbolicVerifier
+        v = SymbolicVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE
+
+
+class TestDSLLogicVerifierVC:
+    def test_to_verification_context(self):
+        from qwed_new.core.dsl_logic_verifier import DSLLogicVerifier
+        v = DSLLogicVerifier()
+        vc = v.to_verification_context(_unverifiable_result(), "test query")
+        assert vc.verdict == Verdict.UNVERIFIABLE

--- a/tests/test_verifier_vc_mappings.py
+++ b/tests/test_verifier_vc_mappings.py
@@ -4,9 +4,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-import pytest
-
-from qwed_new.core.diagnostics import DiagnosticResult, DiagnosticStatus
+from qwed_new.core.diagnostics import DiagnosticResult
 from qwed_new.core.verification_context import Verdict
 
 


### PR DESCRIPTION
## **User description**
Completes the Verification Context v1.0 rollout across all verification engines.

Each verifier now maps its DiagnosticResult to a Verification Context v1.0 document via the existing verification_context_bridge.

## Verifiers updated

- ConsensusVerifier
- DSLLogicVerifier
- FactVerifier
- GraphFactVerifier
- ImageVerifier
- LogicVerifier
- ReasoningVerifier
- SchemaVerifier
- SQLVerifier
- SymbolicVerifier
- CodeVerifier

(StatsVerifier already had it from Phase 2)

## What each method does

```python
def to_verification_context(self, result, query):
    return verification_context_from_diagnostic_result(
        result,
        formal_statement=query,
        verifier=self.__class__.__name__,
    )
```

## Testing

1979 tests pass, 102 skipped.


___

## **CodeAnt-AI Description**
Add verification context output across verification engines

### What Changed
- Adds a standard way for verifier results to be represented as Verification Context v1.0 documents
- Covers consensus, fact, graph, image, logic, reasoning, schema, SQL, symbolic, code, and DSL verification engines
- Includes the verifier name and original query in each generated context

### Impact
`✅ Consistent verification context across engines`
`✅ Easier sharing of verification results`
`✅ Preserved verifier and query details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a standardized way to convert verification results and submitted queries into structured verification context documents.
  - Contexts include the original query, diagnostic details, proof-related information, verifier identity, and optional attestation information.
  - Support is now available consistently across supported verification methods, improving interoperability for downstream review and reporting.
  - Added representation for unverifiable and blocked verification outcomes.

- **Tests**
  - Added coverage for verification-context conversion across supported verification methods and outcome types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->