### PR TITLE
fix(math): structurally harden safe_parse_expr against RCE (NFKC + charset gate + AST allowlist)

### DIFF
--- a/src/qwed_new/core/safe_parser.py
+++ b/src/qwed_new/core/safe_parser.py
@@ -43,6 +43,7 @@ from sympy import (
     E, I, Integer, Float, Rational, Symbol, oo, pi,
 )
 from sympy.parsing.sympy_parser import (
+    convert_xor,
     parse_expr,
     standard_transformations,
     implicit_multiplication_application,
@@ -104,7 +105,9 @@ _ALLOWED_AST_NODES = frozenset(
         ast.Pow,
         ast.USub,
         ast.UAdd,
-        # ``^`` is converted to ``**`` by sympy's convert_xor before eval.
+        # ``^`` is converted to ``**`` by sympy's convert_xor, which the
+        # default pipeline below includes — caret exponentiation parses
+        # instead of failing with a TypeError at eval time.
         ast.BitXor,
     }
 )
@@ -289,6 +292,7 @@ def safe_parse_expr(
     local_dict = _build_safe_local_dict(extra_symbols)
     if transformations is None:
         transformations = standard_transformations + (
+            convert_xor,
             implicit_multiplication_application,
         )
     global_dict = dict(_SAFE_GLOBAL_DICT_TEMPLATE)

--- a/src/qwed_new/core/safe_parser.py
+++ b/src/qwed_new/core/safe_parser.py
@@ -6,17 +6,36 @@ a denylist for dangerous constructs, and a restricted evaluation
 namespace.  This module is the ONLY approved entry point for parsing
 user-supplied math expressions in production code.
 
-Security boundary:
-    1. Reject known-dangerous Python/OS constructs (denylist).
-    2. Remove __builtins__ from the eval global dict.
-    3. Allow-list only expected math symbols, constants, and functions.
-    4. Enforce basic input validation (type, length, empty check).
+Security boundary (structural, in order):
+    1. NFKC-normalize the input so the filters see exactly what the
+       compiler will see (PEP 3131 normalizes identifiers at compile
+       time; without this, compatibility-equivalent codepoints bypass
+       every string filter — see issue #330).
+    2. Charset allowlist: only arithmetic operators, decimal digits,
+       names, and whitespace. A '.' is only legal as a decimal point
+       between two digits, so attribute access is structurally
+       impossible in input that does not parse as Python (implicit
+       multiplication path, where no AST check can run).
+    3. Denylist for known-dangerous constructs (defense in depth).
+    4. AST node-type allowlist: input that parses as Python may only
+       contain arithmetic expression nodes — Attribute, Subscript,
+       string constants, lambdas, comprehensions, comparisons, etc.
+       are rejected before parse_expr's eval can run (see issue #329).
+    5. __builtins__ removed from the eval global dict; allowlisted
+       math symbols, constants, and functions only.
+    6. Enforce basic input validation (type, length, empty check).
 
-CWE-95 mitigation -- see PR #200 for full security analysis.
+The denylist alone can never defend an eval sink — layers 2 and 4 are
+the structural guarantee; layer 3 catches residual non-expression
+names early with a clearer error.
+
+CWE-95 mitigation -- see PR #200 for the original security analysis
+and issues #329/#330 for the bypasses this structure closes.
 """
 
 import ast
 import re
+import unicodedata
 from typing import Any, Dict, Optional, Tuple
 
 import sympy
@@ -50,14 +69,54 @@ _DENYLIST_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Charset allowlist applied after NFKC normalization. Quotes, brackets,
+# braces, semicolons, backslashes, comparison/boolean operators and '='
+# cannot appear at all: without them, string concatenation, subscripts,
+# and statement injection are structurally impossible.
+_CHARSET_PATTERN = re.compile(r"^[A-Za-z0-9_+\-*/().,^%\s]+$", re.ASCII)
+
+# A '.' is only legal as a decimal point with a digit on BOTH sides.
+# This rejects every attribute access (``x.__class__``, ``2 .real``)
+# and bare decimal forms like ``.5`` (write ``0.5`` instead).
+_BAD_DECIMAL_DOT = re.compile(r"(?<![0-9])\.|\.(?![0-9])")
+
+# AST node-type allowlist for input that parses as Python. Implicit
+# multiplication expressions (``2x``, ``sin x``) fail ast.parse and are
+# covered by the charset gate instead.
+_ALLOWED_AST_NODES = frozenset(
+    {
+        ast.Expression,
+        ast.BinOp,
+        ast.UnaryOp,
+        ast.Call,
+        ast.Name,
+        ast.Load,
+        ast.Constant,
+        ast.keyword,
+        ast.Add,
+        ast.Sub,
+        ast.Mult,
+        ast.Div,
+        ast.FloorDiv,
+        ast.Mod,
+        ast.Pow,
+        ast.USub,
+        ast.UAdd,
+        # ``^`` is converted to ``**`` by sympy's convert_xor before eval.
+        ast.BitXor,
+    }
+)
+
 _SAFE_GLOBAL_DICT_TEMPLATE: Dict[str, Any] = {"__builtins__": {}}
 
 
-def _check_ast_depth(expression: str) -> None:
-    """Reject Python-parseable expressions exceeding max AST depth (DoS defence).
+def _check_ast_safety(expression: str) -> None:
+    """Reject Python-parseable expressions that use non-arithmetic syntax
+    or exceed max AST depth (issues #329/#330).
 
-    Expressions using implicit multiplication (e.g. 2x, sin x) fail ast.parse
-    and skip this check — they are caught by the post-parse sympy depth check.
+    Expressions using implicit multiplication (e.g. 2x, sin x) fail
+    ast.parse and skip this check — they are caught by the charset gate
+    and the post-parse sympy depth check.
     """
     try:
         tree = ast.parse(expression, mode="eval")
@@ -68,6 +127,19 @@ def _check_ast_depth(expression: str) -> None:
         raise SafeParserError(
             f"Expression AST depth {depth} exceeds limit of {_AST_MAX_DEPTH}"
         )
+    for node in ast.walk(tree):
+        if type(node) not in _ALLOWED_AST_NODES:
+            raise SafeParserError(
+                f"Expression contains disallowed syntax: {type(node).__name__}. "
+                "Only arithmetic expressions are supported."
+            )
+        if isinstance(node, ast.Constant):
+            value = node.value
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise SafeParserError(
+                    f"Expression contains disallowed constant of type "
+                    f"{type(value).__name__}; only numeric literals are supported."
+                )
 
 
 def _ast_node_depth(node: ast.AST, current: int = 0) -> int:
@@ -142,8 +214,8 @@ def _build_safe_local_dict(
         "Integer": Integer, "Float": Float, "Rational": Rational,
         # Symbol is required because SymPy standard_transformations may emit
         # Symbol('name') during evaluation. This allows users to create symbols
-        # with arbitrary names — the denylist and stripped builtins mitigate
-        # downstream attribute-access risks on resulting objects.
+        # with arbitrary names — the charset/AST gates and stripped builtins
+        # mitigate downstream attribute-access risks on resulting objects.
         "Symbol": Symbol,
     }
     if extra_symbols:
@@ -151,6 +223,13 @@ def _build_safe_local_dict(
             if not isinstance(key, str):
                 raise SafeParserError(
                     f"extra_symbols keys must be strings, got {type(key).__name__}"
+                )
+            # Raw-key ASCII identifier check: no normalization, so a
+            # fullwidth key can never NFKC-alias a built-in name at compile
+            # time (PEP 3131).
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+                raise SafeParserError(
+                    f"extra_symbols key {key!r} is not a plain ASCII identifier"
                 )
             if _DENYLIST_PATTERN.search(key):
                 raise SafeParserError(
@@ -179,19 +258,32 @@ def safe_parse_expr(
         raise SafeParserError(
             f"Expression must be a string, got {type(expression).__name__}"
         )
-    stripped = expression.strip()
+    # NFKC before every filter: PEP 3131 normalizes identifiers at compile
+    # time, so the filters must operate on what the compiler will see
+    # (issue #330 — fullwidth/bold codepoints bypassed the ASCII denylist).
+    stripped = unicodedata.normalize("NFKC", expression.strip())
     if not stripped:
         raise SafeParserError("Expression is empty")
     if len(stripped) > MAX_EXPRESSION_LENGTH:
         raise SafeParserError(
             f"Expression exceeds maximum length of {MAX_EXPRESSION_LENGTH} characters"
         )
+    if not _CHARSET_PATTERN.match(stripped):
+        raise SafeParserError(
+            "Expression contains disallowed characters. Only arithmetic "
+            "operators, decimal numbers, identifiers, and whitespace are supported."
+        )
+    if _BAD_DECIMAL_DOT.search(stripped):
+        raise SafeParserError(
+            "Expression contains disallowed use of '.': it may only appear "
+            "as a decimal point between digits (attribute access is not supported)."
+        )
     match = _DENYLIST_PATTERN.search(stripped)
     if match:
         raise SafeParserError(
             f"Expression contains disallowed construct: {match.group()!r}"
         )
-    _check_ast_depth(stripped)
+    _check_ast_safety(stripped)
     local_dict = _build_safe_local_dict(extra_symbols)
     if transformations is None:
         transformations = standard_transformations + (
@@ -218,7 +310,7 @@ def validate_variable_name(variable: str) -> str:
         raise SafeParserError(
             f"Variable name must be a string, got {type(variable).__name__}"
         )
-    stripped = variable.strip()
+    stripped = unicodedata.normalize("NFKC", variable.strip())
     if not stripped:
         raise SafeParserError("Variable name is empty")
     if len(stripped) > 50:

--- a/src/qwed_new/core/safe_parser.py
+++ b/src/qwed_new/core/safe_parser.py
@@ -78,7 +78,9 @@ _CHARSET_PATTERN = re.compile(r"^[A-Za-z0-9_+\-*/().,^%\s]+$", re.ASCII)
 # A '.' is only legal as a decimal point with a digit on BOTH sides.
 # This rejects every attribute access (``x.__class__``, ``2 .real``)
 # and bare decimal forms like ``.5`` (write ``0.5`` instead).
-_BAD_DECIMAL_DOT = re.compile(r"(?<![0-9])\.|\.(?![0-9])")
+# re.ASCII pins \d to [0-9] so NFKC-surviving unicode digits cannot
+# satisfy the lookarounds.
+_BAD_DECIMAL_DOT = re.compile(r"(?<!\d)\.|\.(?!\d)", re.ASCII)
 
 # AST node-type allowlist for input that parses as Python. Implicit
 # multiplication expressions (``2x``, ``sin x``) fail ast.parse and are
@@ -226,8 +228,8 @@ def _build_safe_local_dict(
                 )
             # Raw-key ASCII identifier check: no normalization, so a
             # fullwidth key can never NFKC-alias a built-in name at compile
-            # time (PEP 3131).
-            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+            # time (PEP 3131). re.ASCII pins \w to [A-Za-z0-9_].
+            if not re.match(r"^[A-Za-z_]\w*$", key, re.ASCII):
                 raise SafeParserError(
                     f"extra_symbols key {key!r} is not a plain ASCII identifier"
                 )

--- a/tests/security/test_safe_parser.py
+++ b/tests/security/test_safe_parser.py
@@ -216,9 +216,11 @@ class TestASTAllowlist:
 
     @pytest.mark.parametrize("payload", [
         # Original #329 PoC (139 chars, denylist-clean).
-        "x.equals.__func__.__getattribute__('__gl'+'obals__')"
-        "['__buil'+'tins__']['__im'+'port__']('su'+'bprocess')"
-        ".run(['to'+'uch','/tmp/qwed_pwn'])",
+        (
+            "x.equals.__func__.__getattribute__('__gl'+'obals__')"
+            + "['__buil'+'tins__']['__im'+'port__']('su'+'bprocess')"
+            + ".run(['to'+'uch','/tmp/qwed_pwn'])"
+        ),
         # Unlisted dunders the old denylist never matched.
         "x.__class__",
         "x.__getattribute__('foo')",
@@ -268,8 +270,10 @@ class TestNFKCNormalization:
     @pytest.mark.parametrize("payload", [
         # Bold mathematical alphanumeric codepoints (U+1D4xx).
         "E.__\U0001D4D0\U0001D4D1\U0001D4D2\U0001D4D3\U0001D4D4__",
-        "x.__\U0001D4D0\U0001D4D1\U0001D4D2\U0001D4D3\U0001D4D4\U0001D4D5"
-        "\U0001D4D6\U0001D4D7\U0001D4D8\U0001D4D9\U0001D4DB\U0001D4D4__",
+        (
+            "x.__\U0001D4D0\U0001D4D1\U0001D4D2\U0001D4D3\U0001D4D4\U0001D4D5"
+            + "\U0001D4D6\U0001D4D7\U0001D4D8\U0001D4D9\U0001D4DB\U0001D4D4__"
+        ),
         # Fullwidth forms.
         "\uFF4F\uFF53.\uFF53\uFF59\uFF53\uFF54\uFF45\uFF4D('id')",
         "\uFF45\uFF56\uFF41\uFF4C('1')",
@@ -338,11 +342,13 @@ class TestExtraSymbolsHardening:
 
     def test_extra_symbol_key_rejects_non_identifier(self):
         from sympy import Symbol
+        bad_key = {"a b": Symbol("a")}
         with pytest.raises(SafeParserError, match="plain ASCII identifier"):
-            safe_parse_expr("x + 1", extra_symbols={"a b": Symbol("a")})
+            safe_parse_expr("x + 1", extra_symbols=bad_key)
 
     def test_extra_symbol_key_rejects_unicode_alias(self):
         from sympy import Symbol
         # Fullwidth 'x' would NFKC-alias the built-in 'x' at compile time.
+        unicode_key = {"\uFF58": Symbol("x")}
         with pytest.raises(SafeParserError, match="plain ASCII identifier"):
-            safe_parse_expr("x + 1", extra_symbols={"\uFF58": Symbol("x")})
+            safe_parse_expr("x + 1", extra_symbols=unicode_key)

--- a/tests/security/test_safe_parser.py
+++ b/tests/security/test_safe_parser.py
@@ -38,7 +38,9 @@ class TestDenylist:
         'vars()',
     ])
     def test_injection_blocked(self, payload):
-        with pytest.raises(SafeParserError, match="disallowed construct"):
+        # Payloads carrying quotes/brackets/dots are caught by the charset
+        # gate before the denylist runs; both raise a "disallowed..." error.
+        with pytest.raises(SafeParserError, match="disallowed"):
             safe_parse_expr(payload)
 
 
@@ -205,3 +207,142 @@ class TestExtraSymbols:
     def test_extra_symbol_rejects_non_sympy(self):
         with pytest.raises(SafeParserError, match="must be a SymPy"):
             safe_parse_expr("x + 1", extra_symbols={"bad": lambda: None})
+
+
+class TestASTAllowlist:
+    """Issue #329 — denylist bypass via unlisted dunders + string-literal
+    splitting. The structural fix is an AST node-type allowlist: input that
+    parses as Python may only contain arithmetic expression nodes."""
+
+    @pytest.mark.parametrize("payload", [
+        # Original #329 PoC (139 chars, denylist-clean).
+        "x.equals.__func__.__getattribute__('__gl'+'obals__')"
+        "['__buil'+'tins__']['__im'+'port__']('su'+'bprocess')"
+        ".run(['to'+'uch','/tmp/qwed_pwn'])",
+        # Unlisted dunders the old denylist never matched.
+        "x.__class__",
+        "x.__getattribute__('foo')",
+        "x.__func__",
+        "x.__self__",
+        "x.__dict__",
+        "x.__base__",
+        "x.__init__",
+        # String-literal splitting of denylisted names.
+        "'__gl'+'obals__'",
+        '"__im" + "port__"',
+        # Stealth wrapper from the PoC.
+        "[__import__('os'), x][1]",
+        # Other non-arithmetic syntax the allowlist rejects.
+        "lambda: 1",
+        "x if x else 1",
+        "[1, 2, 3]",
+        "{1: 2}",
+        "(1, 2)",
+        "x < y",
+        "x == y",
+        "not x",
+        "x and y",
+        "f'{x}'",
+        "x[0]",
+        "x.real",
+        "Symbol('x').real",
+        "2 .__class__",
+    ])
+    def test_non_arithmetic_syntax_blocked(self, payload):
+        with pytest.raises(SafeParserError):
+            safe_parse_expr(payload)
+
+    def test_string_constants_rejected_but_numbers_ok(self):
+        with pytest.raises(SafeParserError, match="disallowed"):
+            safe_parse_expr("'a'")
+        with pytest.raises(SafeParserError, match="disallowed"):
+            safe_parse_expr("True")
+        assert safe_parse_expr("1 + 2.5") is not None
+
+
+class TestNFKCNormalization:
+    """Issue #330 — PEP 3131 normalizes identifiers at compile time, so
+    NFKC-equivalent codepoints bypassed the ASCII denylist. The parser now
+    normalizes before every filter and restricts the charset to ASCII."""
+
+    @pytest.mark.parametrize("payload", [
+        # Bold mathematical alphanumeric codepoints (U+1D4xx).
+        "E.__\U0001D4D0\U0001D4D1\U0001D4D2\U0001D4D3\U0001D4D4__",
+        "x.__\U0001D4D0\U0001D4D1\U0001D4D2\U0001D4D3\U0001D4D4\U0001D4D5"
+        "\U0001D4D6\U0001D4D7\U0001D4D8\U0001D4D9\U0001D4DB\U0001D4D4__",
+        # Fullwidth forms.
+        "\uFF4F\uFF53.\uFF53\uFF59\uFF53\uFF54\uFF45\uFF4D('id')",
+        "\uFF45\uFF56\uFF41\uFF4C('1')",
+        # Greek capital alpha NFKC-normalizes to an identifier start.
+        "\u0391.__class__",
+        # Residual non-ASCII after normalization is rejected outright.
+        "\u03C0 + 1",
+    ])
+    def test_nfkc_bypass_blocked(self, payload):
+        with pytest.raises(SafeParserError, match="disallowed"):
+            safe_parse_expr(payload)
+
+    def test_ascii_names_unchanged_after_normalization(self):
+        assert str(safe_parse_expr("alpha + 1")) == "alpha + 1"
+
+
+class TestStrictDecimalDot:
+    """A '.' is only legal as a decimal point with a digit on both sides,
+    which makes attribute access structurally impossible in input that
+    does not parse as Python (implicit multiplication path)."""
+
+    @pytest.mark.parametrize("expr", [
+        "x.__class__",
+        "x.y",
+        "2.x",
+        ".5",
+        "5.",
+    ])
+    def test_non_decimal_dot_rejected(self, expr):
+        with pytest.raises(SafeParserError, match="decimal point"):
+            safe_parse_expr(expr)
+
+    @pytest.mark.parametrize("expr", ["3.14", "3.14 * 2", "0.5 + 1"])
+    def test_decimal_still_works(self, expr):
+        assert safe_parse_expr(expr) is not None
+
+
+class TestCharsetGate:
+    """Quotes, brackets, braces, and statement separators cannot appear at
+    all, covering the implicit-multiplication path where no AST runs."""
+
+    @pytest.mark.parametrize("payload", [
+        "'a'",
+        '"a"',
+        "x[0]",
+        "{1: 2}",
+        "x; y",
+        "import os",
+        "x = 1",
+        "x@y",
+        "x`y`",
+        "x\\y",
+    ])
+    def test_disallowed_characters_rejected(self, payload):
+        # Some payloads are caught by the denylist instead (e.g. bare
+        # keywords like `import os` are charset-valid); both raise
+        # a "disallowed..." error.
+        with pytest.raises(SafeParserError, match="disallowed"):
+            safe_parse_expr(payload)
+
+    def test_implicit_multiplication_still_works(self):
+        assert str(safe_parse_expr("2x + 3x")) == "5*x"
+
+
+class TestExtraSymbolsHardening:
+
+    def test_extra_symbol_key_rejects_non_identifier(self):
+        from sympy import Symbol
+        with pytest.raises(SafeParserError, match="plain ASCII identifier"):
+            safe_parse_expr("x + 1", extra_symbols={"a b": Symbol("a")})
+
+    def test_extra_symbol_key_rejects_unicode_alias(self):
+        from sympy import Symbol
+        # Fullwidth 'x' would NFKC-alias the built-in 'x' at compile time.
+        with pytest.raises(SafeParserError, match="plain ASCII identifier"):
+            safe_parse_expr("x + 1", extra_symbols={"\uFF58": Symbol("x")})

--- a/tests/security/test_safe_parser.py
+++ b/tests/security/test_safe_parser.py
@@ -61,6 +61,8 @@ class TestLegitimateExpressions:
         ("pi", "pi"),
         ("E", "E"),
         ("Abs(-5)", "5"),
+        ("x ^ 2", "x**2"),
+        ("2 ^ 3", "8"),
     ])
     def test_valid_expression(self, expr, expected_str):
         result = safe_parse_expr(expr)


### PR DESCRIPTION
## **User description**
Closes #329, closes #330 (both CVSS 8.8, CWE-95 authenticated RCE on `/verify/math` — regression of the #200 fix).

## Why a denylist can never hold

The #200 fix was a regex denylist over the raw source string in front of sympy `parse_expr`, which terminates in a raw `eval()`. Two composable primitives defeated it (both PoCs reproduced before this fix):

1. **#329 — unlisted dunders + string-literal splitting.** `__getattribute__`, `__func__`, `__dict__`, `__base__` etc. were never in the denylist, and `'__gl'+'obals__'` contains no denylisted substring but evaluates to `__globals__`. Any attribute walk starting from a namespace object reached `__builtins__` → `__import__` → RCE.
2. **#330 — NFKC normalization.** CPython normalizes identifiers to NFKC at compile time (PEP 3131), so `__𝐜𝐥𝐚𝐬𝐬__` (bold math codepoints) and fullwidth forms pass the ASCII denylist but become real attribute accesses inside `eval`.

## What this PR does

Structural boundary in `safe_parse_expr`, layered in order — the denylist is demoted to defense in depth:

| Layer | Check | Kills |
|---|---|---|
| 1 | NFKC-normalize input before every filter | #330 — filters now see what the compiler sees |
| 2 | ASCII charset allowlist; `.` only legal as a decimal point between two digits | all attribute access on the implicit-multiplication path (e.g. `2x`) where no AST check can run |
| 3 | Denylist (unchanged) | residual dangerous names, clearer error |
| 4 | AST node-type allowlist for Python-parseable input: `Expression/BinOp/UnaryOp/Call/Name/Load/Constant/keyword` + arithmetic operators only | #329 — `Attribute`, `Subscript`, string constants, lambdas, comprehensions, comparisons, boolean ops rejected before `eval` can run |

Plus hardening of `extra_symbols` keys (raw-ASCII identifier check — a fullwidth key can no longer NFKC-alias a built-in name at compile time).

## Deliberate strictness (documented trade-offs)

- `.` must have a digit on **both** sides: `.5` and `2.` are now rejected (write `0.5`). This is what makes attribute access structurally impossible on the non-AST path.
- Non-ASCII input rejected outright after NFKC (use `alpha`, not `α`).
- String constants rejected → `Symbol('x')` is no longer expressible in user input (bare `x` still works; sympy's internal `Symbol('name')` emission during transformation is unaffected).
- Comparisons/booleans/`not` rejected — not arithmetic; verifiers compare results separately.

## Verification

- All PoCs from #329 and #330 (including the 139-char original, the stealth `[<payload>, x][1]` wrapper, bold/fullwidth NFKC variants, and the in-band leak `Integer(Symbol.__𝐬𝐮𝐛𝐜𝐥𝐚𝐬𝐬𝐞𝐬__...)`) now raise `SafeParserError` — see new `TestASTAllowlist`, `TestNFKCNormalization`, `TestStrictDecimalDot`, `TestCharsetGate` classes.
- Full suite green: **1836 passed + 102 skipped** (main) + **214 passed** (`tests/security`), incl. all pre-existing legitimate-expression, batch-math, and consensus tests — no functional regressions.
- `x ^ 2` failure noted during testing is pre-existing on `main` (sympy's `standard_transformations` does not include `convert_xor`); unrelated to this change.


___

## **CodeAnt-AI Description**
Block code execution through unsafe math expressions

### What Changed
- Math input is normalized and restricted to ASCII arithmetic syntax before evaluation
- Attribute access, indexing, strings, statements, comparisons, lambdas, and other non-arithmetic constructs are rejected
- Decimal points remain supported, while unsupported dot usage is rejected
- Extra symbols must use plain ASCII identifier names, preventing Unicode aliases of built-in names
- Added coverage for known code-execution bypasses, Unicode normalization tricks, invalid syntax, and preserved arithmetic behavior

### Impact
`✅ Prevented authenticated code execution through math expressions`
`✅ Rejected Unicode and syntax-based parser bypasses`
`✅ Preserved decimal and implicit-multiplication calculations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
