### PR TITLE
fix(deploy): scrape /metrics/prometheus, not the JSON /metrics endpoint

### DIFF
--- a/deploy/prometheus.yml
+++ b/deploy/prometheus.yml
@@ -21,7 +21,10 @@ scrape_configs:
   - job_name: 'qwed-api'
     static_configs:
       - targets: ['host.docker.internal:8000']
-    metrics_path: '/metrics'
+    # /metrics/prometheus serves the Prometheus text exposition format;
+    # /metrics returns JSON, which Prometheus cannot parse (Greptile P1
+    # on docs PR QWED-AI/docs#269).
+    metrics_path: '/metrics/prometheus'
     scrape_interval: 10s
     # http_headers:
     #   X-Api-Key:


### PR DESCRIPTION
## **User description**
## Summary

One-line deploy fix surfaced by the Greptile P1 review on docs PR [QWED-AI/docs#269](https://github.com/QWED-AI/docs/pull/269): the `qwed-api` Prometheus job in `deploy/prometheus.yml` pointed `metrics_path` at `/metrics`, which returns **JSON** that Prometheus cannot parse. The text exposition format is served by `/metrics/prometheus`.

Pre-existing misconfiguration (the scrape was already broken by the auth gate before #349), but load-bearing now that the docs describe the authenticated-scrape bootstrap. The endpoint requires the same operator authentication (`QWED_METRICS_OPERATOR_USER_IDS`, fail-closed when unset).

No code paths affected; YAML validated.


___

## **CodeAnt-AI Description**
Fix the QWED API metrics endpoint used by Prometheus

### What Changed
- Prometheus now requests the text-formatted metrics endpoint instead of the JSON endpoint, allowing scraped metrics to be parsed correctly
- The existing operator authentication requirement remains in place for the metrics scrape

### Impact
`✅ Working QWED API metrics collection`
`✅ Prometheus-compatible metric data`
`✅ Fewer scrape parsing errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Prometheus metrics collection to use the Prometheus-compatible endpoint, enabling successful scraping and monitoring.
  * Unauthenticated scrape requests continue to return a 401 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->