### PR TITLE
feat(precision): advisory flag for binary floating-point constants

### DIFF
--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -656,14 +656,10 @@ async def verify_math(
         # Precision advisory (issue #347): flag binary floating-point
         # constants WITHOUT affecting the verdict — advisory_checks are
         # structurally non-proof-bearing. QWED_RULES.md: flag float math,
-        # suggest decimal.Decimal / sympy.
-        if "=" in expression:
-            # Build advisory source from normalized equation sides (safe_parse_expr)
-            # so equations like 0.5*x = 0.5*x, 0.5x = 0.5x, and 0.1 = 0.1 receive the advisory.
-            advisory_source = f"({left}) + ({right})"
-        else:
-            advisory_source = expression
-        float_advisory = AdvisoryCheck.float_precision(advisory_source)
+        # suggest decimal.Decimal / sympy. Parse submitted text directly
+        # so equations (including 0.0*x = 0.0*x, 0.5**0 = 1) retain lexical
+        # float literals before symbolic simplification.
+        float_advisory = AdvisoryCheck.float_precision(expression)
         if float_advisory is not None:
             dr.developer_fields.setdefault("advisory_checks", []).append(float_advisory)
 

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -657,7 +657,13 @@ async def verify_math(
         # constants WITHOUT affecting the verdict — advisory_checks are
         # structurally non-proof-bearing. QWED_RULES.md: flag float math,
         # suggest decimal.Decimal / sympy.
-        float_advisory = AdvisoryCheck.float_precision(expression)
+        if "=" in expression:
+            # Build advisory source from normalized equation sides (safe_parse_expr)
+            # so equations like 0.5*x = 0.5*x, 0.5x = 0.5x, and 0.1 = 0.1 receive the advisory.
+            advisory_source = f"({left}) + ({right})"
+        else:
+            advisory_source = expression
+        float_advisory = AdvisoryCheck.float_precision(advisory_source)
         if float_advisory is not None:
             dr.developer_fields.setdefault("advisory_checks", []).append(float_advisory)
 

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -9,6 +9,7 @@ from fractions import Fraction
 
 from qwed_new.core.security import redact_pii
 from qwed_new.core.diagnostics import (
+    AdvisoryCheck,
     DiagnosticResult,
     admission_decision,
     enforce_trust_decision,
@@ -651,6 +652,14 @@ async def verify_math(
                             "Expression is not numeric",
                             developer_fields={"is_valid": False, "simplified": str(simplified), "original": str(parsed)},
                         )
+
+        # Precision advisory (issue #347): flag binary floating-point
+        # constants WITHOUT affecting the verdict — advisory_checks are
+        # structurally non-proof-bearing. QWED_RULES.md: flag float math,
+        # suggest decimal.Decimal / sympy.
+        float_advisory = AdvisoryCheck.float_precision(expression)
+        if float_advisory is not None:
+            dr.developer_fields.setdefault("advisory_checks", []).append(float_advisory)
 
         dr = _enforce_trust(dr, query=expression)
 

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -126,6 +126,31 @@ def _is_word_or_dot(ch: str) -> bool:
     return _is_ident_char(ch) or ch == "."
 
 
+def _scan_digits(text: str, i: int) -> int:
+    """Advance past ASCII digits starting at *i*; single bounded loop."""
+    n = len(text)
+    while i < n and "0" <= text[i] <= "9":
+        i += 1
+    return i
+
+
+def _scan_exponent_tail(text: str, i: int) -> int:
+    """Consume an ``e[+-]digits`` exponent at *i*, else return *i* unchanged.
+
+    A bare ``e`` (``2ex``) is not an exponent — the caller treats it as an
+    identifier start, matching the old pattern's optional exponent group."""
+    n = len(text)
+    if i >= n or text[i] not in "eE":
+        return i
+    j = i + 1
+    if j < n and text[j] in "+-":
+        j += 1
+    k = _scan_digits(text, j)
+    if k == j:
+        return i
+    return k
+
+
 def _scan_number(text: str, i: int) -> int:
     """End index (exclusive) of the numeric literal starting at *i*.
 
@@ -133,23 +158,10 @@ def _scan_number(text: str, i: int) -> int:
     ``digits[.digits][e[+-]digits]`` or ``.digits`` — scanned forward with
     no backtracking. Callers guarantee ``text[i]`` starts a number (an
     ASCII digit, or ``.`` followed by a digit)."""
-    n = len(text)
-    while i < n and "0" <= text[i] <= "9":
-        i += 1
-    if i < n and text[i] == ".":
-        i += 1
-        while i < n and "0" <= text[i] <= "9":
-            i += 1
-    if i < n and text[i] in "eE":
-        j = i + 1
-        if j < n and text[j] in "+-":
-            j += 1
-        k = j
-        while k < n and "0" <= text[k] <= "9":
-            k += 1
-        if k > j:
-            i = k
-    return i
+    i = _scan_digits(text, i)
+    if i < len(text) and text[i] == ".":
+        i = _scan_digits(text, i + 1)
+    return _scan_exponent_tail(text, i)
 
 
 def _scan_ident(text: str, i: int) -> int:
@@ -165,6 +177,62 @@ def _skip_ws(text: str, i: int) -> int:
     while i < n and text[i] in " \t":
         i += 1
     return i
+
+
+def _starts_number(side: str, i: int) -> bool:
+    """True when a numeric literal starts at *i* (digit, or ``.`` + digit)."""
+    ch = side[i]
+    if "0" <= ch <= "9":
+        return True
+    return ch == "." and i + 1 < len(side) and "0" <= side[i + 1] <= "9"
+
+
+def _emit_number_operand(side: str, i: int, out: List[str]) -> int:
+    """Emit the number at *i* plus any implicit-mul ``*``; return next index."""
+    end = _scan_number(side, i)
+    j = _skip_ws(side, end)
+    n = len(side)
+    if j < n and _is_ident_start(side[j]):
+        m = _scan_ident(side, j)
+        if keyword.iskeyword(side[j:m]):
+            out.append(side[i:end])
+            return end
+        out.append(side[i:end])
+        out.append("*")
+        return j
+    if j < n and side[j] == "(":
+        out.append(side[i:end])
+        out.append("*")
+        return j
+    out.append(side[i:end])
+    return end
+
+
+def _is_implicit_application(side: str, ident: str, end: int, j: int) -> bool:
+    """True for ``sin 0.5``: whitespace-separated identifier applied to a number.
+
+    Keywords are excluded (``not 0.5`` must keep parsing), and the number
+    must genuinely follow whitespace — ``x0.5`` stays untouched."""
+    n = len(side)
+    if j <= end or j >= n or keyword.iskeyword(ident):
+        return False
+    return _starts_number(side, j)
+
+
+def _emit_ident_operand(side: str, i: int, out: List[str]) -> int:
+    """Emit the identifier at *i*, parenthesizing ``f 0.5`` application."""
+    end = _scan_ident(side, i)
+    ident = side[i:end]
+    j = _skip_ws(side, end)
+    if not _is_implicit_application(side, ident, end, j):
+        out.append(ident)
+        return end
+    num_end = _scan_number(side, j)
+    out.append(ident)
+    out.append("(")
+    out.append(side[j:num_end])
+    out.append(")")
+    return num_end
 
 
 def _normalize_implicit_mul(side: str) -> str:
@@ -189,50 +257,10 @@ def _normalize_implicit_mul(side: str) -> str:
     while i < n:
         ch = side[i]
         prev_ok = i == 0 or not _is_word_or_dot(side[i - 1])
-        if (
-            ("0" <= ch <= "9" or (ch == "." and i + 1 < n and "0" <= side[i + 1] <= "9"))
-            and prev_ok
-        ):
-            end = _scan_number(side, i)
-            j = _skip_ws(side, end)
-            if j < n and _is_ident_start(side[j]):
-                m = _scan_ident(side, j)
-                if keyword.iskeyword(side[j:m]):
-                    out.append(side[i:end])
-                    i = end
-                else:
-                    out.append(side[i:end])
-                    out.append("*")
-                    i = j
-            elif j < n and side[j] == "(":
-                out.append(side[i:end])
-                out.append("*")
-                i = j
-            else:
-                out.append(side[i:end])
-                i = end
+        if _starts_number(side, i) and prev_ok:
+            i = _emit_number_operand(side, i, out)
         elif _is_ident_start(ch) and prev_ok:
-            end = _scan_ident(side, i)
-            ident = side[i:end]
-            j = _skip_ws(side, end)
-            if (
-                j > end
-                and j < n
-                and (
-                    "0" <= side[j] <= "9"
-                    or (side[j] == "." and j + 1 < n and "0" <= side[j + 1] <= "9")
-                )
-                and not keyword.iskeyword(ident)
-            ):
-                num_end = _scan_number(side, j)
-                out.append(ident)
-                out.append("(")
-                out.append(side[j:num_end])
-                out.append(")")
-                i = num_end
-            else:
-                out.append(ident)
-                i = end
+            i = _emit_ident_operand(side, i, out)
         else:
             out.append(ch)
             i += 1
@@ -377,7 +405,7 @@ class AdvisoryCheck:
         return cls(
             name=data.get("name", ""),
             advisory_only=advisory_only,
-            constraint_id=data.get("constraint_id"),
+            constraint_id=data.get("constraint_id") or "",
             details=data.get("details", {}),
         )
 

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -232,6 +232,13 @@ def _emit_ident_operand(side: str, i: int, out: List[str]) -> int:
     out.append("(")
     out.append(side[j:num_end])
     out.append(")")
+    # A trailing operand (``sin 0.5x``, ``sin 0.5(x+1)``) needs an explicit
+    # ``*`` — otherwise ``sin(0.5)x`` is a syntax error and the advisory is
+    # lost (Sentry on #348).
+    k = _skip_ws(side, num_end)
+    if k < len(side) and (_is_ident_start(side[k]) or side[k] == "("):
+        out.append("*")
+        return k
     return num_end
 
 

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -40,9 +40,9 @@ Dict[str, Any] returns to DiagnosticResult) is tracked in blocked issues:
 from __future__ import annotations
 
 import ast
-import re
 import hashlib
 import json
+import keyword
 import logging
 from dataclasses import dataclass, field, replace
 from enum import Enum
@@ -111,7 +111,132 @@ class AdmissionDecision(str, Enum):
 # developer_fields.advisory_checks for audit/developer review only.
 # ---------------------------------------------------------------------------
 
-_IMPLICIT_MUL_RE = re.compile(r"(?<![\w.])((\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?)([a-zA-Z_])")
+_MAX_EQUATION_SIDE_CHARS = 4000
+
+
+def _is_ident_start(ch: str) -> bool:
+    return ch == "_" or "a" <= ch <= "z" or "A" <= ch <= "Z"
+
+
+def _is_ident_char(ch: str) -> bool:
+    return _is_ident_start(ch) or "0" <= ch <= "9"
+
+
+def _is_word_or_dot(ch: str) -> bool:
+    return _is_ident_char(ch) or ch == "."
+
+
+def _scan_number(text: str, i: int) -> int:
+    """End index (exclusive) of the numeric literal starting at *i*.
+
+    Shape mirrors the old implicit-mul number pattern —
+    ``digits[.digits][e[+-]digits]`` or ``.digits`` — scanned forward with
+    no backtracking. Callers guarantee ``text[i]`` starts a number (an
+    ASCII digit, or ``.`` followed by a digit)."""
+    n = len(text)
+    while i < n and "0" <= text[i] <= "9":
+        i += 1
+    if i < n and text[i] == ".":
+        i += 1
+        while i < n and "0" <= text[i] <= "9":
+            i += 1
+    if i < n and text[i] in "eE":
+        j = i + 1
+        if j < n and text[j] in "+-":
+            j += 1
+        k = j
+        while k < n and "0" <= text[k] <= "9":
+            k += 1
+        if k > j:
+            i = k
+    return i
+
+
+def _scan_ident(text: str, i: int) -> int:
+    """End index (exclusive) of the identifier starting at *i*."""
+    n = len(text)
+    while i < n and _is_ident_char(text[i]):
+        i += 1
+    return i
+
+
+def _skip_ws(text: str, i: int) -> int:
+    n = len(text)
+    while i < n and text[i] in " \t":
+        i += 1
+    return i
+
+
+def _normalize_implicit_mul(side: str) -> str:
+    """Insert explicit ``*`` / call parens for implicit multiplication.
+
+    Single left-to-right pass — O(len(side)), no backtracking by
+    construction (every iteration advances ``i`` by at least one char).
+    Handles ``2x``, ``2 x``, ``2(``, and ``sin 0.5``-style application so
+    the advisory parser sees the constants SymPy accepts.
+
+    Python keywords are never treated as operands: ``0.5 in [0.5, 1]``
+    and ``2 if x else 3`` parse fine today, and rewriting them would
+    break the parse and lose the advisory. Likewise, an identifier
+    directly glued to a number (``x0.5``) is left alone — only genuine
+    whitespace-separated application is parenthesized.
+
+    Advisory-only: the result feeds float-constant extraction, never a
+    verdict."""
+    n = len(side)
+    out: List[str] = []
+    i = 0
+    while i < n:
+        ch = side[i]
+        prev_ok = i == 0 or not _is_word_or_dot(side[i - 1])
+        if (
+            ("0" <= ch <= "9" or (ch == "." and i + 1 < n and "0" <= side[i + 1] <= "9"))
+            and prev_ok
+        ):
+            end = _scan_number(side, i)
+            j = _skip_ws(side, end)
+            if j < n and _is_ident_start(side[j]):
+                m = _scan_ident(side, j)
+                if keyword.iskeyword(side[j:m]):
+                    out.append(side[i:end])
+                    i = end
+                else:
+                    out.append(side[i:end])
+                    out.append("*")
+                    i = j
+            elif j < n and side[j] == "(":
+                out.append(side[i:end])
+                out.append("*")
+                i = j
+            else:
+                out.append(side[i:end])
+                i = end
+        elif _is_ident_start(ch) and prev_ok:
+            end = _scan_ident(side, i)
+            ident = side[i:end]
+            j = _skip_ws(side, end)
+            if (
+                j > end
+                and j < n
+                and (
+                    "0" <= side[j] <= "9"
+                    or (side[j] == "." and j + 1 < n and "0" <= side[j + 1] <= "9")
+                )
+                and not keyword.iskeyword(ident)
+            ):
+                num_end = _scan_number(side, j)
+                out.append(ident)
+                out.append("(")
+                out.append(side[j:num_end])
+                out.append(")")
+                i = num_end
+            else:
+                out.append(ident)
+                i = end
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
 
 
 def _parse_expression_side(side: str) -> Optional[ast.AST]:
@@ -119,7 +244,13 @@ def _parse_expression_side(side: str) -> Optional[ast.AST]:
         return ast.parse(side, mode="eval")
     except (SyntaxError, ValueError, RecursionError):
         pass
-    norm = _IMPLICIT_MUL_RE.sub(r"\1*\3", side)
+    if len(side) > _MAX_EQUATION_SIDE_CHARS:
+        # Advisory-only path: oversized sides skip normalization rather
+        # than burn CPU — absence of an advisory is always safe.
+        return None
+    norm = _normalize_implicit_mul(side)
+    if norm == side:
+        return None
     try:
         return ast.parse(norm, mode="eval")
     except (SyntaxError, ValueError, RecursionError):
@@ -130,7 +261,7 @@ def _parse_expression_side(side: str) -> Optional[ast.AST]:
 def _parse_equation_trees(source: str) -> List[ast.AST]:
     if "=" not in source:
         return []
-    left, sep, right = source.partition("=")
+    left, _, right = source.partition("=")
     if "=" in left or "=" in right:
         return []
     left_tree = _parse_expression_side(left.strip())

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -40,6 +40,7 @@ Dict[str, Any] returns to DiagnosticResult) is tracked in blocked issues:
 from __future__ import annotations
 
 import ast
+import re
 import hashlib
 import json
 import logging
@@ -110,24 +111,72 @@ class AdmissionDecision(str, Enum):
 # developer_fields.advisory_checks for audit/developer review only.
 # ---------------------------------------------------------------------------
 
+_IMPLICIT_MUL_RE = re.compile(r"(?<![\w.])((\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?)([a-zA-Z_])")
+
+
+def _parse_expression_side(side: str) -> Optional[ast.AST]:
+    try:
+        return ast.parse(side, mode="eval")
+    except (SyntaxError, ValueError, RecursionError):
+        pass
+    norm = _IMPLICIT_MUL_RE.sub(r"\1*\3", side)
+    try:
+        return ast.parse(norm, mode="eval")
+    except (SyntaxError, ValueError, RecursionError):
+        # Normalization failed or unparsable side; skip
+        return None
+
+
+def _parse_equation_trees(source: str) -> List[ast.AST]:
+    if "=" not in source:
+        return []
+    left, sep, right = source.partition("=")
+    if "=" in left or "=" in right:
+        return []
+    left_tree = _parse_expression_side(left.strip())
+    right_tree = _parse_expression_side(right.strip())
+    if left_tree is None or right_tree is None:
+        return []
+    return [left_tree, right_tree]
+
+
+def _parse_source_trees(source: str, expression_mode: bool = True) -> List[ast.AST]:
+    try:
+        return [ast.parse(source, mode="eval" if expression_mode else "exec")]
+    except (SyntaxError, ValueError, RecursionError):
+        if expression_mode:
+            return _parse_equation_trees(source)
+        return []
+
+
+def _extract_float_constants(trees: List[ast.AST]) -> List[str]:
+    return sorted(
+        {
+            repr(node.value)
+            for tree in trees
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, (float, complex))
+        }
+    )
+
+
 @dataclass(frozen=True)
 class AdvisoryCheck:
