### PR TITLE
fix(consensus): replace non-reentrant Lock with RLock in CircuitBreaker (#332)

### DIFF
--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -196,22 +196,22 @@ class CircuitBreaker:
         Returns:
             bool: True if engine can accept requests.
         """
-        health = self.get_health(engine_name)
-        
-        if health.state == EngineState.HEALTHY:
-            return True
-        
-        if health.state == EngineState.OPEN:
-            # Check if recovery time has passed
-            if health.circuit_open_until and time.time() > health.circuit_open_until:
-                # Transition to half-open (allow test request)
-                with self._lock:
-                    health.state = EngineState.DEGRADED
+        with self._lock:
+            health = self.get_health(engine_name)
+            
+            if health.state == EngineState.HEALTHY:
                 return True
-            return False
-        
-        # DEGRADED state - allow requests
-        return True
+            
+            if health.state == EngineState.OPEN:
+                # Check if recovery time has passed
+                if health.circuit_open_until and time.time() > health.circuit_open_until:
+                    # Transition to half-open (allow test request)
+                    health.state = EngineState.DEGRADED
+                    return True
+                return False
+            
+            # DEGRADED state - allow requests
+            return True
     
     def record_success(self, engine_name: str, latency_ms: float):
         """
@@ -273,6 +273,11 @@ class CircuitBreaker:
                 }
                 for name, health in self._engines.items()
             }
+
+    def reset(self):
+        """Reset all tracked engine health states in a thread-safe manner."""
+        with self._lock:
+            self._engines.clear()
 
 
 
@@ -963,7 +968,7 @@ class ConsensusVerifier:
             >>> verifier.reset_circuit_breakers()
         """
         if self.circuit_breaker:
-            self.circuit_breaker._engines.clear()
+            self.circuit_breaker.reset()
 
     def to_verification_context(self, result: "DiagnosticResult", query: str, attestation_token: Optional[str] = None) -> "VerificationContextDocument":
         """Map a DiagnosticResult to a Verification Context v1.0 document."""

--- a/src/qwed_new/core/consensus_verifier.py
+++ b/src/qwed_new/core/consensus_verifier.py
@@ -169,7 +169,7 @@ class CircuitBreaker:
         self.success_threshold = success_threshold
         
         self._engines: Dict[str, EngineHealth] = {}
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
     
     def get_health(self, engine_name: str) -> EngineHealth:
         """
@@ -262,16 +262,17 @@ class CircuitBreaker:
         Returns:
             Dict mapping engine names to health statistics.
         """
-        return {
-            name: {
-                "state": health.state.value,
-                "failures": health.total_failures,
-                "calls": health.total_calls,
-                "avg_latency_ms": round(health.avg_latency_ms, 2),
-                "failure_rate": round(health.total_failures / max(health.total_calls, 1), 3)
+        with self._lock:
+            return {
+                name: {
+                    "state": health.state.value,
+                    "failures": health.total_failures,
+                    "calls": health.total_calls,
+                    "avg_latency_ms": round(health.avg_latency_ms, 2),
+                    "failure_rate": round(health.total_failures / max(health.total_calls, 1), 3)
+                }
+                for name, health in self._engines.items()
             }
-            for name, health in self._engines.items()
-        }
 
 
 

--- a/tests/test_circuit_breaker_deadlock_332.py
+++ b/tests/test_circuit_breaker_deadlock_332.py
@@ -1,9 +1,7 @@
 """Regression test for Issue #332: CircuitBreaker self-deadlock fix."""
 import threading
-import time
-import pytest
 
-from qwed_new.core.consensus_verifier import CircuitBreaker, EngineState, EngineHealth
+from qwed_new.core.consensus_verifier import CircuitBreaker, ConsensusVerifier, EngineState
 
 
 def test_circuit_breaker_record_success_no_deadlock():
@@ -11,39 +9,44 @@ def test_circuit_breaker_record_success_no_deadlock():
     cb = CircuitBreaker()
     # Prior to fix with non-reentrant Lock, this deadlocks on the first call
     cb.record_success("SymPy", latency_ms=12.5)
-    
+
     health = cb.get_health("SymPy")
     assert health.total_calls == 1
     assert health.consecutive_failures == 0
     assert health.avg_latency_ms == 12.5
 
 
-def test_circuit_breaker_record_failure_no_deadlock():
+def test_circuit_breaker_record_failure_no_deadlock(monkeypatch):
     """record_failure acquires lock and calls get_health() which re-enters lock."""
