### PR TITLE
fix: resolve PyPI publish failure on Metadata-Version 2.5

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -35,7 +35,7 @@ jobs:
         run: python -m build
       
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
           # OIDC trusted publisher: no token/password field required.
           # Configure at https://pypi.org/manage/project/qwed/settings/publishing/
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
           path: dist/
       
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -79,4 +79,4 @@ jobs:
           path: dist/
       
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,3 +80,5 @@ jobs:
       
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ pii = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.27.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## **User description**
## Summary

The v7.1.0 PyPI publish for the `qwed` package failed during `gh-action-pypi-publish`'s `verify_metadata` step:

```
Checking dist/qwed-7.1.0-py3-none-any.whl: ERROR  InvalidDistribution:
Invalid distribution metadata: '2.5' is not a valid metadata version
```

**Not a token issue** — the failure occurred during metadata verification, before any upload attempt.

## Root Cause

Two things combined:

1. `hatchling` was unpinned in `pyproject.toml` (`requires = ["hatchling"]`), so the build floated to the latest (1.32.0), which now emits **Metadata-Version 2.5** in the wheel.
2. The publish action was pinned to `ed0c539` (Sep 2025), whose Docker image bundles `twine < 7` — which does **not** recognize Metadata-Version 2.5.

The SDK publish workflow used a newer pin (`cef2210`), which is why the Python SDK published but the main `qwed` publish failed.

## Changes

### Pin `hatchling` (`pyproject.toml`)
- `requires = ["hatchling==1.27.0"]`
- Verified: 1.27.0 emits **Metadata-Version 2.4** (broadly supported by all twine versions ≥ 6.1), so builds are reproducible and the metadata version can no longer float out from under the publish tooling.
- Verified locally: wheel builds with `Metadata-Version: 2.4` and `twine check` passes.

### Bump `pypa/gh-action-pypi-publish` to v1.14.2 (`dc37677`)
- `publish.yml` — both TestPyPI and PyPI publish steps
- `publish-sdks.yml` — Python SDK publish step
- v1.14.2's runtime requires `twine >= 7` explicitly "to support metadata v2.5 including PEP 794", so it is compatible with both 2.4 and 2.5 metadata going forward.

## Verification

- `python -m build` with pinned hatchling → `Metadata-Version: 2.4` ✓
- `twine check dist/*` → PASSED ✓
- `tests/test_sdk_init.py` → 12 passed ✓


___

## **CodeAnt-AI Description**
Stabilize Python package publishing and metadata compatibility

### What Changed
- Python packages are built with a fixed build tool version that produces widely supported package metadata
- TestPyPI, PyPI, and Python SDK publishing now use an updated publisher that accepts current metadata formats
- Releases can pass metadata verification instead of failing before upload

### Impact
`✅ Fewer PyPI release failures`
`✅ Reproducible package builds`
`✅ Successful publishing of Python SDK releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing tooling to a newer verified release.
  * Pinned the build system to a specific version for more consistent package creation and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->