-    """A non-proof-bearing analysis result attached as advisory metadata.
+    """A single non-verdict-affecting advisory check.
 
-    Advisory checks may carry useful information for developers or auditors,
-    but they MUST NOT influence the verification verdict. The constraint:
-
-        advisory_only = True
-
-    is structurally enforced: advisory checks populate
-    developer_fields.advisory_checks, never status or proof_ref.
+    Advisory checks flag operational, precision, or architectural
+    concerns (e.g. binary float math, deprecations, performance
+    suggestions). They are strictly informational: by contract, they
+    MUST NOT influence the verification verdict or proof_ref (Issue #347).
     """
+
     name: str
     advisory_only: bool = True
-    constraint_id: Optional[str] = None
+    constraint_id: str = ""
     details: Dict[str, Any] = field(default_factory=dict)
 
-    def __post_init__(self) -> None:
+    def __post_init__(self):
         if self.advisory_only is not True:
             raise ValueError(
                 "AdvisoryCheck.advisory_only must be True — "
@@ -152,39 +201,18 @@ class AdvisoryCheck:
         not what is exact, and documented inputs like
         `1000 * (1 + 0.05)**2` legitimately contain floats (#347).
 
-        Equality input (`0.1 + 0.2 = 0.3`) is not one eval-mode expression,
-        so in expression mode the two sides of a bare `=` are parsed
-        separately (CodeAnt on #348). Complex constants count too:
-        `1.0j` is binary-float-based arithmetic the same way `0.1` is.
+        Equality input (`0.1 + 0.2 = 0.3`, `0.0*x = 0.0*x`) is parsed
+        side-by-side to preserve lexical float literals even when symbolic
+        simplification would eagerly collapse them. Complex constants count
+        too: `1.0j` is binary-float-based arithmetic the same way `0.1` is.
 
         Returns None when the source parses clean of float/complex
         constants or cannot be parsed at all (parse failures are the
         security gates' business, not this advisory's)."""
-        trees = []
-        try:
-            trees.append(ast.parse(source, mode="eval" if expression_mode else "exec"))
-        except (SyntaxError, ValueError, RecursionError):
-            if expression_mode:
-                left, sep, right = source.partition("=")
-                if sep and "=" not in left and "=" not in right:
-                    import re
-                    for side in (left.strip(), right.strip()):
-                        try:
-                            trees.append(ast.parse(side, mode="eval"))
-                        except (SyntaxError, ValueError, RecursionError):
-                            # Try normalizing implicit multiplication (e.g. 0.5x -> 0.5*x)
-                            norm = re.sub(r'(\d+([.]\d*)?|\.\d+)([a-zA-Z_])', r'\1*\3', side)
-                            try:
-                                trees.append(ast.parse(norm, mode="eval"))
-                            except (SyntaxError, ValueError, RecursionError):
-                                pass
+        trees = _parse_source_trees(source, expression_mode=expression_mode)
         if not trees:
             return None
-        constants = sorted(
-            {repr(node.value) for tree in trees for node in ast.walk(tree)
-             if isinstance(node, ast.Constant)
-             and isinstance(node.value, (float, complex))}
-        )
+        constants = _extract_float_constants(trees)
         if not constants:
             return None
         return cls(

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -152,16 +152,38 @@ class AdvisoryCheck:
         not what is exact, and documented inputs like
         `1000 * (1 + 0.05)**2` legitimately contain floats (#347).
 
-        Returns None when the source parses clean of float constants or
-        cannot be parsed at all (parse failures are the security gates'
-        business, not this advisory's)."""
+        Equality input (`0.1 + 0.2 = 0.3`) is not one eval-mode expression,
+        so in expression mode the two sides of a bare `=` are parsed
+        separately (CodeAnt on #348). Complex constants count too:
+        `1.0j` is binary-float-based arithmetic the same way `0.1` is.
+
+        Returns None when the source parses clean of float/complex
+        constants or cannot be parsed at all (parse failures are the
+        security gates' business, not this advisory's)."""
+        trees = []
         try:
-            tree = ast.parse(source, mode="eval" if expression_mode else "exec")
+            trees.append(ast.parse(source, mode="eval" if expression_mode else "exec"))
         except (SyntaxError, ValueError, RecursionError):
+            if expression_mode:
+                left, sep, right = source.partition("=")
+                if sep and "=" not in left and "=" not in right:
+                    import re
+                    for side in (left.strip(), right.strip()):
+                        try:
+                            trees.append(ast.parse(side, mode="eval"))
+                        except (SyntaxError, ValueError, RecursionError):
+                            # Try normalizing implicit multiplication (e.g. 0.5x -> 0.5*x)
+                            norm = re.sub(r'(\d+([.]\d*)?|\.\d+)([a-zA-Z_])', r'\1*\3', side)
+                            try:
+                                trees.append(ast.parse(norm, mode="eval"))
+                            except (SyntaxError, ValueError, RecursionError):
+                                pass
+        if not trees:
             return None
         constants = sorted(
-            {repr(node.value) for node in ast.walk(tree)
-             if isinstance(node, ast.Constant) and isinstance(node.value, float)}
+            {repr(node.value) for tree in trees for node in ast.walk(tree)
+             if isinstance(node, ast.Constant)
+             and isinstance(node.value, (float, complex))}
         )
         if not constants:
             return None

--- a/src/qwed_new/core/diagnostics.py
+++ b/src/qwed_new/core/diagnostics.py
@@ -39,6 +39,7 @@ Dict[str, Any] returns to DiagnosticResult) is tracked in blocked issues:
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import json
 import logging
@@ -140,6 +141,45 @@ class AdvisoryCheck:
             "constraint_id": self.constraint_id,
             "details": self.details,
         }
+
+    @classmethod
+    def float_precision(cls, source: str, expression_mode: bool = True) -> Optional["AdvisoryCheck"]:
+        """Advisory: *source* contains binary floating-point constants.
+
+        QWED_RULES.md: floating-point math is flagged and decimal.Decimal /
+        SymPy exact rationals are suggested. This is a PRECISION advisory,
+        never a rejection — execution-safety gates decide what may run,
+        not what is exact, and documented inputs like
+        `1000 * (1 + 0.05)**2` legitimately contain floats (#347).
+
+        Returns None when the source parses clean of float constants or
+        cannot be parsed at all (parse failures are the security gates'
+        business, not this advisory's)."""
+        try:
+            tree = ast.parse(source, mode="eval" if expression_mode else "exec")
+        except (SyntaxError, ValueError, RecursionError):
+            return None
+        constants = sorted(
+            {repr(node.value) for node in ast.walk(tree)
+             if isinstance(node, ast.Constant) and isinstance(node.value, float)}
+        )
+        if not constants:
+            return None
+        return cls(
+            name="floating-point-constants",
+            constraint_id="precision.float-constants",
+            details={
+                "constants": constants,
+                "note": (
+                    "Binary floating-point values can be inexact; results "
+                    "may differ from exact decimal arithmetic."
+                ),
+                "suggestion": (
+                    "Use decimal.Decimal or SymPy exact rationals "
+                    "(sympy.Rational) where exact arithmetic matters."
+                ),
+            },
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "AdvisoryCheck":

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
 import ast
 
-from .diagnostics import DiagnosticResult, DiagnosticStatus, enforce_trust_decision
+from .diagnostics import AdvisoryCheck, DiagnosticResult, DiagnosticStatus, enforce_trust_decision
 from .secure_code_executor import _DANGEROUS_MODULE_ROOTS, _DANGEROUS_OS_CALLS
 from .verification_context import (
     Admission,
@@ -560,6 +560,12 @@ class StatsVerifier:
                 },
             )
 
+        # Precision advisory (issue #347): generated stats code is
+        # float-native, so float constants are EXPECTED — the advisory
+        # flags them for exactness-sensitive consumers without affecting
+        # the verdict (advisory_checks are structurally non-proof-bearing).
+        float_advisory = AdvisoryCheck.float_precision(code, expression_mode=False)
+
         # 2. Pre-execution security validation
         try:
             security_report = self._validate_security(code)
@@ -685,14 +691,17 @@ class StatsVerifier:
                 "risk_level": security_report.risk_level,
             },
         }
+        completion_fields = {
+            "constraint_id": CONSTRAINT_CLAIM_NOT_VERIFIED,
+            "is_valid": False,
+            "claim_supported": False,
+            **execution_evidence,
+        }
+        if float_advisory is not None:
+            completion_fields["advisory_checks"] = [float_advisory]
         return DiagnosticResult.unverifiable(
             agent_message="Statistical analysis completed, but the claim could not be deterministically verified.",
-            developer_fields={
-                "constraint_id": CONSTRAINT_CLAIM_NOT_VERIFIED,
-                "is_valid": False,
-                "claim_supported": False,
-                **execution_evidence,
-            },
+            developer_fields=completion_fields,
         )
     
     def to_verification_context(

--- a/tests/test_float_precision_advisory.py
+++ b/tests/test_float_precision_advisory.py
@@ -149,6 +149,13 @@ class TestFloatPrecisionAdvisoryHelper:
         assert check["advisory_only"] is True
         assert check["constraint_id"] == "precision.float-constants"
 
+    def test_from_dict_normalizes_missing_constraint_id(self):
+        # CodeRabbit nitpick on #348: to_dict must emit a string per the
+        # field contract even when the payload omits constraint_id.
+        check = AdvisoryCheck.from_dict({"name": "x", "advisory_only": True})
+        assert check.constraint_id == ""
+        assert check.to_dict()["constraint_id"] == ""
+
 
 class TestVerifyMathEndpointAdvisory:
     @pytest.fixture

--- a/tests/test_float_precision_advisory.py
+++ b/tests/test_float_precision_advisory.py
@@ -35,6 +35,49 @@ class TestFloatPrecisionAdvisoryHelper:
     def test_scientific_notation_flagged(self):
         assert AdvisoryCheck.float_precision("1e9 * 2") is not None
 
+    def test_equality_expression_sides_flagged(self):
+        # CodeAnt on #348: `0.1 + 0.2 = 0.3` is not one eval-mode
+        # expression — the two sides are parsed separately and both
+        # surfaces' float constants are reported.
+        advisory = AdvisoryCheck.float_precision("0.1 + 0.2 = 0.3")
+        assert advisory is not None
+        constants = advisory.details["constants"]
+        assert any("0.1" in c for c in constants)
+        assert any("0.3" in c for c in constants)
+
+    def test_equality_with_clean_side_still_flags_float_side(self):
+        advisory = AdvisoryCheck.float_precision("0.5 = x")
+        assert advisory is not None
+        assert advisory.details["constants"] == ["0.5"]
+
+    def test_explicit_multiplication_equality_flagged(self):
+        # Greptile on #348: 0.5*x = 0.5*x
+        advisory = AdvisoryCheck.float_precision("0.5*x = 0.5*x")
+        assert advisory is not None
+        assert advisory.details["constants"] == ["0.5"]
+
+    def test_implicit_multiplication_equality_flagged(self):
+        # Greptile on #348: 0.5x = 0.5x
+        advisory = AdvisoryCheck.float_precision("0.5x = 0.5x")
+        assert advisory is not None
+        assert advisory.details["constants"] == ["0.5"]
+
+    def test_equality_literal_flagged(self):
+        # CodeRabbit on #348: 0.1 = 0.1
+        advisory = AdvisoryCheck.float_precision("0.1 = 0.1")
+        assert advisory is not None
+        assert advisory.details["constants"] == ["0.1"]
+
+    def test_complex_literals_flagged(self):
+        # CodeAnt nitpick: 1.0j is an AST complex constant, not float.
+        advisory = AdvisoryCheck.float_precision("1.0j * 2")
+        assert advisory is not None
+        assert any("j" in c for c in advisory.details["constants"])
+
+    def test_malformed_equality_returns_none(self):
+        # Neither side parses: no advisory, no exception.
+        assert AdvisoryCheck.float_precision("!! = ??") is None
+
     def test_unparsable_source_returns_none(self):
         # Parse failures are the security gates' business, not this
         # advisory's.
@@ -55,7 +98,7 @@ class TestFloatPrecisionAdvisoryHelper:
 
 
 class TestVerifyMathEndpointAdvisory:
-    @pytest.fixture()
+    @pytest.fixture
     def client(self):
         from qwed_new.api.main import app, get_session
         from qwed_new.core.tenant_context import TenantContext, get_current_tenant
@@ -84,6 +127,42 @@ class TestVerifyMathEndpointAdvisory:
 
     def test_exact_expression_carries_no_float_advisory(self, client):
         resp = client.post("/verify/math", json={"expression": "2 + 3"})
+        assert resp.status_code == 200, resp.text
+        checks = resp.json().get("developer_fields", {}).get("advisory_checks", [])
+        assert not any(c.get("constraint_id") == "precision.float-constants" for c in checks)
+
+    def test_equation_expression_carries_float_advisory(self, client):
+        # Greptile / CodeRabbit / Sentry on #348: equations like
+        # 0.5*x = 0.5*x and 0.5x = 0.5x must carry precision advisory.
+        resp = client.post("/verify/math", json={"expression": "0.5*x = 0.5*x"})
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data.get("status") == "VERIFIED"
+        checks = data.get("developer_fields", {}).get("advisory_checks", [])
+        adv = next((c for c in checks if c.get("constraint_id") == "precision.float-constants"), None)
+        assert adv is not None
+        assert "0.5" in adv["details"]["constants"]
+
+    def test_implicit_multiplication_equation_carries_float_advisory(self, client):
+        # Greptile on #348: 0.5x = 0.5x
+        resp = client.post("/verify/math", json={"expression": "0.5x = 0.5x"})
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data.get("status") == "VERIFIED"
+        checks = data.get("developer_fields", {}).get("advisory_checks", [])
+        adv = next((c for c in checks if c.get("constraint_id") == "precision.float-constants"), None)
+        assert adv is not None
+        assert "0.5" in adv["details"]["constants"]
+
+    def test_literal_equation_carries_float_advisory(self, client):
+        # CodeRabbit on #348: 0.1 = 0.1
+        resp = client.post("/verify/math", json={"expression": "0.1 = 0.1"})
+        assert resp.status_code == 200, resp.text
+        checks = resp.json().get("developer_fields", {}).get("advisory_checks", [])
+        assert any(c.get("constraint_id") == "precision.float-constants" for c in checks)
+
+    def test_exact_equation_carries_no_float_advisory(self, client):
+        resp = client.post("/verify/math", json={"expression": "x = x"})
         assert resp.status_code == 200, resp.text
         checks = resp.json().get("developer_fields", {}).get("advisory_checks", [])
         assert not any(c.get("constraint_id") == "precision.float-constants" for c in checks)

--- a/tests/test_float_precision_advisory.py
+++ b/tests/test_float_precision_advisory.py
@@ -76,6 +76,16 @@ class TestFloatPrecisionAdvisoryHelper:
         assert advisory is not None
         assert advisory.details["constants"] == ["0.5"]
 
+    def test_function_application_with_trailing_operand_flagged(self):
+        # Sentry on #348: `sin 0.5x` normalized to `sin(0.5)x` — a syntax
+        # error that lost the advisory. The trailing operand needs `*`.
+        advisory = AdvisoryCheck.float_precision("sin 0.5x = sin 0.5x")
+        assert advisory is not None
+        assert advisory.details["constants"] == ["0.5"]
+        advisory = AdvisoryCheck.float_precision("sin 0.5 x = sin 0.5 x")
+        assert advisory is not None
+        assert advisory.details["constants"] == ["0.5"]
+
     def test_implicit_mul_with_paren_flagged(self):
         # Same implicit-multiplication class, paren form: `0.5(x+1)`.
         advisory = AdvisoryCheck.float_precision("0.5(x+1) = 0.5(x+1)")

--- a/tests/test_float_precision_advisory.py
+++ b/tests/test_float_precision_advisory.py
@@ -1,0 +1,125 @@
+"""Issue #347: binary floating-point constants in math/stats verification
+surface as a precision ADVISORY (`developer_fields.advisory_checks`), never
+a rejection — QWED_RULES.md: flag floating-point math, suggest
+decimal.Decimal / sympy. Adjudicated on PR #346: execution-safety gates
+decide what may run, not what is exact."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from qwed_new.core.diagnostics import AdvisoryCheck, DiagnosticResult
+from qwed_new.core.stats_verifier import StatsVerifier
+
+
+class TestFloatPrecisionAdvisoryHelper:
+    def test_float_expression_produces_advisory(self):
+        advisory = AdvisoryCheck.float_precision("0.1 + 0.2")
+        assert advisory is not None
+        assert advisory.advisory_only is True
+        assert advisory.constraint_id == "precision.float-constants"
+        assert any("0.1" in c for c in advisory.details["constants"])
+        assert "Decimal" in advisory.details["suggestion"]
+
+    def test_exact_integer_expression_is_clean(self):
+        assert AdvisoryCheck.float_precision("2 + 2") is None
+
+    def test_decimal_construction_is_clean(self):
+        # A Decimal call carries a string, not a float constant — exactly
+        # the shape the advisory recommends.
+        assert AdvisoryCheck.float_precision('Decimal("0.1") + Decimal("0.2")') is None
+
+    def test_scientific_notation_flagged(self):
+        assert AdvisoryCheck.float_precision("1e9 * 2") is not None
+
+    def test_unparsable_source_returns_none(self):
+        # Parse failures are the security gates' business, not this
+        # advisory's.
+        assert AdvisoryCheck.float_precision("import !!") is None
+
+    def test_exec_mode_source(self):
+        advisory = AdvisoryCheck.float_precision("df.fillna(0.5)", expression_mode=False)
+        assert advisory is not None
+        assert any("0.5" in c for c in advisory.details["constants"])
+
+    def test_advisory_serializes_into_developer_fields(self):
+        advisory = AdvisoryCheck.float_precision("0.1")
+        dr = DiagnosticResult.verified("ok", evidence={}, developer_fields={"is_valid": True})
+        dr.developer_fields.setdefault("advisory_checks", []).append(advisory)
+        check = dr.to_dict()["developer_fields"]["advisory_checks"][0]
+        assert check["advisory_only"] is True
+        assert check["constraint_id"] == "precision.float-constants"
+
+
+class TestVerifyMathEndpointAdvisory:
+    @pytest.fixture()
+    def client(self):
+        from qwed_new.api.main import app, get_session
+        from qwed_new.core.tenant_context import TenantContext, get_current_tenant
+
+        def _fake_tenant():
+            # api_key value is unused — the dependency is overridden.
+            return TenantContext(
+                organization_id=1, organization_name="test-org",
+                tier="free", api_key="k-1",
+            )
+
+        def _fake_session():
+            return MagicMock()
+
+        app.dependency_overrides[get_current_tenant] = _fake_tenant
+        app.dependency_overrides[get_session] = _fake_session
+        yield TestClient(app)
+        app.dependency_overrides.pop(get_current_tenant, None)
+        app.dependency_overrides.pop(get_session, None)
+
+    def test_float_expression_carries_advisory(self, client):
+        resp = client.post("/verify/math", json={"expression": "0.1 + 0.2"})
+        assert resp.status_code == 200, resp.text
+        checks = resp.json().get("developer_fields", {}).get("advisory_checks", [])
+        assert any(c.get("constraint_id") == "precision.float-constants" for c in checks)
+
+    def test_exact_expression_carries_no_float_advisory(self, client):
+        resp = client.post("/verify/math", json={"expression": "2 + 3"})
+        assert resp.status_code == 200, resp.text
+        checks = resp.json().get("developer_fields", {}).get("advisory_checks", [])
+        assert not any(c.get("constraint_id") == "precision.float-constants" for c in checks)
+
+
+class TestStatsCompletedAnalysisAdvisory:
+    def test_completed_analysis_carries_float_advisory(self):
+        """The one stats completion path (claim not deterministically
+        verified) attaches the advisory when the generated code uses
+        floats — the expected shape for numpy/pandas code."""
+        verifier = StatsVerifier()
+        verifier._translator = SimpleNamespace(
+            translate_stats=lambda query, columns, provider=None:
+                "result = float(df['a'].mean() * 0.5)"
+        )
+        verifier._select_sandbox = lambda: ("docker", object())
+        verifier._execute_docker = lambda code, context: SimpleNamespace(
+            success=True, error=None, result=1.0, execution_time_ms=1.0,
+        )
+        result = verifier.verify_stats("What is half the mean of a?", pd.DataFrame({"a": [1, 2, 3]}))
+        checks = result.developer_fields.get("advisory_checks", [])
+        assert any(c.constraint_id == "precision.float-constants" for c in checks)
+        assert all(c.advisory_only is True for c in checks)
+
+    def test_float_free_code_carries_no_advisory(self):
+        verifier = StatsVerifier()
+        verifier._translator = SimpleNamespace(
+            translate_stats=lambda query, columns, provider=None:
+                "result = df['a'].sum()"
+        )
+        verifier._select_sandbox = lambda: ("docker", object())
+        verifier._execute_docker = lambda code, context: SimpleNamespace(
+            success=True, error=None, result=6, execution_time_ms=1.0,
+        )
+        result = verifier.verify_stats("What is the sum of a?", pd.DataFrame({"a": [1, 2, 3]}))
+        assert not any(
+            c.constraint_id == "precision.float-constants"
+            for c in result.developer_fields.get("advisory_checks", [])
+        )

--- a/tests/test_float_precision_advisory.py
+++ b/tests/test_float_precision_advisory.py
@@ -62,6 +62,17 @@ class TestFloatPrecisionAdvisoryHelper:
         assert advisory is not None
         assert advisory.details["constants"] == ["0.5"]
 
+    def test_symbolic_simplification_preserves_lexical_floats(self):
+        # Greptile on #348: 0.0*x = 0.0*x and 0.5**0 = 1 collapse symbolically
+        # to 0 = 0 and 1 = 1, but must retain their lexical float advisories.
+        adv1 = AdvisoryCheck.float_precision("0.0*x = 0.0*x")
+        assert adv1 is not None
+        assert adv1.details["constants"] == ["0.0"]
+
+        adv2 = AdvisoryCheck.float_precision("0.5**0 = 1")
+        assert adv2 is not None
+        assert adv2.details["constants"] == ["0.5"]
+
     def test_equality_literal_flagged(self):
         # CodeRabbit on #348: 0.1 = 0.1
         advisory = AdvisoryCheck.float_precision("0.1 = 0.1")
@@ -74,9 +85,17 @@ class TestFloatPrecisionAdvisoryHelper:
         assert advisory is not None
         assert any("j" in c for c in advisory.details["constants"])
 
+    def test_scientific_notation_equation_preserves_advisory(self):
+        # CodeRabbit on #348: 1e3x = 1e3x consumes the exponent before implicit multiplication
+        advisory = AdvisoryCheck.float_precision("1e3x = 1e3x")
+        assert advisory is not None
+        assert any("1000" in c for c in advisory.details["constants"])
+
     def test_malformed_equality_returns_none(self):
-        # Neither side parses: no advisory, no exception.
+        # CodeRabbit on #348: return None if either side cannot be parsed
         assert AdvisoryCheck.float_precision("!! = ??") is None
+        assert AdvisoryCheck.float_precision("0.1 = ??") is None
+        assert AdvisoryCheck.float_precision("?? = 0.1") is None
 
     def test_unparsable_source_returns_none(self):
         # Parse failures are the security gates' business, not this
@@ -160,6 +179,23 @@ class TestVerifyMathEndpointAdvisory:
         assert resp.status_code == 200, resp.text
         checks = resp.json().get("developer_fields", {}).get("advisory_checks", [])
         assert any(c.get("constraint_id") == "precision.float-constants" for c in checks)
+
+    def test_collapsing_equation_preserves_float_advisory(self, client):
+        # Greptile on #348: 0.0*x = 0.0*x simplifies to 0 = 0, but advisory must retain 0.0
+        resp = client.post("/verify/math", json={"expression": "0.0*x = 0.0*x"})
+        assert resp.status_code == 200, resp.text
+        checks = resp.json().get("developer_fields", {}).get("advisory_checks", [])
+        adv = next((c for c in checks if c.get("constraint_id") == "precision.float-constants"), None)
+        assert adv is not None
+        assert "0.0" in adv["details"]["constants"]
+
+        # 0.5**0 = 1 simplifies to 1 = 1, but advisory must retain 0.5
+        resp2 = client.post("/verify/math", json={"expression": "0.5**0 = 1"})
+        assert resp2.status_code == 200, resp2.text
+        checks2 = resp2.json().get("developer_fields", {}).get("advisory_checks", [])
+        adv2 = next((c for c in checks2 if c.get("constraint_id") == "precision.float-constants"), None)
+        assert adv2 is not None
+        assert "0.5" in adv2["details"]["constants"]
 
     def test_exact_equation_carries_no_float_advisory(self, client):
         resp = client.post("/verify/math", json={"expression": "x = x"})

--- a/tests/test_float_precision_advisory.py
+++ b/tests/test_float_precision_advisory.py
@@ -62,6 +62,40 @@ class TestFloatPrecisionAdvisoryHelper:
         assert advisory is not None
         assert advisory.details["constants"] == ["0.5"]
 
+    def test_whitespace_implicit_multiplication_flagged(self):
+        # Greptile P1 on #348: `0.5 x = 0.5 x` verifies as an identity,
+        # so the advisory must surface its float constants too.
+        advisory = AdvisoryCheck.float_precision("0.5 x = 0.5 x")
+        assert advisory is not None
+        assert advisory.details["constants"] == ["0.5"]
+
+    def test_implicit_function_application_flagged(self):
+        # Greptile P1 on #348: `sin 0.5 = sin 0.5` verifies; the advisory
+        # must still surface the float constant.
+        advisory = AdvisoryCheck.float_precision("sin 0.5 = sin 0.5")
+        assert advisory is not None
+        assert advisory.details["constants"] == ["0.5"]
+
+    def test_implicit_mul_with_paren_flagged(self):
+        # Same implicit-multiplication class, paren form: `0.5(x+1)`.
+        advisory = AdvisoryCheck.float_precision("0.5(x+1) = 0.5(x+1)")
+        assert advisory is not None
+        assert advisory.details["constants"] == ["0.5"]
+
+    def test_keywords_are_never_implicit_mul_operands(self):
+        # `0.5 in [0.5, 1]` parses today; rewriting `in` as an operand
+        # would break the parse and lose the advisory.
+        advisory = AdvisoryCheck.float_precision("0.5 in [0.5, 1]")
+        assert advisory is not None
+        assert advisory.details["constants"] == ["0.5"]
+        # No floats anywhere: still None, and no crash.
+        assert AdvisoryCheck.float_precision("3 in x = 3 in x") is None
+
+    def test_oversized_side_skips_advisory(self):
+        # Advisory-only path: oversized sides skip normalization rather
+        # than burn CPU — absence of an advisory is always safe.
+        assert AdvisoryCheck.float_precision("0 " * 5000 + "= 1") is None
+
     def test_symbolic_simplification_preserves_lexical_floats(self):
         # Greptile on #348: 0.0*x = 0.0*x and 0.5**0 = 1 collapse symbolically
         # to 0 = 0 and 1 = 1, but must retain their lexical float advisories.


### PR DESCRIPTION
## **User description**
Closes #347. Follow-up from PR #346 round 1 (CodeRabbit 🟠 withdrawn finding → maintainer adjudication: precision advisory, not a gate rejection).

## What

Math and stats verification inputs may contain binary floating-point constants whose evaluation can be inexact relative to decimal arithmetic. QWED_RULES.md instructs: **flag** floating-point math and suggest `decimal.Decimal` / `sympy`. Until now nothing surfaced that signal.

New `AdvisoryCheck.float_precision(source, expression_mode)` in `diagnostics.py`: parses the source and returns a non-verdict-affecting advisory (`constraint_id: precision.float-constants`, `advisory_only=True` — structurally cannot influence status or proof_ref) listing the offending constants with the Decimal/sympy suggestion. Unparsable input returns `None` — parse failures belong to the security gates, not this advisory.

Wired into:
- **`/verify/math`** — the advisory is attached to the result (all branches) just before trust enforcement;
- **`StatsVerifier.verify_stats`** — the completed-analysis result carries the advisory when the generated code uses floats, which is the *expected* shape for numpy/pandas code — flagged, never disrupted.

## Explicitly not changed

No gate rejects float constants. `MathVerificationTask.expression`'s documented example (`1000 * (1 + 0.05)**2`) and effectively all real statistics code are float-based; execution-safety gates decide what may **run**, not what is **exact** (adjudicated on #346).

## Verification

- 11 new tests: helper units (floats flagged, integer/`Decimal(...)` clean, scientific notation, unparsable pass-through, `to_dict` serialization), `/verify/math` endpoint integration via dependency overrides (float expression carries the advisory, exact expression does not), and stats completed-analysis injection via stubbed translator/sandbox (float code carries it, float-free code does not).
- Full suite: **2151 passed, 102 skipped**.
- QWED engine via real `scan_file` routing on all changed files: only pre-existing WARNING advisories, 0 blocking findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Floating-point precision advisories now analyze submitted expressions directly, including equations and generated statistical code.
  - Advisories recognize implicit multiplication, function application, scientific notation, and complex constants.
  - Precision notices remain available in verification and statistical analysis diagnostics without changing execution results.

- **Bug Fixes**
  - Improved detection of floating-point constants before symbolic simplification.
  - Malformed or unparsable expressions no longer produce misleading advisories.
  - Advisory results are now consistently preserved in statistical analysis responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Flag binary floating-point values as precision advisories during math and statistics verification

### What Changed
- Math verification now reports an advisory when expressions contain decimal, scientific-notation, or complex floating-point constants, while preserving the existing verification result.
- Equations and implicit multiplication such as `0.5x = 0.5x` are recognized, including floats that would otherwise disappear during symbolic simplification.
- Completed statistics analyses report the same advisory when generated code uses floating-point constants.
- Advisories identify the affected constants and recommend `Decimal` or exact SymPy arithmetic; integer-only, exact, and unparsable inputs remain unaffected.

### Impact
`✅ Clearer precision risks in math results`
`✅ Float-based statistics continue without rejection`
`✅ Exact-arithmetic guidance for sensitive calculations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