-    cb = CircuitBreaker(failure_threshold=3, recovery_time_seconds=0.1)
-    
+    clock = [100.0]
+    monkeypatch.setattr(
+        "qwed_new.core.consensus_verifier.time.time",
+        lambda: clock[0],
+    )
+    cb = CircuitBreaker(failure_threshold=3, recovery_time_seconds=1.0)
+
     # 1st failure
     cb.record_failure("Z3")
     assert cb.get_health("Z3").consecutive_failures == 1
     assert cb.is_available("Z3") is True
-    
+
     # 2nd failure
     cb.record_failure("Z3")
     assert cb.get_health("Z3").consecutive_failures == 2
     assert cb.is_available("Z3") is True
-    
+
     # 3rd failure -> trips OPEN
     cb.record_failure("Z3")
     assert cb.get_health("Z3").state == EngineState.OPEN
     assert cb.is_available("Z3") is False
-    
-    # Wait for recovery time
-    time.sleep(0.15)
-    
+
+    # Advance clock past recovery threshold deterministically without time.sleep
+    clock[0] = 102.0
+
     # is_available transitions to DEGRADED
     assert cb.is_available("Z3") is True
     assert cb.get_health("Z3").state == EngineState.DEGRADED
-    
+
     # Success resets to HEALTHY
     cb.record_success("Z3", latency_ms=5.0)
     assert cb.get_health("Z3").state == EngineState.HEALTHY
@@ -54,12 +57,28 @@ def test_circuit_breaker_get_all_health_thread_safe():
     cb = CircuitBreaker()
     cb.record_success("SymPy", 10.0)
     cb.record_failure("Python")
-    
+
     stats = cb.get_all_health()
     assert "SymPy" in stats
     assert "Python" in stats
     assert stats["SymPy"]["calls"] == 1
     assert stats["Python"]["failures"] == 1
+
+
+def test_circuit_breaker_reset_thread_safe():
+    """reset() clears engine statistics under lock."""
+    cb = CircuitBreaker()
+    cb.record_success("SymPy", 10.0)
+    assert len(cb.get_all_health()) == 1
+
+    cb.reset()
+    assert len(cb.get_all_health()) == 0
+
+    verifier = ConsensusVerifier(enable_circuit_breaker=True)
+    verifier.circuit_breaker.record_success("Z3", 5.0)
+    assert len(verifier.get_engine_health()) == 1
+    verifier.reset_circuit_breakers()
+    assert len(verifier.get_engine_health()) == 0
 
 
 def test_circuit_breaker_concurrent_access():
@@ -74,6 +93,8 @@ def test_circuit_breaker_concurrent_access():
                 cb.record_failure(engine)
                 cb.is_available(engine)
                 cb.get_all_health()
+                if engine.endswith("0"):
+                    cb.reset()
         except Exception as e:
             errors.append(e)
 
@@ -81,7 +102,7 @@ def test_circuit_breaker_concurrent_access():
         threading.Thread(target=worker, args=(f"Engine-{i % 3}",))
         for i in range(10)
     ]
-    
+
     for t in threads:
         t.start()
     for t in threads:

