### PR TITLE
chore: prepare v7.1.0 release (Verification Context v1.0 rollout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the QWED Protocol will be documented in this file.
 
 ## [Unreleased]
 
+## [7.1.0] - 2026-08-16
+
+### Verification Context v1.0 Rollout
+
+#### Ontology & Spec (#301, #302)
+
+- **ADR-001..005 — verification ontology** — formally define the object of verification, the verification context document, the truth-vs-admission separation, the formalization boundary, and the root of trust.
+- **Verification Context v1.0 spec freeze** — the 4-layer JSON document contract (interpretation / proof / evidence / decision) with canonical RFC 8785 JSON encoding, UTF-16 key ordering, fail-closed schema validation, and content-bound `proof_ref`.
+
+#### Core Model (#308, #309)
+
+- **`VerificationContext` model + JSON schema** — `VerificationContext`, `VerificationContextDocument`, `Verdict`, `Admission`, and nested `Interpretation` / `Proof` / `Evidence` / `Decision` types with fail-closed validation.
+- **Public proof_ref generation / resolution** — `compute_document_proof_ref()` and `resolve_document_proof_ref()` exposed as public API; references are content-bound SHA-256 hashes over the canonical document.
+
+#### Bridge & Verifier Mappings (#310, #316)
+
+- **`verification_context_from_diagnostic_result()`** — converts `DiagnosticResult` → VC document; VERIFIED without attestation demotes to UNVERIFIABLE (fail-closed, consistent with the core contract).
+- **`to_verification_context()` on all 13 verifiers** — complete engine coverage with optional `attestation_token` support: Math, Logic, Symbolic, SQL, Code, Schema, Fact, Image, Graph, Reasoning, Stats, Consensus, and SecureCodeExecutor.
+
+#### Surface Exposure (#311, #313, #314, #315)
+
+- **SDK / API / CLI exposure** — Verification Context surfaced across the API routes, CLI, and SDK.
+- **Docker action VC outputs** — the containerized GitHub Action emits `verdict`, `admission`, `proof_ref`, and `verification_context` outputs.
+- **Metadata & README alignment** — repository metadata aligned with the v7.0 architecture.
+- **SDK re-exports** — all Verification Context v1.0 types re-exported from `qwed_sdk`.
+
+> **Semver:** minor release — additive public API (VC model, mappings, resolver, routes, outputs). No breaking wire changes.
+
 ## [7.0.0] - 2026-08-08
 
 ### Engine Migration to DiagnosticResult (Meta #216)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to the QWED Protocol will be documented in this file.
 #### Bridge & Verifier Mappings (#310, #316)
 
 - **`verification_context_from_diagnostic_result()`** — converts `DiagnosticResult` → VC document; VERIFIED without attestation demotes to UNVERIFIABLE (fail-closed, consistent with the core contract).
-- **`to_verification_context()` on all 13 verifiers** — complete engine coverage with optional `attestation_token` support: Math, Logic, Symbolic, SQL, Code, Schema, Fact, Image, Graph, Reasoning, Stats, Consensus, and SecureCodeExecutor.
+- **`to_verification_context()` on all 13 verifiers** — complete engine coverage: Math, Logic, Symbolic, SQL, Code, Schema, Fact, Image, Graph, Reasoning, Stats, Consensus, and SecureCodeExecutor.
 
 #### Surface Exposure (#311, #313, #314, #315)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ## Release Update: v7.1.0 — Verification Context v1.0 Rollout
 
-`v7.1.0` ships the **Verification Context (VC) v1.0** — the external, interoperable layer on top of `DiagnosticResult`. Every engine now emits a schema-validated, canonically-encoded, tamper-evident verification document describing *what* was verified, against *what* evidence, under *which* interpretation, with *what* admission decision.
+`v7.1.0` ships the **Verification Context (VC) v1.0** — the external, interoperable layer on top of `DiagnosticResult`. Verification methods continue to return `DiagnosticResult`; a schema-validated, canonically-encoded, tamper-evident verification document describing *what* was verified, against *what* evidence, under *which* interpretation, with *what* admission decision is produced on demand via the explicit `to_verification_context()` conversion.
 
 - **VC v1.0 spec + ontology (ADR-001..005, #301–#302)** — object of verification, verification context, truth-vs-admission separation, formalization boundary, and root of trust are formally defined
 - **`VerificationContext` model + JSON schema (#308)** — 4-layer document (interpretation / proof / evidence / decision) with RFC 8785 canonical JSON encoding, UTF-16 key ordering, and fail-closed schema validation
@@ -49,9 +49,9 @@
 - **SDK / API / CLI exposure (#311)** — VC surfaces across the API routes, CLI, and SDK
 - **Docker action VC outputs (#313)** — the containerized GitHub Action now emits `verdict`, `admission`, `proof_ref`, and `verification_context` outputs
 - **SDK re-exports (#315)** — all VC types re-exported from `qwed_sdk`
-- **`to_verification_context()` on all 13 verifiers (#316)** — full engine coverage with optional `attestation_token` support
+- **`to_verification_context()` on all 13 verifiers (#316)** — full engine coverage; conversion is explicit and returns a `VerificationContextDocument` from a `DiagnosticResult`
 
-> This is an **additive** minor release — no breaking wire changes. If you're upgrading from `v7.0.0`, the new VC surface is available but nothing you relied on changed behavior.
+> This is an **additive** minor release — no breaking wire changes; existing wire contracts remain unchanged. If you're upgrading from `v7.0.0`, the new VC surface is available but nothing you relied on changed behavior.
 
 If you're upgrading from `v6.0.x`, review the [changelog](CHANGELOG.md) for the full migration notes.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@
 
 ---
 
+## Release Update: v7.1.0 — Verification Context v1.0 Rollout
+
+`v7.1.0` ships the **Verification Context (VC) v1.0** — the external, interoperable layer on top of `DiagnosticResult`. Every engine now emits a schema-validated, canonically-encoded, tamper-evident verification document describing *what* was verified, against *what* evidence, under *which* interpretation, with *what* admission decision.
+
+- **VC v1.0 spec + ontology (ADR-001..005, #301–#302)** — object of verification, verification context, truth-vs-admission separation, formalization boundary, and root of trust are formally defined
+- **`VerificationContext` model + JSON schema (#308)** — 4-layer document (interpretation / proof / evidence / decision) with RFC 8785 canonical JSON encoding, UTF-16 key ordering, and fail-closed schema validation
+- **Public `proof_ref` generation / resolution (#309)** — content-bound SHA-256 reference generation and resolver exposed as public API
+- **Bridge: `verification_context_from_diagnostic_result()` (#310)** — converts `DiagnosticResult` → VC document; StatsVerifier is the first mapped verifier
+- **SDK / API / CLI exposure (#311)** — VC surfaces across the API routes, CLI, and SDK
+- **Docker action VC outputs (#313)** — the containerized GitHub Action now emits `verdict`, `admission`, `proof_ref`, and `verification_context` outputs
+- **SDK re-exports (#315)** — all VC types re-exported from `qwed_sdk`
+- **`to_verification_context()` on all 13 verifiers (#316)** — full engine coverage with optional `attestation_token` support
+
+> This is an **additive** minor release — no breaking wire changes. If you're upgrading from `v7.0.0`, the new VC surface is available but nothing you relied on changed behavior.
+
+If you're upgrading from `v6.0.x`, review the [changelog](CHANGELOG.md) for the full migration notes.
+
+---
+
 ## Release Update: v7.0.0 — Full DiagnosticResult Engine Conformance
 
 `v7.0.0` completes **Meta #216** — every verification engine now returns the unified `DiagnosticResult`, and execution is never conflated with verification.
@@ -648,6 +667,7 @@ We are building the **Universal Verification Standard** for the agentic web.
 - **✔ SymbolicVerifier migration** — First fully `DiagnosticResult`-conformant engine; serves as reference implementation (v5.3.0)
 - **✔ Trust Boundary Completion** — All verification API pathways return `DiagnosticResult` + route through `enforce_trust_decision`; mandatory attestation at the admission boundary; VERIFIED requires a non-empty, evidence-bound proof_ref (v6.0.0)
 - **✔ Full DiagnosticResult engine conformance** — All 13 engines return `DiagnosticResult`; execution is never conflated with verification; fail-closed batch verification (META #216, v7.0.0)
+- **✔ Verification Context v1.0 rollout** — All 13 engines expose `to_verification_context()`; schema-validated, canonically-encoded, tamper-evident VC documents across SDK / API / CLI / Docker action (v7.1.0)
 
 ### In Progress
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed"
-version = "7.0.0"
+version = "7.1.0"
 description = "Open-source AI verification infrastructure for deterministic verification of LLM outputs, tool calls, code, schemas, and agent state before production execution."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/qwed_sdk/__init__.py
+++ b/qwed_sdk/__init__.py
@@ -56,7 +56,7 @@ from qwed_new.core.verification_context import (
     is_valid_document,
 )
 
-__version__ = "7.0.0"
+__version__ = "7.1.0"
 __all__ = [
     "QWEDClient",
     "QWEDAsyncClient",

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qwed"
-version = "7.0.0"
+version = "7.1.0"
 edition = "2021"
 authors = ["QWED-AI"]
 description = "Rust SDK for QWED Verification Protocol"

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -11,7 +11,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qwed = "7.0.0"
+qwed = "7.1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "7.0.0",
+    "version": "7.1.0",
     "description": "TypeScript SDK for QWED Verification Protocol",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/src/qwed_new/__init__.py
+++ b/src/qwed_new/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2024 QWED Team
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "7.0.0"
+__version__ = "7.1.0"

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -39,7 +39,7 @@ TenantDependency = Annotated[TenantContext, Depends(get_current_tenant)]
 SessionDependency = Annotated[Session, Depends(get_session)]
 AgentTokenHeader = Annotated[str, Header(...)]
 
-APP_VERSION = "7.0.0"
+APP_VERSION = "7.1.0"
 
 app = FastAPI(
     title="QWED API",

--- a/tests/test_sdk_init.py
+++ b/tests/test_sdk_init.py
@@ -14,7 +14,7 @@ def test_sdk_init_module_executes():
         from qwed_sdk import __version__ as _  # noqa: F401
     from qwed_sdk import __all__ as sdk_all, __version__ as sdk_version
     assert sdk_all is not None
-    assert sdk_version == "7.0.0"
+    assert sdk_version == "7.1.0"
 
 
 def test_sdk_init_exports_verdict_enum():


### PR DESCRIPTION
## Summary

Bumps the repository to **v7.1.0** — the Verification Context v1.0 rollout release (minor, additive). The codebase has shipped the full VC v1.0 surface since `v7.0.0` (#301–#316) but the version on disk still declared `7.0.0`, misrepresenting what anyone installing from PyPI/npm/crates.io actually receives.

## What Changed

### Version bumps → `7.1.0`

- `pyproject.toml` (qwed)
- `src/qwed_new/__init__.py` (`__version__`)
- `qwed_sdk/__init__.py` (`__version__`)
- `sdk-ts/package.json`
- `sdk-rust/Cargo.toml`
- `src/qwed_new/api/main.py` (`APP_VERSION`)

### Changelog & docs

- `CHANGELOG.md` — new `[7.1.0]` entry covering the VC v1.0 rollout: ADR-001..005 + spec (#301, #302), model + schema (#308), proof_ref generation/resolution (#309), bridge + StatsVerifier mapping (#310), SDK/API/CLI exposure (#311), Docker action VC outputs (#313), metadata alignment (#314), SDK re-exports (#315), `to_verification_context()` on all 13 verifiers (#316)
- `README.md` — new "Release Update: v7.1.0" section + roadmap item
- `tests/test_sdk_init.py` — version assertion updated to `7.1.0`

## Why Minor (not Major)

All changes since `v7.0.0` are **additive** — new public API (VC model, mappings, resolver, routes, SDK exports, action outputs). No breaking wire changes.

## Not Included

- `deploy/kubernetes/deployment.yaml` — intentionally left pinned to a **published** image (`6.0.0`); bumping to `7.1.0` now would cause `ImagePullBackOff` until the release publishes the Docker tag
- `sdk-go` — versions via git tags; no file to bump
- `changelog.mdx` / `ROLLOUT_REPORT.md` — untracked website/rollout docs with mojibake encoding; left out of the release

## Testing

- Full suite: **1991 passed, 102 skipped** across Python 3.11

## Notes

- Cutting the v7.1.0 GitHub Release auto-publishes: PyPI (`qwed`), SDKs (npm, crates.io), and Docker (`qwedai/qwed-verification:7.1.0`/`7.1`).
- The GitHub Action image is versioned independently (`3.2.0`, published via manual dispatch) — not touched by this release unless you want to bump it.

Closes: part of the VC v1.0 rollout tracking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes and roadmap updates for Verification Context v1.0, covering the specification, validation, proof references, diagnostics, and SDK/API/CLI/Docker availability.
  * Documented verifier coverage and confirmed additive public APIs with no breaking wire changes.

* **Chores**
  * Updated the project, SDKs, and API version from 7.0.0 to 7.1.0.
  * Updated version checks and installation guidance for the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->