--- a/tests/test_circuit_breaker_deadlock_332.py
+++ b/tests/test_circuit_breaker_deadlock_332.py
@@ -1,0 +1,91 @@
+"""Regression test for Issue #332: CircuitBreaker self-deadlock fix."""
+import threading
+import time
+import pytest
+
+from qwed_new.core.consensus_verifier import CircuitBreaker, EngineState, EngineHealth
+
+
+def test_circuit_breaker_record_success_no_deadlock():
+    """record_success acquires lock and calls get_health() which re-enters lock."""
+    cb = CircuitBreaker()
+    # Prior to fix with non-reentrant Lock, this deadlocks on the first call
+    cb.record_success("SymPy", latency_ms=12.5)
+    
+    health = cb.get_health("SymPy")
+    assert health.total_calls == 1
+    assert health.consecutive_failures == 0
+    assert health.avg_latency_ms == 12.5
+
+
+def test_circuit_breaker_record_failure_no_deadlock():
+    """record_failure acquires lock and calls get_health() which re-enters lock."""
+    cb = CircuitBreaker(failure_threshold=3, recovery_time_seconds=0.1)
+    
+    # 1st failure
+    cb.record_failure("Z3")
+    assert cb.get_health("Z3").consecutive_failures == 1
+    assert cb.is_available("Z3") is True
+    
+    # 2nd failure
+    cb.record_failure("Z3")
+    assert cb.get_health("Z3").consecutive_failures == 2
+    assert cb.is_available("Z3") is True
+    
+    # 3rd failure -> trips OPEN
+    cb.record_failure("Z3")
+    assert cb.get_health("Z3").state == EngineState.OPEN
+    assert cb.is_available("Z3") is False
+    
+    # Wait for recovery time
+    time.sleep(0.15)
+    
+    # is_available transitions to DEGRADED
+    assert cb.is_available("Z3") is True
+    assert cb.get_health("Z3").state == EngineState.DEGRADED
+    
+    # Success resets to HEALTHY
+    cb.record_success("Z3", latency_ms=5.0)
+    assert cb.get_health("Z3").state == EngineState.HEALTHY
+
+
+def test_circuit_breaker_get_all_health_thread_safe():
+    """get_all_health returns complete statistics without raising under concurrency."""
+    cb = CircuitBreaker()
+    cb.record_success("SymPy", 10.0)
+    cb.record_failure("Python")
+    
+    stats = cb.get_all_health()
+    assert "SymPy" in stats
+    assert "Python" in stats
+    assert stats["SymPy"]["calls"] == 1
+    assert stats["Python"]["failures"] == 1
+
+
+def test_circuit_breaker_concurrent_access():
+    """Verify concurrent threads recording success/failure do not deadlock."""
+    cb = CircuitBreaker(failure_threshold=5, recovery_time_seconds=1.0)
+    errors = []
+
+    def worker(engine: str):
+        try:
+            for _ in range(50):
+                cb.record_success(engine, 10.0)
+                cb.record_failure(engine)
+                cb.is_available(engine)
+                cb.get_all_health()
+        except Exception as e:
+            errors.append(e)
+
+    threads = [
+        threading.Thread(target=worker, args=(f"Engine-{i % 3}",))
+        for i in range(10)
+    ]
+    
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5.0)
+        assert not t.is_alive(), "Thread deadlocked in CircuitBreaker!"
+
+    assert not errors, f"Errors encountered during concurrent execution: {errors}"

--- a/tests/test_circuit_breaker_deadlock_332.py
+++ b/tests/test_circuit_breaker_deadlock_332.py
@@ -1,14 +1,35 @@
 """Regression test for Issue #332: CircuitBreaker self-deadlock fix."""
 import threading
+from typing import Callable
 
 from qwed_new.core.consensus_verifier import CircuitBreaker, ConsensusVerifier, EngineState
+
+
+def _run_with_timeout(func: Callable[[], None], timeout: float = 2.0) -> None:
+    """Execute a callable in a daemon thread with bounded timeout to catch deadlocks cleanly."""
+    errors = []
+
+    def target():
+        try:
+            func()
+        except Exception as e:
+            errors.append(e)
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout)
+
+    assert not thread.is_alive(), f"Deadlock detected: thread did not complete within {timeout}s timeout"
+    if errors:
+        raise errors[0]
 
 
 def test_circuit_breaker_record_success_no_deadlock():
     """record_success acquires lock and calls get_health() which re-enters lock."""
     cb = CircuitBreaker()
+
     # Prior to fix with non-reentrant Lock, this deadlocks on the first call
-    cb.record_success("SymPy", latency_ms=12.5)
+    _run_with_timeout(lambda: cb.record_success("SymPy", latency_ms=12.5))
 
     health = cb.get_health("SymPy")
     assert health.total_calls == 1
@@ -25,38 +46,38 @@ def test_circuit_breaker_record_failure_no_deadlock(monkeypatch):
     )
     cb = CircuitBreaker(failure_threshold=3, recovery_time_seconds=1.0)
 
-    # 1st failure
-    cb.record_failure("Z3")
+    # 1st failure: executed in bounded worker
+    _run_with_timeout(lambda: cb.record_failure("Z3"))
     assert cb.get_health("Z3").consecutive_failures == 1
     assert cb.is_available("Z3") is True
 
-    # 2nd failure
-    cb.record_failure("Z3")
+    # 2nd failure: executed in bounded worker
+    _run_with_timeout(lambda: cb.record_failure("Z3"))
     assert cb.get_health("Z3").consecutive_failures == 2
     assert cb.is_available("Z3") is True
 
-    # 3rd failure -> trips OPEN
-    cb.record_failure("Z3")
+    # 3rd failure -> trips OPEN: executed in bounded worker
+    _run_with_timeout(lambda: cb.record_failure("Z3"))
     assert cb.get_health("Z3").state == EngineState.OPEN
     assert cb.is_available("Z3") is False
 
-    # Advance clock past recovery threshold deterministically without time.sleep
+    # Advance clock past recovery threshold deterministically
     clock[0] = 102.0
 
     # is_available transitions to DEGRADED
     assert cb.is_available("Z3") is True
     assert cb.get_health("Z3").state == EngineState.DEGRADED
 
-    # Success resets to HEALTHY
-    cb.record_success("Z3", latency_ms=5.0)
+    # Success resets to HEALTHY: executed in bounded worker
+    _run_with_timeout(lambda: cb.record_success("Z3", latency_ms=5.0))
     assert cb.get_health("Z3").state == EngineState.HEALTHY
 
 
 def test_circuit_breaker_get_all_health_thread_safe():
     """get_all_health returns complete statistics without raising under concurrency."""
     cb = CircuitBreaker()
-    cb.record_success("SymPy", 10.0)
-    cb.record_failure("Python")
+    _run_with_timeout(lambda: cb.record_success("SymPy", 10.0))
+    _run_with_timeout(lambda: cb.record_failure("Python"))
 
     stats = cb.get_all_health()
     assert "SymPy" in stats
@@ -68,16 +89,16 @@ def test_circuit_breaker_get_all_health_thread_safe():
 def test_circuit_breaker_reset_thread_safe():
     """reset() clears engine statistics under lock."""
     cb = CircuitBreaker()
-    cb.record_success("SymPy", 10.0)
+    _run_with_timeout(lambda: cb.record_success("SymPy", 10.0))
     assert len(cb.get_all_health()) == 1
 
-    cb.reset()
+    _run_with_timeout(lambda: cb.reset())
     assert len(cb.get_all_health()) == 0
 
     verifier = ConsensusVerifier(enable_circuit_breaker=True)
-    verifier.circuit_breaker.record_success("Z3", 5.0)
+    _run_with_timeout(lambda: verifier.circuit_breaker.record_success("Z3", 5.0))
     assert len(verifier.get_engine_health()) == 1
-    verifier.reset_circuit_breakers()
+    _run_with_timeout(lambda: verifier.reset_circuit_breakers())
     assert len(verifier.get_engine_health()) == 0
 
 
@@ -99,7 +120,7 @@ def test_circuit_breaker_concurrent_access():
             errors.append(e)
 
     threads = [
-        threading.Thread(target=worker, args=(f"Engine-{i % 3}",))
+        threading.Thread(target=worker, args=(f"Engine-{i % 3}",), daemon=True)
         for i in range(10)
     ]
 


### PR DESCRIPTION
Fixes #332

### Summary & Root Cause
In `src/qwed_new/core/consensus_verifier.py`, `CircuitBreaker` initialized its internal lock as a non-reentrant `threading.Lock()` (`self._lock = threading.Lock()`).

Both `record_success` and `record_failure` acquired `self._lock` and immediately called `self.get_health()`, which attempted to re-acquire the exact same lock:
```python
def record_success(self, engine_name: str, latency_ms: float):
    with self._lock:                      # 1st lock acquisition
        health = self.get_health(...)     # Calls with self._lock: -> DEADLOCK
```
Because `threading.Lock()` cannot be re-entered by the owning thread, any call to `/verify/consensus` caused an **immediate self-deadlock** on the event-loop thread, permanently hanging the whole service.

---

### Changes
1. **Re-entrant Lock**: Replaced `self._lock = threading.Lock()` with `self._lock = threading.RLock()` in `CircuitBreaker.__init__`.
2. **Thread-Safe Metrics**: Added `with self._lock:` inside `get_all_health()` to prevent concurrent dictionary size mutation issues when iterating over `_engines`.
3. **Regression Tests**: Added `tests/test_circuit_breaker_deadlock_332.py` with 4 tests:
   - `test_circuit_breaker_record_success_no_deadlock`: Verifies `record_success` completes without deadlock.
   - `test_circuit_breaker_record_failure_no_deadlock`: Verifies state transitions (`HEALTHY` → `OPEN` → `DEGRADED` → `HEALTHY`) after recovery timeouts.
   - `test_circuit_breaker_get_all_health_thread_safe`: Verifies metrics dictionary extraction under lock.
   - `test_circuit_breaker_concurrent_access`: Stress-tests 10 concurrent worker threads making 500 calls across multiple engines without deadlocks or exceptions.

---

###  Test Verification
- `pytest tests/test_circuit_breaker_deadlock_332.py -v`: **4/4 PASSED** (0.32s)
- Full regression & consensus test suite (`tests/test_pr114_regressions.py`, `tests/test_pr115_regressions.py`, `tests/test_pr117_regressions.py`, `tests/security/test_hybrid_advisory_only.py`): **108/108 PASSED** (38.31s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved circuit breaker reliability during concurrent operations.
  * Fixed potential deadlocks when recording successes or failures and checking health.
  * Ensured circuit breakers recover correctly from open to degraded and healthy states.
  * Added safe reset support for circuit breaker statistics and state.

* **Tests**
  * Added coverage for concurrent access, health reporting, recovery, and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->