### PR TITLE
fix(security): sandbox containment — log rotation, pids_limit, container removal, result size caps

### DIFF
--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -224,11 +224,21 @@ _MAX_LOG_RESULT_CHARS = 64_000
 
 
 def _cap_log_result(result_dict) -> str:
-    """Serialize a DiagnosticResult dict for VerificationLog.result, capped."""
-    text = str(result_dict)
+    """Serialize a DiagnosticResult dict for VerificationLog.result, capped.
+
+    The audit integrity verifier decodes this field with json.loads
+    (audit_logger._decode_result_payload — malformed payloads raise
+    SecurityError), so both paths must emit VALID JSON, not Python repr
+    (CodeAnt on PR #351).
+    """
+    text = json.dumps(result_dict, default=str)
     if len(text) <= _MAX_LOG_RESULT_CHARS:
         return text
-    return text[:_MAX_LOG_RESULT_CHARS] + f"...[truncated {len(text) - _MAX_LOG_RESULT_CHARS} chars]"
+    return json.dumps({
+        "truncated": True,
+        "serialized_chars": len(text),
+        "preview": text[:_MAX_LOG_RESULT_CHARS],
+    }, default=str)
 
 
 _METRICS_OPERATOR_ENV_VAR = "QWED_METRICS_OPERATOR_USER_IDS"

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -221,6 +221,34 @@ def get_optional_api_key_record(
 # this is the audit-trail backstop so no endpoint can persist an unbounded
 # serialized result row.
 _MAX_LOG_RESULT_CHARS = 64_000
+_MAX_LOG_RESULT_STRING_CHARS = 1_000
+
+
+def _bound_log_strings(value, seen=None):
+    """Truncate long strings pre-encoding (Greptile P2 on PR #351).
+
+    iterencode emits a JSON string value as a SINGLE token, so an unbounded
+    string inside the dict would be fully materialized before the size cap
+    could run. Bounding first keeps every chunk small. RecursionError from a
+    circular reference is caught by the caller like other encode failures.
+    """
+    if isinstance(value, str):
+        if len(value) <= _MAX_LOG_RESULT_STRING_CHARS:
+            return value
+        return value[:_MAX_LOG_RESULT_STRING_CHARS] + "...[truncated]"
+    if isinstance(value, dict):
+        seen = set() if seen is None else seen
+        if id(value) in seen:
+            return "...[circular]"
+        seen.add(id(value))
+        try:
+            return {k: _bound_log_strings(v, seen) for k, v in value.items()}
+        finally:
+            seen.discard(id(value))
+    if isinstance(value, list):
+        seen = set() if seen is None else seen
+        return [_bound_log_strings(v, seen) for v in value]
+    return value
 
 
 def _cap_log_result(result_dict) -> str:
@@ -229,20 +257,21 @@ def _cap_log_result(result_dict) -> str:
     The audit integrity verifier decodes this field with json.loads
     (audit_logger._decode_result_payload — malformed payloads raise
     SecurityError), so both paths must emit VALID JSON, not Python repr.
-    Serialization is streamed so an oversized dict never materializes in
-    memory, and the fallback stays inside the cap: the preview is sanitized
-    of JSON-escapable characters BEFORE embedding, so escaping cannot
-    re-expand it (CodeRabbit on PR #351).
+    Serialization is streamed and string-bounded so an oversized dict never
+    materializes in memory, and the fallback stays inside the cap: the
+    preview is sanitized of JSON-escapable characters BEFORE embedding, so
+    escaping cannot re-expand it (CodeRabbit on PR #351).
     """
     parts = []
     total = 0
     try:
-        for chunk in json.JSONEncoder(default=str).iterencode(result_dict):
+        bounded = _bound_log_strings(result_dict)
+        for chunk in json.JSONEncoder(default=str).iterencode(bounded):
             parts.append(chunk)
             total += len(chunk)
             if total > _MAX_LOG_RESULT_CHARS:
                 break
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, RecursionError):
         return json.dumps({"truncated": True, "unserializable": True})
     if total <= _MAX_LOG_RESULT_CHARS:
         return "".join(parts)

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -247,7 +247,13 @@ def _bound_log_strings(value, seen=None):
             seen.discard(id(value))
     if isinstance(value, list):
         seen = set() if seen is None else seen
-        return [_bound_log_strings(v, seen) for v in value]
+        if id(value) in seen:
+            return "...[circular]"
+        seen.add(id(value))
+        try:
+            return [_bound_log_strings(v, seen) for v in value]
+        finally:
+            seen.discard(id(value))
     return value
 
 

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -222,9 +222,13 @@ def get_optional_api_key_record(
 # serialized result row.
 _MAX_LOG_RESULT_CHARS = 64_000
 _MAX_LOG_RESULT_STRING_CHARS = 1_000
+# Aggregate traversal budget (Greptile P1 on PR #351): stop cloning the
+# structure once enough bounded content has been retained, so a request with
+# very many small values cannot drive unbounded traversal on the event loop.
+_LOG_BOUND_BUDGET_CHARS = 2 * _MAX_LOG_RESULT_CHARS
 
 
-def _bound_log_strings(value, seen=None):
+def _bound_log_strings(value, seen=None, budget=None):
     """Truncate long strings pre-encoding (Greptile P2 on PR #351).
 
     iterencode emits a JSON string value as a SINGLE token, so an unbounded
@@ -232,9 +236,15 @@ def _bound_log_strings(value, seen=None):
     could run. Bounding first keeps every chunk small. RecursionError from a
     circular reference is caught by the caller like other encode failures.
     """
+    if budget is None:
+        budget = [_LOG_BOUND_BUDGET_CHARS]
+    if budget[0] <= 0:
+        return "...[audit truncated]"
     if isinstance(value, str):
         if len(value) <= _MAX_LOG_RESULT_STRING_CHARS:
+            budget[0] -= len(value)
             return value
+        budget[0] -= _MAX_LOG_RESULT_STRING_CHARS
         return value[:_MAX_LOG_RESULT_STRING_CHARS] + "...[truncated]"
     if isinstance(value, dict):
         seen = set() if seen is None else seen
@@ -242,7 +252,13 @@ def _bound_log_strings(value, seen=None):
             return "...[circular]"
         seen.add(id(value))
         try:
-            return {k: _bound_log_strings(v, seen) for k, v in value.items()}
+            out = {}
+            for k, v in value.items():
+                out[k] = _bound_log_strings(v, seen, budget)
+                if budget[0] <= 0:
+                    out["...audit truncated"] = True
+                    break
+            return out
         finally:
             seen.discard(id(value))
     if isinstance(value, list):
@@ -251,7 +267,13 @@ def _bound_log_strings(value, seen=None):
             return "...[circular]"
         seen.add(id(value))
         try:
-            return [_bound_log_strings(v, seen) for v in value]
+            out = []
+            for v in value:
+                out.append(_bound_log_strings(v, seen, budget))
+                if budget[0] <= 0:
+                    out.append("...audit truncated")
+                    break
+            return out
         finally:
             seen.discard(id(value))
     return value
@@ -263,8 +285,8 @@ def _cap_log_result(result_dict) -> str:
     The audit integrity verifier decodes this field with json.loads
     (audit_logger._decode_result_payload — malformed payloads raise
     SecurityError), so both paths must emit VALID JSON, not Python repr.
-    Serialization is streamed and string-bounded so an oversized dict never
-    materializes in memory, and the fallback stays inside the cap: the
+    Serialization is streamed and aggregate-bounded so an oversized dict
+    never materializes in memory, and the fallback stays inside the cap: the
     preview is sanitized of JSON-escapable characters BEFORE embedding, so
     escaping cannot re-expand it (CodeRabbit on PR #351).
     """

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -216,6 +216,21 @@ def get_optional_api_key_record(
     return api_key
 
 
+# #339: VerificationLog.result snapshots the full DiagnosticResult dict. The
+# amplifier path is capped at its source (stats_verifier caps observed_result),
+# this is the audit-trail backstop so no endpoint can persist an unbounded
+# serialized result row.
+_MAX_LOG_RESULT_CHARS = 64_000
+
+
+def _cap_log_result(result_dict) -> str:
+    """Serialize a DiagnosticResult dict for VerificationLog.result, capped."""
+    text = str(result_dict)
+    if len(text) <= _MAX_LOG_RESULT_CHARS:
+        return text
+    return text[:_MAX_LOG_RESULT_CHARS] + f"...[truncated {len(text) - _MAX_LOG_RESULT_CHARS} chars]"
+
+
 _METRICS_OPERATOR_ENV_VAR = "QWED_METRICS_OPERATOR_USER_IDS"
 
 
@@ -306,7 +321,7 @@ async def verify_natural_language(
         organization_id=tenant.organization_id,
         user_id=tenant.user_id if hasattr(tenant, 'user_id') else None,
         query=request.query,
-        result=str(dr.to_dict()),
+        result=_cap_log_result(dr.to_dict()),
         is_verified=dr.is_authoritative,
         domain="MATH"
     )
@@ -356,7 +371,7 @@ async def verify_logic(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=request.query,
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=dr.is_authoritative,
             domain="LOGIC"
         )
@@ -382,7 +397,7 @@ async def verify_logic(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=request.query,
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=False,
             domain="LOGIC"
         )
@@ -430,7 +445,7 @@ async def verify_stats(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=query,
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=dr.is_authoritative
             and dr.developer_fields.get("is_valid") is True,
             domain="STATS"
@@ -451,7 +466,7 @@ async def verify_stats(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=query,
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=False,
             domain="STATS"
         )
@@ -511,7 +526,7 @@ async def verify_fact(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=claim,
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=dr.is_authoritative,
             domain="FACT"
         )
@@ -531,7 +546,7 @@ async def verify_fact(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=claim,
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=False,
             domain="FACT"
         )
@@ -572,7 +587,7 @@ async def verify_code(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=code[:200],
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=dr.developer_fields.get("is_valid") is True,
             domain="CODE"
         )
@@ -594,7 +609,7 @@ async def verify_code(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=(code or "")[:200],
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=False,
             domain="CODE"
         )
@@ -714,7 +729,7 @@ async def verify_math(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=expression,
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=dr.is_authoritative,
             domain="MATH"
         )
@@ -734,7 +749,7 @@ async def verify_math(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=expression,
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=False,
             domain="MATH"
         )
@@ -779,7 +794,7 @@ async def verify_sql(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=query,
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=dr.is_authoritative,
             domain="SQL"
         )
@@ -801,7 +816,7 @@ async def verify_sql(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=query,
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=False,
             domain="SQL"
         )
@@ -855,7 +870,7 @@ async def verify_image(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=f"Image claim: {claim}",
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=dr.is_authoritative,
             domain="IMAGE"
         )
@@ -875,7 +890,7 @@ async def verify_image(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=f"Image claim: {claim}",
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=False,
             domain="IMAGE"
         )
@@ -951,7 +966,7 @@ async def verify_rag(
             log = VerificationLog(
                 organization_id=tenant.organization_id,
                 query=f"RAG Document Verify: {request.target_document_id}",
-                result=str(dr.to_dict()),
+                result=_cap_log_result(dr.to_dict()),
                 is_verified=False,
                 domain="RAG"
             )
@@ -975,7 +990,7 @@ async def verify_rag(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=f"RAG Document Verify: {request.target_document_id}",
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=dr.is_authoritative,
             domain="RAG"
         )
@@ -996,7 +1011,7 @@ async def verify_rag(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=f"RAG Document Verify: {doc_id}",
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=False,
             domain="RAG"
         )
@@ -1060,7 +1075,7 @@ async def verify_process(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=f"Process Verification ({request.mode})",
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=dr.is_authoritative,
             domain="PROCESS"
         )
@@ -1080,7 +1095,7 @@ async def verify_process(
         log = VerificationLog(
             organization_id=tenant.organization_id,
             query=f"Process Verification ({request.mode})",
-            result=str(dr.to_dict()),
+            result=_cap_log_result(dr.to_dict()),
             is_verified=False,
             domain="PROCESS"
         )

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -303,11 +303,12 @@ def _cap_log_result(result_dict) -> str:
         return json.dumps({"truncated": True, "unserializable": True})
     if total <= _MAX_LOG_RESULT_CHARS:
         return "".join(parts)
-    preview = (
-        "".join(parts)[:_MAX_LOG_RESULT_CHARS]
-        .replace("\\", "?")
-        .replace('"', "'")
-    )
+    preview = "".join(parts)[:_MAX_LOG_RESULT_CHARS]
+    # strip control characters AND JSON-escapable characters before embedding:
+    # escaped control chars expand to 2-6 characters each (CodeRabbit on
+    # PR #351), so the sanitized preview keeps the fallback inside the cap
+    preview = "".join(ch if ch.isprintable() else "?" for ch in preview)
+    preview = preview.replace("\\", "?").replace('"', "'")
     return json.dumps({"truncated": True, "preview": preview})
 
 

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -29,6 +29,7 @@ from qwed_new.core.tenant_context import get_current_tenant, TenantContext
 from qwed_new.core.database import create_db_and_tables, get_session
 from qwed_new.core.models import VerificationLog, ApiKey, User
 from qwed_new.core.rate_limiter import check_rate_limit
+from qwed_new.core.json_bounding import bound_json_value
 
 # Import auth router
 from qwed_new.auth import auth_router
@@ -223,60 +224,13 @@ def get_optional_api_key_record(
 _MAX_LOG_RESULT_CHARS = 64_000
 _MAX_LOG_RESULT_STRING_CHARS = 1_000
 # Aggregate traversal budget (Greptile P1 on PR #351): stop cloning the
-# structure once enough bounded content has been retained, so a request with
-# very many small values cannot drive unbounded traversal on the event loop.
+# structure once enough bounded content has been retained, so a request
+# with very many small values cannot drive unbounded traversal on the
+# event loop. The bounding traversal itself lives in
+# qwed_new.core.json_bounding, shared with stats_verifier (Sonar: the two
+# copies had already diverged).
 _LOG_BOUND_BUDGET_CHARS = 2 * _MAX_LOG_RESULT_CHARS
 
-
-def _bound_log_strings(value, seen=None, budget=None):
-    """Truncate long strings pre-encoding (Greptile P2 on PR #351).
-
-    iterencode emits a JSON string value as a SINGLE token, so an unbounded
-    string inside the dict would be fully materialized before the size cap
-    could run. Bounding first keeps every chunk small. RecursionError from a
-    circular reference is caught by the caller like other encode failures.
-    """
-    if budget is None:
-        budget = [_LOG_BOUND_BUDGET_CHARS]
-    if budget[0] <= 0:
-        return "...[audit truncated]"
-    if isinstance(value, str):
-        if len(value) <= _MAX_LOG_RESULT_STRING_CHARS:
-            budget[0] -= len(value)
-            return value
-        budget[0] -= _MAX_LOG_RESULT_STRING_CHARS
-        return value[:_MAX_LOG_RESULT_STRING_CHARS] + "...[truncated]"
-    if isinstance(value, dict):
-        seen = set() if seen is None else seen
-        if id(value) in seen:
-            return "...[circular]"
-        seen.add(id(value))
-        try:
-            out = {}
-            for k, v in value.items():
-                out[k] = _bound_log_strings(v, seen, budget)
-                if budget[0] <= 0:
-                    out["...audit truncated"] = True
-                    break
-            return out
-        finally:
-            seen.discard(id(value))
-    if isinstance(value, list):
-        seen = set() if seen is None else seen
-        if id(value) in seen:
-            return "...[circular]"
-        seen.add(id(value))
-        try:
-            out = []
-            for v in value:
-                out.append(_bound_log_strings(v, seen, budget))
-                if budget[0] <= 0:
-                    out.append("...audit truncated")
-                    break
-            return out
-        finally:
-            seen.discard(id(value))
-    return value
 
 
 def _cap_log_result(result_dict) -> str:
@@ -285,15 +239,23 @@ def _cap_log_result(result_dict) -> str:
     The audit integrity verifier decodes this field with json.loads
     (audit_logger._decode_result_payload — malformed payloads raise
     SecurityError), so both paths must emit VALID JSON, not Python repr.
-    Serialization is streamed and aggregate-bounded so an oversized dict
-    never materializes in memory, and the fallback stays inside the cap: the
-    preview is sanitized of JSON-escapable characters BEFORE embedding, so
-    escaping cannot re-expand it (CodeRabbit on PR #351).
+    Serialization is streamed and aggregate-bounded (see
+    qwed_new.core.json_bounding) so an oversized dict never materializes in
+    memory, and the fallback stays strictly inside the cap: the envelope
+    length is reserved before slicing, the preview is sanitized of
+    non-printable and JSON-escapable characters, and ensure_ascii=False keeps
+    printable non-ASCII at 1 char each (CodeRabbit on PR #351).
     """
     parts = []
     total = 0
     try:
-        bounded = _bound_log_strings(result_dict)
+        bounded = bound_json_value(
+            result_dict,
+            max_string_chars=_MAX_LOG_RESULT_STRING_CHARS,
+            budget_chars=_LOG_BOUND_BUDGET_CHARS,
+            string_marker="...[truncated]",
+            budget_marker="...audit truncated",
+        )
         for chunk in json.JSONEncoder(default=str).iterencode(bounded):
             parts.append(chunk)
             total += len(chunk)
@@ -303,13 +265,14 @@ def _cap_log_result(result_dict) -> str:
         return json.dumps({"truncated": True, "unserializable": True})
     if total <= _MAX_LOG_RESULT_CHARS:
         return "".join(parts)
-    preview = "".join(parts)[:_MAX_LOG_RESULT_CHARS]
-    # strip control characters AND JSON-escapable characters before embedding:
-    # escaped control chars expand to 2-6 characters each (CodeRabbit on
-    # PR #351), so the sanitized preview keeps the fallback inside the cap
+    envelope = json.dumps({"truncated": True, "preview": ""})
+    preview = "".join(parts)[:(_MAX_LOG_RESULT_CHARS - len(envelope))]
+    # strip control characters AND JSON-escapable characters: with both gone,
+    # ensure_ascii=False encodes the preview exactly 1 char per char, so the
+    # stored payload is envelope + preview <= _MAX_LOG_RESULT_CHARS
     preview = "".join(ch if ch.isprintable() else "?" for ch in preview)
     preview = preview.replace("\\", "?").replace('"', "'")
-    return json.dumps({"truncated": True, "preview": preview})
+    return json.dumps({"truncated": True, "preview": preview}, ensure_ascii=False)
 
 
 _METRICS_OPERATOR_ENV_VAR = "QWED_METRICS_OPERATOR_USER_IDS"

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -228,17 +228,30 @@ def _cap_log_result(result_dict) -> str:
 
     The audit integrity verifier decodes this field with json.loads
     (audit_logger._decode_result_payload — malformed payloads raise
-    SecurityError), so both paths must emit VALID JSON, not Python repr
-    (CodeAnt on PR #351).
+    SecurityError), so both paths must emit VALID JSON, not Python repr.
+    Serialization is streamed so an oversized dict never materializes in
+    memory, and the fallback stays inside the cap: the preview is sanitized
+    of JSON-escapable characters BEFORE embedding, so escaping cannot
+    re-expand it (CodeRabbit on PR #351).
     """
-    text = json.dumps(result_dict, default=str)
-    if len(text) <= _MAX_LOG_RESULT_CHARS:
-        return text
-    return json.dumps({
-        "truncated": True,
-        "serialized_chars": len(text),
-        "preview": text[:_MAX_LOG_RESULT_CHARS],
-    }, default=str)
+    parts = []
+    total = 0
+    try:
+        for chunk in json.JSONEncoder(default=str).iterencode(result_dict):
+            parts.append(chunk)
+            total += len(chunk)
+            if total > _MAX_LOG_RESULT_CHARS:
+                break
+    except (TypeError, ValueError):
+        return json.dumps({"truncated": True, "unserializable": True})
+    if total <= _MAX_LOG_RESULT_CHARS:
+        return "".join(parts)
+    preview = (
+        "".join(parts)[:_MAX_LOG_RESULT_CHARS]
+        .replace("\\", "?")
+        .replace('"', "'")
+    )
+    return json.dumps({"truncated": True, "preview": preview})
 
 
 _METRICS_OPERATOR_ENV_VAR = "QWED_METRICS_OPERATOR_USER_IDS"

--- a/src/qwed_new/core/json_bounding.py
+++ b/src/qwed_new/core/json_bounding.py
@@ -1,0 +1,121 @@
+"""Pre-encode JSON bounding for bounded audit surfaces (issues #338/#339).
+
+Shared by the VerificationLog cap (api.main._cap_log_result) and the stats
+observed_result cap (stats_verifier._cap_observed_result). Three properties,
+each from a PR #351 review round:
+
+- Strings are bounded BEFORE encoding: iterencode emits a string value as a
+  single token, so an unbounded string would be fully materialized despite
+  the streaming output cap (Greptile P2).
+- Aggregates carry a shared traversal budget: a payload of many small values
+  must not drive unbounded cloning before the cap applies (Greptile P1).
+- Cycles — in dicts OR lists — degrade to inline "...[circular]" markers
+  instead of RecursionError (Sentry LOW).
+
+Cognitive complexity is kept per-function (Sonar) by splitting the traversal
+into per-type helpers.
+"""
+
+from typing import Any, List, Optional, Set
+
+CYCLE_MARKER = "...[circular]"
+
+
+def bound_json_value(
+    value: Any,
+    *,
+    max_string_chars: int,
+    budget_chars: int,
+    string_marker: str,
+    budget_marker: str,
+) -> Any:
+    """Return a bounded copy of *value* under the given caps."""
+    return _bound(
+        value,
+        set(),
+        [budget_chars],
+        max_string_chars,
+        string_marker,
+        budget_marker,
+    )
+
+
+def _bound(
+    value: Any,
+    seen: Set[int],
+    budget: List[int],
+    max_string: int,
+    string_marker: str,
+    budget_marker: str,
+) -> Any:
+    if budget[0] <= 0:
+        return budget_marker
+    if isinstance(value, str):
+        return _bound_string(value, budget, max_string, string_marker)
+    if isinstance(value, dict):
+        return _bound_dict(value, seen, budget, max_string, string_marker, budget_marker)
+    if isinstance(value, (list, tuple)):
+        return _bound_list(value, seen, budget, max_string, string_marker, budget_marker)
+    return value
+
+
+def _bound_string(value: str, budget: List[int], max_string: int, string_marker: str) -> str:
+    if len(value) <= max_string:
+        budget[0] -= len(value)
+        return value
+    budget[0] -= max_string
+    return value[:max_string] + string_marker
+
+
+def _bound_container_enter(value: Any, seen: Set[int]) -> bool:
+    """Register *value* for cycle detection; False when already visited."""
+    if id(value) in seen:
+        return False
+    seen.add(id(value))
+    return True
+
+
+def _bound_dict(
+    value: dict,
+    seen: Set[int],
+    budget: List[int],
+    max_string: int,
+    string_marker: str,
+    budget_marker: str,
+) -> dict:
+    if not _bound_container_enter(value, seen):
+        return CYCLE_MARKER
+    try:
+        out = {}
+        for k, v in value.items():
+            # str(k): a non-string key must not TypeError the whole payload
+            # into the unserializable fallback (CodeRabbit on PR #351)
+            out[str(k)] = _bound(v, seen, budget, max_string, string_marker, budget_marker)
+            if budget[0] <= 0:
+                out[budget_marker] = True
+                break
+        return out
+    finally:
+        seen.discard(id(value))
+
+
+def _bound_list(
+    value: Any,
+    seen: Set[int],
+    budget: List[int],
+    max_string: int,
+    string_marker: str,
+    budget_marker: str,
+) -> list:
+    if not _bound_container_enter(value, seen):
+        return CYCLE_MARKER
+    try:
+        out = []
+        for v in value:
+            out.append(_bound(v, seen, budget, max_string, string_marker, budget_marker))
+            if budget[0] <= 0:
+                out.append(budget_marker)
+                break
+        return out
+    finally:
+        seen.discard(id(value))

--- a/src/qwed_new/core/json_bounding.py
+++ b/src/qwed_new/core/json_bounding.py
@@ -16,7 +16,7 @@ Cognitive complexity is kept per-function (Sonar) by splitting the traversal
 into per-type helpers.
 """
 
-from typing import Any, List, Optional, Set
+from typing import Any, List, Set
 
 CYCLE_MARKER = "...[circular]"
 

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -568,7 +568,9 @@ try:
         with open('/workspace/result.json', 'w') as f:
             for chunk in QwedEncoder().iterencode(payload):
                 total += len(chunk)
-                if total > {self.max_result_bytes}:
+                # a string value is emitted as a single token — reject it
+                # immediately rather than materializing it in full
+                if total > {self.max_result_bytes} or len(chunk) > {self.max_result_bytes}:
                     exceeded = True
                     break
                 f.write(chunk)

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -348,23 +348,23 @@ class SecureCodeExecutor:
         # post-creation lifecycle. One kwargs dict shared by both create calls
         # (CodeRabbit: a limit added to only one copy would silently miss the
         # pull-retry path).
-        create_kwargs = dict(
-            image=self.image,
-            command=cmd,
-            volumes={tmpdir: {'bind': '/workspace', 'mode': 'rw'}},
-            mem_limit=self.memory_limit,
-            cpu_period=100000,
-            cpu_quota=int(self.cpu_limit * 100000),
-            network_mode="none",  # No internet access
+        create_kwargs = {
+            "image": self.image,
+            "command": cmd,
+            "volumes": {tmpdir: {'bind': '/workspace', 'mode': 'rw'}},
+            "mem_limit": self.memory_limit,
+            "cpu_period": 100000,
+            "cpu_quota": int(self.cpu_limit * 100000),
+            "network_mode": "none",  # No internet access
             # #338: the daemon's default json-file driver is unbounded —
             # sandbox stdout grows on the daemon HOST, outside every
             # container resource limit, until the disk fills.
-            log_config=LogConfig(
+            "log_config": LogConfig(
                 type=LogConfig.types.JSON,
                 config={"max-size": "10m", "max-file": "1"},
             ),
-            pids_limit=self.pids_limit,
-        )
+            "pids_limit": self.pids_limit,
+        }
         try:
             container = self.client.containers.create(**create_kwargs)
         except docker.errors.ImageNotFound:

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -340,7 +340,12 @@ class SecureCodeExecutor:
         # Use pre-built pandas image
         cmd = "python /workspace/script.py"
 
-        container = self.client.containers.run(
+        # Create first, start INSIDE the cleanup scope (#351 review): the SDK's
+        # containers.run() creates the container and only then starts it, so a
+        # start failure raised before our finally existed and leaked the created
+        # container. With create() + start(), the finally covers the whole
+        # post-creation lifecycle.
+        container = self.client.containers.create(
             image=self.image,
             command=cmd,
             volumes={tmpdir: {'bind': '/workspace', 'mode': 'rw'}},
@@ -356,22 +361,22 @@ class SecureCodeExecutor:
                 config={"max-size": "10m", "max-file": "1"},
             ),
             pids_limit=self.pids_limit,
-            remove=False,  # removed explicitly in the finally below
-            detach=True,  # Run in background
         )
 
         try:
-            # Wait for completion with timeout
-            # Note: docker-py wait() timeout is in seconds since v3.0.0
-            container.wait(timeout=self.timeout)
-            return container
-        except Exception as e:
-            logger.warning(f"Container timeout or error: {e}")
+            container.start()
             try:
-                container.kill()
-            except Exception:
-                logger.debug("Failed to kill container after timeout", exc_info=True)
-            raise ExecutionError(f"Execution timed out after {self.timeout}s") from e
+                # Wait for completion with timeout
+                # Note: docker-py wait() timeout is in seconds since v3.0.0
+                container.wait(timeout=self.timeout)
+            except Exception as e:
+                logger.warning(f"Container timeout or error: {e}")
+                try:
+                    container.kill()
+                except Exception:
+                    logger.debug("Failed to kill container after timeout", exc_info=True)
+                raise ExecutionError(f"Execution timed out after {self.timeout}s") from e
+            return container
         finally:
             # #338: every execution must leave no container behind — a stopped
             # container keeps its full json-file log on the daemon host
@@ -529,18 +534,24 @@ try:
             payload = {{'result': res.to_dict(orient='records')}}
         else:
             payload = {{'result': res}}
-        blob = json.dumps(payload, cls=QwedEncoder)
-        if len(blob) > {self.max_result_bytes}:
-            # #339: reject oversized results INSIDE the container — a
-            # reference-multiplied payload stays under the container memory
-            # cap while its serialized JSON grows unboundedly on disk.
-            blob = json.dumps({{'error': 'Result exceeds maximum allowed size'}}, cls=QwedEncoder)
+        # #339: stream-serialize and abort at the cap. A one-shot json.dumps
+        # would fully materialize the escaped expansion in container memory
+        # before any size check could run; iterencode emits lazily so memory
+        # stays bounded. ensure_ascii keeps len(chunk) == bytes on disk.
+        total = 0
+        exceeded = False
+        with open('/workspace/result.json', 'w') as f:
+            for chunk in QwedEncoder().iterencode(payload):
+                total += len(chunk)
+                if total > {self.max_result_bytes}:
+                    exceeded = True
+                    break
+                f.write(chunk)
+        if exceeded:
             with open('/workspace/result.json', 'w') as f:
-                f.write(blob)
+                f.write(json.dumps({{'error': 'Result exceeds maximum allowed size'}}))
             print('Result exceeds maximum allowed size', file=sys.stderr)
             sys.exit(1)
-        with open('/workspace/result.json', 'w') as f:
-            f.write(blob)
     else:
         with open('/workspace/result.json', 'w') as f:
             json.dump({{'error': 'Code did not set result variable'}}, f)

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -345,45 +345,35 @@ class SecureCodeExecutor:
         # containers.run() creates the container and only then starts it, so a
         # start failure raised before our finally existed and leaked the created
         # container. With create() + start(), the finally covers the whole
-        # post-creation lifecycle.
+        # post-creation lifecycle. One kwargs dict shared by both create calls
+        # (CodeRabbit: a limit added to only one copy would silently miss the
+        # pull-retry path).
+        create_kwargs = dict(
+            image=self.image,
+            command=cmd,
+            volumes={tmpdir: {'bind': '/workspace', 'mode': 'rw'}},
+            mem_limit=self.memory_limit,
+            cpu_period=100000,
+            cpu_quota=int(self.cpu_limit * 100000),
+            network_mode="none",  # No internet access
+            # #338: the daemon's default json-file driver is unbounded —
+            # sandbox stdout grows on the daemon HOST, outside every
+            # container resource limit, until the disk fills.
+            log_config=LogConfig(
+                type=LogConfig.types.JSON,
+                config={"max-size": "10m", "max-file": "1"},
+            ),
+            pids_limit=self.pids_limit,
+        )
         try:
-            container = self.client.containers.create(
-                image=self.image,
-                command=cmd,
-                volumes={tmpdir: {'bind': '/workspace', 'mode': 'rw'}},
-                mem_limit=self.memory_limit,
-                cpu_period=100000,
-                cpu_quota=int(self.cpu_limit * 100000),
-                network_mode="none",  # No internet access
-                # #338: the daemon's default json-file driver is unbounded —
-                # sandbox stdout grows on the daemon HOST, outside every
-                # container resource limit, until the disk fills.
-                log_config=LogConfig(
-                    type=LogConfig.types.JSON,
-                    config={"max-size": "10m", "max-file": "1"},
-                ),
-                pids_limit=self.pids_limit,
-            )
+            container = self.client.containers.create(**create_kwargs)
         except docker.errors.ImageNotFound:
             # containers.run() auto-pulled a missing image; create() does not
             # (CI never pre-pulls the sandbox image). Pull, then retry — the
             # 404 means no container was created, so no cleanup is owed.
             logger.info("Sandbox image %s missing; pulling", self.image)
             self.client.images.pull(self.image)
-            container = self.client.containers.create(
-                image=self.image,
-                command=cmd,
-                volumes={tmpdir: {'bind': '/workspace', 'mode': 'rw'}},
-                mem_limit=self.memory_limit,
-                cpu_period=100000,
-                cpu_quota=int(self.cpu_limit * 100000),
-                network_mode="none",  # No internet access
-                log_config=LogConfig(
-                    type=LogConfig.types.JSON,
-                    config={"max-size": "10m", "max-file": "1"},
-                ),
-                pids_limit=self.pids_limit,
-            )
+            container = self.client.containers.create(**create_kwargs)
 
         try:
             container.start()

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -345,23 +345,44 @@ class SecureCodeExecutor:
         # start failure raised before our finally existed and leaked the created
         # container. With create() + start(), the finally covers the whole
         # post-creation lifecycle.
-        container = self.client.containers.create(
-            image=self.image,
-            command=cmd,
-            volumes={tmpdir: {'bind': '/workspace', 'mode': 'rw'}},
-            mem_limit=self.memory_limit,
-            cpu_period=100000,
-            cpu_quota=int(self.cpu_limit * 100000),
-            network_mode="none",  # No internet access
-            # #338: the daemon's default json-file driver is unbounded —
-            # sandbox stdout grows on the daemon HOST, outside every
-            # container resource limit, until the disk fills.
-            log_config=LogConfig(
-                type=LogConfig.types.JSON,
-                config={"max-size": "10m", "max-file": "1"},
-            ),
-            pids_limit=self.pids_limit,
-        )
+        try:
+            container = self.client.containers.create(
+                image=self.image,
+                command=cmd,
+                volumes={tmpdir: {'bind': '/workspace', 'mode': 'rw'}},
+                mem_limit=self.memory_limit,
+                cpu_period=100000,
+                cpu_quota=int(self.cpu_limit * 100000),
+                network_mode="none",  # No internet access
+                # #338: the daemon's default json-file driver is unbounded —
+                # sandbox stdout grows on the daemon HOST, outside every
+                # container resource limit, until the disk fills.
+                log_config=LogConfig(
+                    type=LogConfig.types.JSON,
+                    config={"max-size": "10m", "max-file": "1"},
+                ),
+                pids_limit=self.pids_limit,
+            )
+        except docker.errors.ImageNotFound:
+            # containers.run() auto-pulled a missing image; create() does not
+            # (CI never pre-pulls the sandbox image). Pull, then retry — the
+            # 404 means no container was created, so no cleanup is owed.
+            logger.info("Sandbox image %s missing; pulling", self.image)
+            self.client.images.pull(self.image)
+            container = self.client.containers.create(
+                image=self.image,
+                command=cmd,
+                volumes={tmpdir: {'bind': '/workspace', 'mode': 'rw'}},
+                mem_limit=self.memory_limit,
+                cpu_period=100000,
+                cpu_quota=int(self.cpu_limit * 100000),
+                network_mode="none",  # No internet access
+                log_config=LogConfig(
+                    type=LogConfig.types.JSON,
+                    config={"max-size": "10m", "max-file": "1"},
+                ),
+                pids_limit=self.pids_limit,
+            )
 
         try:
             container.start()
@@ -381,7 +402,10 @@ class SecureCodeExecutor:
             # #338: every execution must leave no container behind — a stopped
             # container keeps its full json-file log on the daemon host
             # indefinitely. Result read-back uses the mounted result.json,
-            # never container logs, so removal here is safe.
+            # never container logs, so removal here is safe. Removal failure
+            # FAILS CLOSED (CodeRabbit on PR #351): a successful verdict must
+            # not silently coexist with a leaked container; execute() maps the
+            # raise to a non-success outcome.
             try:
                 container.remove(force=True)
             except Exception:
@@ -389,6 +413,7 @@ class SecureCodeExecutor:
                     "Failed to remove sandbox container for %s", execution_id,
                     exc_info=True,
                 )
+                raise
     
     def _is_safe_code(self, code: str) -> DiagnosticResult:
         """

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -11,6 +11,7 @@ Provides sandboxed execution of LLM-generated code with:
 
 import ast
 import docker
+from docker.types import LogConfig
 import tempfile
 import json
 import os
@@ -230,6 +231,15 @@ class SecureCodeExecutor:
         self.cpu_limit = 0.5  # 50% of one CPU core
         self.memory_limit = "512m"  # 512 MB
         self.timeout = 10  # seconds
+        # #338: process count is the last kernel resource the container
+        # config left unbounded — a gate-passing fork bomb allocates host
+        # PIDs up to kernel.pid_max for the whole execution window.
+        self.pids_limit = 128
+        # #339: result.json read-back cap. json.load reads the whole file
+        # plus the decoded value into this process; gate-passing code can
+        # multiply references under the container memory cap to grow the
+        # on-disk JSON unboundedly.
+        self.max_result_bytes = 2 * 1024 * 1024
         self.execution_count = 0
         
         # Docker image to use
@@ -285,6 +295,14 @@ class SecureCodeExecutor:
                     # 4. Parse result
                     result_file = os.path.join(tmpdir, "result.json")
                     if os.path.exists(result_file):
+                        # #339: size-check BEFORE reading — json.load holds the
+                        # whole file plus the decoded value in this process,
+                        # parsed synchronously on the event loop. The wrapper
+                        # enforces the same cap, so reaching this branch with
+                        # an oversized file means the cap was bypassed.
+                        if os.path.getsize(result_file) > self.max_result_bytes:
+                            logger.warning("Result file exceeds size cap for %s", execution_id)
+                            return False, "Result exceeds maximum allowed size", None
                         with open(result_file, 'r') as f:
                             result_data = json.load(f)
                         
@@ -321,7 +339,7 @@ class SecureCodeExecutor:
         
         # Use pre-built pandas image
         cmd = "python /workspace/script.py"
-        
+
         container = self.client.containers.run(
             image=self.image,
             command=cmd,
@@ -330,10 +348,18 @@ class SecureCodeExecutor:
             cpu_period=100000,
             cpu_quota=int(self.cpu_limit * 100000),
             network_mode="none",  # No internet access
-            remove=False,  # Keep so we can check status/logs
+            # #338: the daemon's default json-file driver is unbounded —
+            # sandbox stdout grows on the daemon HOST, outside every
+            # container resource limit, until the disk fills.
+            log_config=LogConfig(
+                type=LogConfig.types.JSON,
+                config={"max-size": "10m", "max-file": "1"},
+            ),
+            pids_limit=self.pids_limit,
+            remove=False,  # removed explicitly in the finally below
             detach=True,  # Run in background
         )
-        
+
         try:
             # Wait for completion with timeout
             # Note: docker-py wait() timeout is in seconds since v3.0.0
@@ -346,6 +372,18 @@ class SecureCodeExecutor:
             except Exception:
                 logger.debug("Failed to kill container after timeout", exc_info=True)
             raise ExecutionError(f"Execution timed out after {self.timeout}s") from e
+        finally:
+            # #338: every execution must leave no container behind — a stopped
+            # container keeps its full json-file log on the daemon host
+            # indefinitely. Result read-back uses the mounted result.json,
+            # never container logs, so removal here is safe.
+            try:
+                container.remove(force=True)
+            except Exception:
+                logger.warning(
+                    "Failed to remove sandbox container for %s", execution_id,
+                    exc_info=True,
+                )
     
     def _is_safe_code(self, code: str) -> DiagnosticResult:
         """
@@ -482,16 +520,27 @@ for key, value in context.items():
 try:
     # User code executes here
 {self._indent_code(user_code, spaces=4)}
-    
+
     # Save result (user code should set 'result' variable)
     if 'result' in globals():
         res = globals()['result']
+        # Handle DataFrame results
+        if hasattr(res, 'to_dict'):
+            payload = {{'result': res.to_dict(orient='records')}}
+        else:
+            payload = {{'result': res}}
+        blob = json.dumps(payload, cls=QwedEncoder)
+        if len(blob) > {self.max_result_bytes}:
+            # #339: reject oversized results INSIDE the container — a
+            # reference-multiplied payload stays under the container memory
+            # cap while its serialized JSON grows unboundedly on disk.
+            blob = json.dumps({{'error': 'Result exceeds maximum allowed size'}}, cls=QwedEncoder)
+            with open('/workspace/result.json', 'w') as f:
+                f.write(blob)
+            print('Result exceeds maximum allowed size', file=sys.stderr)
+            sys.exit(1)
         with open('/workspace/result.json', 'w') as f:
-            # Handle DataFrame results
-            if hasattr(res, 'to_dict'):
-                json.dump({{'result': res.to_dict(orient='records')}}, f, cls=QwedEncoder)
-            else:
-                json.dump({{'result': res}}, f, cls=QwedEncoder)
+            f.write(blob)
     else:
         with open('/workspace/result.json', 'w') as f:
             json.dump({{'error': 'Code did not set result variable'}}, f)

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -402,10 +402,14 @@ class SecureCodeExecutor:
             # #338: every execution must leave no container behind — a stopped
             # container keeps its full json-file log on the daemon host
             # indefinitely. Result read-back uses the mounted result.json,
-            # never container logs, so removal here is safe. Removal failure
-            # FAILS CLOSED (CodeRabbit on PR #351): a successful verdict must
-            # not silently coexist with a leaked container; execute() maps the
-            # raise to a non-success outcome.
+            # never container logs, so removal here is safe.
+            #
+            # Cleanup failure is warn-only, NOT fail-closed (deliberate
+            # conflict resolution between two review bots on PR #351): a
+            # removal failure does not remove the leak either way — the only
+            # effect of raising would be discarding a validly computed
+            # verification result (Sentry HIGH). The warning log below is the
+            # operator signal for the resource-hygiene problem; alert on it.
             try:
                 container.remove(force=True)
             except Exception:
@@ -413,7 +417,6 @@ class SecureCodeExecutor:
                     "Failed to remove sandbox container for %s", execution_id,
                     exc_info=True,
                 )
-                raise
     
     def _is_safe_code(self, code: str) -> DiagnosticResult:
         """

--- a/src/qwed_new/core/secure_code_executor.py
+++ b/src/qwed_new/core/secure_code_executor.py
@@ -15,6 +15,7 @@ from docker.types import LogConfig
 import tempfile
 import json
 import os
+import time
 import logging
 from typing import Any, Dict, Tuple, Optional
 
@@ -405,13 +406,22 @@ class SecureCodeExecutor:
             # never container logs, so removal here is safe.
             #
             # Cleanup failure is warn-only, NOT fail-closed (deliberate
-            # conflict resolution between two review bots on PR #351): a
-            # removal failure does not remove the leak either way — the only
-            # effect of raising would be discarding a validly computed
-            # verification result (Sentry HIGH). The warning log below is the
-            # operator signal for the resource-hygiene problem; alert on it.
+            # conflict resolution between three review bots on PR #351):
+            # CodeRabbit wanted fail-closed (CWE-400), Greptile wanted a
+            # retry/reaper, Sentry HIGH correctly noted a removal failure
+            # does not remove the leak either way — raising would only
+            # discard a validly computed verification result. Resolution:
+            # one automatic retry (most removal failures are transient
+            # daemon races right after wait/kill), then a loud warning as
+            # the operator signal — alert on it; a daemon-side reaper
+            # (label-filtered `docker container prune`) remains follow-up
+            # material if leak accumulation is ever observed.
             try:
-                container.remove(force=True)
+                try:
+                    container.remove(force=True)
+                except Exception:
+                    time.sleep(0.5)
+                    container.remove(force=True)
             except Exception:
                 logger.warning(
                     "Failed to remove sandbox container for %s", execution_id,

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -95,13 +95,17 @@ _MAX_OBSERVED_RESULT_JSON_CHARS = 10_000
 def _cap_observed_result(value: Any) -> Any:
     """Return *value* unchanged when small; a bounded preview otherwise.
 
-    Streams the serialization so an oversized value is rejected without fully
-    materializing it in the synchronous event-loop path.
+    Strings are bounded BEFORE encoding (Greptile P2 on PR #351: iterencode
+    emits a string value as a single token, so an unbounded string would be
+    fully materialized despite the streaming cap), then serialization is
+    streamed so an oversized structure never fully materializes on the
+    synchronous event-loop path.
     """
     try:
         parts = []
         total = 0
-        for chunk in json.JSONEncoder().iterencode(value):
+        bounded = _bound_observed_strings(value, set())
+        for chunk in json.JSONEncoder().iterencode(bounded):
             parts.append(chunk)
             total += len(chunk)
             if total > _MAX_OBSERVED_RESULT_JSON_CHARS:
@@ -109,8 +113,26 @@ def _cap_observed_result(value: Any) -> Any:
                     "truncated": True,
                     "preview": ("".join(parts))[:_MAX_OBSERVED_RESULT_JSON_CHARS],
                 }
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, RecursionError):
         return "<unserializable result>"
+    return value
+
+
+def _bound_observed_strings(value: Any, seen: set) -> Any:
+    if isinstance(value, str):
+        if len(value) <= _MAX_OBSERVED_RESULT_JSON_CHARS:
+            return value
+        return value[:_MAX_OBSERVED_RESULT_JSON_CHARS] + "...[truncated]"
+    if isinstance(value, dict):
+        if id(value) in seen:
+            return "...[circular]"
+        seen.add(id(value))
+        try:
+            return {str(k): _bound_observed_strings(v, seen) for k, v in value.items()}
+        finally:
+            seen.discard(id(value))
+    if isinstance(value, (list, tuple)):
+        return [_bound_observed_strings(v, seen) for v in value]
     return value
 
 

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -22,6 +22,7 @@ from importlib.metadata import PackageNotFoundError, version
 import ast
 
 from .diagnostics import AdvisoryCheck, DiagnosticResult, DiagnosticStatus, enforce_trust_decision
+from .json_bounding import bound_json_value
 from .secure_code_executor import _DANGEROUS_MODULE_ROOTS, _DANGEROUS_OS_CALLS
 from .verification_context import (
     Admission,
@@ -119,45 +120,39 @@ def _cap_observed_result(value: Any) -> Any:
     return value
 
 
-def _bound_observed_strings(value: Any, seen: set, budget: list) -> Any:
-    if budget[0] <= 0:
-        return "...[evidence truncated]"
-    if isinstance(value, str):
-        if len(value) <= _MAX_OBSERVED_RESULT_JSON_CHARS:
-            budget[0] -= len(value)
-            return value
-        budget[0] -= _MAX_OBSERVED_RESULT_JSON_CHARS
-        return value[:_MAX_OBSERVED_RESULT_JSON_CHARS] + "...[truncated]"
-    if isinstance(value, dict):
-        if id(value) in seen:
-            return "...[circular]"
-        seen.add(id(value))
-        try:
-            out = {}
-            for k, v in value.items():
-                out[str(k)] = _bound_observed_strings(v, seen, budget)
-                if budget[0] <= 0:
-                    out["...evidence truncated"] = True
-                    break
-            return out
-        finally:
-            seen.discard(id(value))
-    if isinstance(value, (list, tuple)):
-        if id(value) in seen:
-            return "...[circular]"
-        seen.add(id(value))
-        try:
-            out = []
-            for v in value:
-                out.append(_bound_observed_strings(v, seen, budget))
-                if budget[0] <= 0:
-                    out.append("...evidence truncated")
-                    break
-            return out
-        finally:
-            seen.discard(id(value))
-    return value
+def _cap_observed_result(value: Any) -> Any:
+    """Return *value* unchanged when small; a bounded preview otherwise.
 
+    Strings are bounded BEFORE encoding (Greptile P2 on PR #351: iterencode
+    emits a string value as a single token, so an unbounded string would be
+    fully materialized despite the streaming cap), with a shared aggregate
+    traversal budget (Greptile P1: many small values must not drive unbounded
+    cloning), then serialization is streamed so an oversized structure never
+    fully materializes on the synchronous event-loop path. The bounding
+    traversal is shared with api.main's VerificationLog cap (Sonar: the two
+    copies had already diverged).
+    """
+    try:
+        parts = []
+        total = 0
+        bounded = bound_json_value(
+            value,
+            max_string_chars=_MAX_OBSERVED_RESULT_JSON_CHARS,
+            budget_chars=_MAX_OBSERVED_RESULT_JSON_CHARS * 2,
+            string_marker="...[truncated]",
+            budget_marker="...evidence truncated",
+        )
+        for chunk in json.JSONEncoder().iterencode(bounded):
+            parts.append(chunk)
+            total += len(chunk)
+            if total > _MAX_OBSERVED_RESULT_JSON_CHARS:
+                return {
+                    "truncated": True,
+                    "preview": ("".join(parts))[:_MAX_OBSERVED_RESULT_JSON_CHARS],
+                }
+    except (TypeError, ValueError, RecursionError):
+        return "<unserializable result>"
+    return value
 
 def _dataset_fingerprint(df: pd.DataFrame) -> str:
     """Deterministic fingerprint of the input dataset.

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -101,33 +101,6 @@ def _cap_observed_result(value: Any) -> Any:
     fully materialized despite the streaming cap), with a shared aggregate
     traversal budget (Greptile P1: many small values must not drive unbounded
     cloning), then serialization is streamed so an oversized structure never
-    fully materializes on the synchronous event-loop path.
-    """
-    try:
-        parts = []
-        total = 0
-        bounded = _bound_observed_strings(value, set(), [_MAX_OBSERVED_RESULT_JSON_CHARS * 2])
-        for chunk in json.JSONEncoder().iterencode(bounded):
-            parts.append(chunk)
-            total += len(chunk)
-            if total > _MAX_OBSERVED_RESULT_JSON_CHARS:
-                return {
-                    "truncated": True,
-                    "preview": ("".join(parts))[:_MAX_OBSERVED_RESULT_JSON_CHARS],
-                }
-    except (TypeError, ValueError, RecursionError):
-        return "<unserializable result>"
-    return value
-
-
-def _cap_observed_result(value: Any) -> Any:
-    """Return *value* unchanged when small; a bounded preview otherwise.
-
-    Strings are bounded BEFORE encoding (Greptile P2 on PR #351: iterencode
-    emits a string value as a single token, so an unbounded string would be
-    fully materialized despite the streaming cap), with a shared aggregate
-    traversal budget (Greptile P1: many small values must not drive unbounded
-    cloning), then serialization is streamed so an oversized structure never
     fully materializes on the synchronous event-loop path. The bounding
     traversal is shared with api.main's VerificationLog cap (Sonar: the two
     copies had already diverged).

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -97,14 +97,15 @@ def _cap_observed_result(value: Any) -> Any:
 
     Strings are bounded BEFORE encoding (Greptile P2 on PR #351: iterencode
     emits a string value as a single token, so an unbounded string would be
-    fully materialized despite the streaming cap), then serialization is
-    streamed so an oversized structure never fully materializes on the
-    synchronous event-loop path.
+    fully materialized despite the streaming cap), with a shared aggregate
+    traversal budget (Greptile P1: many small values must not drive unbounded
+    cloning), then serialization is streamed so an oversized structure never
+    fully materializes on the synchronous event-loop path.
     """
     try:
         parts = []
         total = 0
-        bounded = _bound_observed_strings(value, set())
+        bounded = _bound_observed_strings(value, set(), [_MAX_OBSERVED_RESULT_JSON_CHARS * 2])
         for chunk in json.JSONEncoder().iterencode(bounded):
             parts.append(chunk)
             total += len(chunk)
@@ -118,17 +119,27 @@ def _cap_observed_result(value: Any) -> Any:
     return value
 
 
-def _bound_observed_strings(value: Any, seen: set) -> Any:
+def _bound_observed_strings(value: Any, seen: set, budget: list) -> Any:
+    if budget[0] <= 0:
+        return "...[evidence truncated]"
     if isinstance(value, str):
         if len(value) <= _MAX_OBSERVED_RESULT_JSON_CHARS:
+            budget[0] -= len(value)
             return value
+        budget[0] -= _MAX_OBSERVED_RESULT_JSON_CHARS
         return value[:_MAX_OBSERVED_RESULT_JSON_CHARS] + "...[truncated]"
     if isinstance(value, dict):
         if id(value) in seen:
             return "...[circular]"
         seen.add(id(value))
         try:
-            return {str(k): _bound_observed_strings(v, seen) for k, v in value.items()}
+            out = {}
+            for k, v in value.items():
+                out[str(k)] = _bound_observed_strings(v, seen, budget)
+                if budget[0] <= 0:
+                    out["...evidence truncated"] = True
+                    break
+            return out
         finally:
             seen.discard(id(value))
     if isinstance(value, (list, tuple)):
@@ -136,7 +147,13 @@ def _bound_observed_strings(value: Any, seen: set) -> Any:
             return "...[circular]"
         seen.add(id(value))
         try:
-            return [_bound_observed_strings(v, seen) for v in value]
+            out = []
+            for v in value:
+                out.append(_bound_observed_strings(v, seen, budget))
+                if budget[0] <= 0:
+                    out.append("...evidence truncated")
+                    break
+            return out
         finally:
             seen.discard(id(value))
     return value

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -83,6 +83,30 @@ def _json_safe(value: Any) -> Any:
         return repr(value)
 
 
+# #339: observed_result lands in developer_fields, which flows into both the
+# VerificationLog row (str(dr.to_dict())) and the response body
+# (merge_diagnostic_result). A reference-multiplied result — e.g.
+# ['\U0001F600' * 12_000_000] * K — stays under the container memory cap while
+# its serialized form grows unboundedly, so the value must be capped at the
+# source rather than trusted downstream.
+_MAX_OBSERVED_RESULT_JSON_CHARS = 10_000
+
+
+def _cap_observed_result(value: Any) -> Any:
+    """Return *value* unchanged when small; a bounded preview otherwise."""
+    try:
+        blob = json.dumps(value)
+    except (TypeError, ValueError):
+        return "<unserializable result>"
+    if len(blob) <= _MAX_OBSERVED_RESULT_JSON_CHARS:
+        return value
+    return {
+        "truncated": True,
+        "serialized_chars": len(blob),
+        "preview": blob[:_MAX_OBSERVED_RESULT_JSON_CHARS],
+    }
+
+
 def _dataset_fingerprint(df: pd.DataFrame) -> str:
     """Deterministic fingerprint of the input dataset.
 
@@ -677,7 +701,7 @@ class StatsVerifier:
             )
 
         execution_evidence = {
-            "observed_result": _json_safe(exec_result.result),
+            "observed_result": _cap_observed_result(_json_safe(exec_result.result)),
             "generated_code": code,
             "columns": columns,
             "dataset_sha256": dataset_sha256,

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -93,18 +93,25 @@ _MAX_OBSERVED_RESULT_JSON_CHARS = 10_000
 
 
 def _cap_observed_result(value: Any) -> Any:
-    """Return *value* unchanged when small; a bounded preview otherwise."""
+    """Return *value* unchanged when small; a bounded preview otherwise.
+
+    Streams the serialization so an oversized value is rejected without fully
+    materializing it in the synchronous event-loop path.
+    """
     try:
-        blob = json.dumps(value)
+        parts = []
+        total = 0
+        for chunk in json.JSONEncoder().iterencode(value):
+            parts.append(chunk)
+            total += len(chunk)
+            if total > _MAX_OBSERVED_RESULT_JSON_CHARS:
+                return {
+                    "truncated": True,
+                    "preview": ("".join(parts))[:_MAX_OBSERVED_RESULT_JSON_CHARS],
+                }
     except (TypeError, ValueError):
         return "<unserializable result>"
-    if len(blob) <= _MAX_OBSERVED_RESULT_JSON_CHARS:
-        return value
-    return {
-        "truncated": True,
-        "serialized_chars": len(blob),
-        "preview": blob[:_MAX_OBSERVED_RESULT_JSON_CHARS],
-    }
+    return value
 
 
 def _dataset_fingerprint(df: pd.DataFrame) -> str:

--- a/src/qwed_new/core/stats_verifier.py
+++ b/src/qwed_new/core/stats_verifier.py
@@ -132,7 +132,13 @@ def _bound_observed_strings(value: Any, seen: set) -> Any:
         finally:
             seen.discard(id(value))
     if isinstance(value, (list, tuple)):
-        return [_bound_observed_strings(v, seen) for v in value]
+        if id(value) in seen:
+            return "...[circular]"
+        seen.add(id(value))
+        try:
+            return [_bound_observed_strings(v, seen) for v in value]
+        finally:
+            seen.discard(id(value))
     return value
 
 

--- a/tests/test_pr5_sandbox_containment.py
+++ b/tests/test_pr5_sandbox_containment.py
@@ -1,0 +1,192 @@
+"""Sandbox containment regression tests (issues #338 + #339).
+
+#338: sandbox containers must cap their stdout log on the daemon host, cap
+host PID allocation, and leave no container behind after any execution.
+#339: the result.json read-back must be size-capped at every hop — inside
+the container wrapper, at the host read-back, in the stats verifier's
+observed_result evidence, and in the VerificationLog audit row.
+"""
+
+import json
+import os
+
+import pytest
+from unittest.mock import MagicMock
+
+from qwed_new.core.secure_code_executor import ExecutionError, SecureCodeExecutor
+from qwed_new.core.stats_verifier import _cap_observed_result
+from qwed_new.api.main import _cap_log_result, _MAX_LOG_RESULT_CHARS
+
+
+def _executor_with_mock_docker():
+    executor = SecureCodeExecutor()
+    executor.docker_available = True
+    executor.client = MagicMock()
+    return executor
+
+
+class TestContainerContainment:
+    """#338: log_config, pids_limit, and guaranteed container removal."""
+
+    def test_run_sets_log_rotation_and_pids_limit(self):
+        executor = _executor_with_mock_docker()
+        executor.client.containers.run.return_value = MagicMock()
+
+        executor._run_in_container("/tmp/does-not-matter", "exec_1")
+
+        kwargs = executor.client.containers.run.call_args.kwargs
+        log_config = kwargs["log_config"]
+        assert log_config.config == {"max-size": "10m", "max-file": "1"}
+        assert kwargs["pids_limit"] == executor.pids_limit == 128
+        # removal is explicit in the finally, not delegated to the daemon
+        assert kwargs["remove"] is False
+
+    def test_container_removed_after_successful_wait(self):
+        executor = _executor_with_mock_docker()
+        container = MagicMock()
+        executor.client.containers.run.return_value = container
+
+        executor._run_in_container("/tmp", "exec_1")
+
+        container.wait.assert_called_once_with(timeout=executor.timeout)
+        container.remove.assert_called_once_with(force=True)
+        container.kill.assert_not_called()
+
+    def test_container_removed_after_timeout_kill(self):
+        executor = _executor_with_mock_docker()
+        container = MagicMock()
+        container.wait.side_effect = Exception("read timeout")
+        executor.client.containers.run.return_value = container
+
+        with pytest.raises(ExecutionError):
+            executor._run_in_container("/tmp", "exec_1")
+
+        container.kill.assert_called_once()
+        container.remove.assert_called_once_with(force=True)
+
+    def test_removal_failure_does_not_mask_successful_execution(self):
+        executor = _executor_with_mock_docker()
+        container = MagicMock()
+        container.remove.side_effect = Exception("daemon hiccup")
+        executor.client.containers.run.return_value = container
+
+        result = executor._run_in_container("/tmp", "exec_1")
+
+        assert result is container
+
+
+class TestHostReadbackCap:
+    """#339: no unbounded json.load on the host."""
+
+    def test_oversized_result_file_rejected_before_parse(self):
+        executor = _executor_with_mock_docker()
+        executor.max_result_bytes = 100  # shrink cap for the test
+
+        def fake_run(tmpdir, execution_id):
+            with open(os.path.join(tmpdir, "result.json"), "w") as f:
+                f.write("A" * 200)
+
+        executor._run_in_container = fake_run
+
+        success, error, result = executor.execute("result = 1", {})
+
+        assert success is False
+        assert error == "Result exceeds maximum allowed size"
+        assert result is None
+
+    def test_normal_result_still_parses(self):
+        executor = _executor_with_docker_and_runner({"result": 4})
+
+        success, error, result = executor.execute("result = 2 + 2", {})
+
+        assert success is True
+        assert result == 4
+
+
+def _executor_with_docker_and_runner(payload):
+    executor = _executor_with_mock_docker()
+
+    def fake_run(tmpdir, execution_id):
+        with open(os.path.join(tmpdir, "result.json"), "w") as f:
+            json.dump(payload, f)
+
+    executor._run_in_container = fake_run
+    return executor
+
+
+class TestWrapperCap:
+    """#339: the in-container wrapper rejects oversized results before write."""
+
+    def _run_wrapper(self, executor, user_code):
+        import subprocess
+        import sys
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # the wrapper hardcodes /workspace; retarget to a portable dir and
+            # run it as a real subprocess — same shape as the container run
+            workspace = tmpdir.replace("\\", "/")
+            with open(os.path.join(tmpdir, "context.json"), "w") as f:
+                json.dump({}, f)
+            wrapped = executor._wrap_code(user_code).replace("/workspace", workspace)
+            script = os.path.join(tmpdir, "script.py")
+            with open(script, "w") as f:
+                f.write(wrapped)
+            proc = subprocess.run(
+                [sys.executable, script],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            with open(os.path.join(tmpdir, "result.json")) as f:
+                return json.load(f), proc.returncode
+
+    def test_oversized_result_rejected_inside_container(self):
+        executor = SecureCodeExecutor()
+        executor.max_result_bytes = 1000
+
+        payload, returncode = self._run_wrapper(executor, "result = 'A' * 5000")
+
+        assert returncode == 1
+        assert payload == {"error": "Result exceeds maximum allowed size"}
+
+    def test_small_result_passes_through(self):
+        executor = SecureCodeExecutor()
+        executor.max_result_bytes = 1000
+
+        payload, returncode = self._run_wrapper(executor, "result = 2 + 2")
+
+        assert returncode == 0
+        assert payload == {"result": 4}
+
+
+class TestObservedResultCap:
+    """#339: stats evidence is capped at the source."""
+
+    def test_small_value_passes_through_unchanged(self):
+        value = {"mean": 3.14, "rows": [1, 2, 3]}
+        assert _cap_observed_result(value) is value
+
+    def test_large_value_replaced_with_bounded_preview(self):
+        value = ["A" * 50_000] * 5
+        capped = _cap_observed_result(value)
+
+        assert capped["truncated"] is True
+        assert capped["serialized_chars"] > 10_000
+        assert len(capped["preview"]) <= 10_000
+        assert len(json.dumps(capped)) < 20_000
+
+
+class TestLogResultCap:
+    """#339: audit rows cannot persist an unbounded serialized result."""
+
+    def test_small_result_unchanged(self):
+        dr = {"status": "VERIFIED", "developer_fields": {"a": 1}}
+        assert _cap_log_result(dr) == str(dr)
+
+    def test_large_result_truncated_with_marker(self):
+        dr = {"status": "UNVERIFIABLE", "blob": "A" * (_MAX_LOG_RESULT_CHARS + 1000)}
+        capped = _cap_log_result(dr)
+
+        assert len(capped) < _MAX_LOG_RESULT_CHARS + 200
+        assert "truncated" in capped

--- a/tests/test_pr5_sandbox_containment.py
+++ b/tests/test_pr5_sandbox_containment.py
@@ -98,15 +98,19 @@ class TestContainerContainment:
         executor.client.images.pull.assert_called_once_with(executor.image)
         assert executor.client.containers.create.call_count == 2
 
-    def test_removal_failure_fails_closed(self):
-        """A leaked container must not coexist with a success verdict."""
+    def test_removal_failure_is_warn_only(self):
+        """Conflict resolution between review bots (PR #351): a removal
+        failure must not discard a validly computed verification result —
+        failing the result would not remove the leaked container either way.
+        The warning log is the operator signal."""
         executor = _executor_with_mock_docker()
         container = MagicMock()
         container.remove.side_effect = Exception("daemon hiccup")
         executor.client.containers.create.return_value = container
 
-        with pytest.raises(Exception, match="daemon hiccup"):
-            executor._run_in_container("/tmp", "exec_1")
+        result = executor._run_in_container("/tmp", "exec_1")
+
+        assert result is container
 
 
 class TestHostReadbackCap:
@@ -266,13 +270,20 @@ class TestLogResultCap:
         json.loads(capped)  # parseability
 
     def test_oversized_output_stays_bounded(self):
-        """Worst case for escaping: a result made of quotes/backslashes."""
-        dr = {"blob": '"' * (_MAX_LOG_RESULT_CHARS + 1000)}
+        """The truncated-document path must stay bounded even when the
+        content is quote-heavy or control-character-heavy (CodeRabbit on
+        PR #351: escaping would otherwise expand the payload past the cap)."""
+        dr = {f"k{i}": '"' * 1000 for i in range(100)}
         capped = _cap_log_result(dr)
-
-        # bare validation: the payload must be parseable JSON
+        assert len(capped) < _MAX_LOG_RESULT_CHARS + 500
         json.loads(capped)
-        assert len(capped) < 5000
+
+        dr = {f"k{i}": "\n" * 1000 for i in range(100)}
+        capped = _cap_log_result(dr)
+        parsed = json.loads(capped)
+        assert parsed["truncated"] is True
+        assert "\n" not in parsed["preview"]
+        assert len(capped) < _MAX_LOG_RESULT_CHARS + 500
 
     def test_circular_reference_yields_bounded_json(self):
         """The bounder breaks the cycle inline; output stays small valid JSON."""

--- a/tests/test_pr5_sandbox_containment.py
+++ b/tests/test_pr5_sandbox_containment.py
@@ -15,7 +15,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from qwed_new.core.secure_code_executor import ExecutionError, SecureCodeExecutor
-from qwed_new.core.stats_verifier import _cap_observed_result
+from qwed_new.core.stats_verifier import _cap_observed_result, _MAX_OBSERVED_RESULT_JSON_CHARS
 from qwed_new.api.main import _cap_log_result, _MAX_LOG_RESULT_CHARS
 
 
@@ -212,6 +212,14 @@ class TestObservedResultCap:
     def test_unserializable_value_falls_back_to_marker(self):
         assert _cap_observed_result({"bad": object()}) == "<unserializable result>"
 
+    def test_aggregate_traversal_budget_stops_cloning(self):
+        """Greptile P1 on PR #351: many small values must not drive unbounded
+        traversal of the aggregate on the event loop."""
+        value = [{"m": "A" * 100} for _ in range(10_000)]  # ~1 MB raw
+        capped = _cap_observed_result(value)
+
+        assert len(json.dumps(capped)) < _MAX_OBSERVED_RESULT_JSON_CHARS * 3
+
 
 class TestLogResultCap:
     """#339: audit rows cannot persist an unbounded serialized result.
@@ -247,6 +255,15 @@ class TestLogResultCap:
         parsed = json.loads(capped)
         assert parsed["truncated"] is True
         assert len(capped) < _MAX_LOG_RESULT_CHARS + 500
+
+    def test_aggregate_traversal_budget_stops_cloning(self):
+        """Greptile P1 on PR #351: many small values must not drive unbounded
+        traversal of the aggregate — the bounder stops at the budget."""
+        dr = {f"k{i}": "A" * 200 for i in range(20_000)}  # ~4 MB raw
+        capped = _cap_log_result(dr)
+
+        assert len(capped) < _MAX_LOG_RESULT_CHARS * 3
+        json.loads(capped)  # parseability
 
     def test_oversized_output_stays_bounded(self):
         """Worst case for escaping: a result made of quotes/backslashes."""

--- a/tests/test_pr5_sandbox_containment.py
+++ b/tests/test_pr5_sandbox_containment.py
@@ -102,15 +102,29 @@ class TestContainerContainment:
         """Conflict resolution between review bots (PR #351): a removal
         failure must not discard a validly computed verification result —
         failing the result would not remove the leaked container either way.
-        The warning log is the operator signal."""
+        One automatic retry absorbs transient daemon races; the warning log
+        is the operator signal if both attempts fail."""
         executor = _executor_with_mock_docker()
         container = MagicMock()
-        container.remove.side_effect = Exception("daemon hiccup")
+        # first attempt fails, retry succeeds
+        container.remove.side_effect = [Exception("daemon race"), None]
         executor.client.containers.create.return_value = container
 
         result = executor._run_in_container("/tmp", "exec_1")
 
         assert result is container
+        assert container.remove.call_count == 2
+
+    def test_removal_retry_exhaustion_is_warn_only(self):
+        executor = _executor_with_mock_docker()
+        container = MagicMock()
+        container.remove.side_effect = Exception("daemon down")
+        executor.client.containers.create.return_value = container
+
+        result = executor._run_in_container("/tmp", "exec_1")
+
+        assert result is container
+        assert container.remove.call_count == 2
 
 
 class TestHostReadbackCap:

--- a/tests/test_pr5_sandbox_containment.py
+++ b/tests/test_pr5_sandbox_containment.py
@@ -253,7 +253,8 @@ class TestLogResultCap:
         dr = {"blob": '"' * (_MAX_LOG_RESULT_CHARS + 1000)}
         capped = _cap_log_result(dr)
 
-        parsed = json.loads(capped)
+        # bare validation: the payload must be parseable JSON
+        json.loads(capped)
         assert len(capped) < 5000
 
     def test_circular_reference_yields_bounded_json(self):
@@ -264,4 +265,14 @@ class TestLogResultCap:
 
         parsed = json.loads(capped)
         assert parsed["self"] == "...[circular]"
+        assert len(capped) < 500
+
+    def test_circular_list_reference_yields_bounded_json(self):
+        """Sentry on PR #351: lists must get the same cycle handling as dicts."""
+        dr = {"status": "VERIFIED", "rows": []}
+        dr["rows"].append(dr["rows"])
+        capped = _cap_log_result(dr)
+
+        parsed = json.loads(capped)
+        assert parsed["rows"] == ["...[circular]"]
         assert len(capped) < 500

--- a/tests/test_pr5_sandbox_containment.py
+++ b/tests/test_pr5_sandbox_containment.py
@@ -82,15 +82,31 @@ class TestContainerContainment:
 
         container.remove.assert_called_once_with(force=True)
 
-    def test_removal_failure_does_not_mask_successful_execution(self):
+    def test_missing_image_is_pulled_then_retried(self):
+        """containers.run() auto-pulled a missing image; create() does not.
+        The create path must preserve that behavior (CI regression)."""
+        executor = _executor_with_mock_docker()
+        container = MagicMock()
+        executor.client.containers.create.side_effect = [
+            docker.errors.ImageNotFound("missing"),
+            container,
+        ]
+
+        result = executor._run_in_container("/tmp", "exec_1")
+
+        assert result is container
+        executor.client.images.pull.assert_called_once_with(executor.image)
+        assert executor.client.containers.create.call_count == 2
+
+    def test_removal_failure_fails_closed(self):
+        """A leaked container must not coexist with a success verdict."""
         executor = _executor_with_mock_docker()
         container = MagicMock()
         container.remove.side_effect = Exception("daemon hiccup")
         executor.client.containers.create.return_value = container
 
-        result = executor._run_in_container("/tmp", "exec_1")
-
-        assert result is container
+        with pytest.raises(Exception, match="daemon hiccup"):
+            executor._run_in_container("/tmp", "exec_1")
 
 
 class TestHostReadbackCap:
@@ -182,7 +198,7 @@ class TestObservedResultCap:
     """#339: stats evidence is capped at the source."""
 
     def test_small_value_passes_through_unchanged(self):
-        value = {"mean": 3.14, "rows": [1, 2, 3]}
+        value = {"mean": 314, "rows": [1, 2, 3]}
         assert _cap_observed_result(value) is value
 
     def test_large_value_replaced_with_bounded_preview(self):
@@ -216,5 +232,23 @@ class TestLogResultCap:
 
         parsed = json.loads(capped)
         assert parsed["truncated"] is True
-        assert parsed["serialized_chars"] > _MAX_LOG_RESULT_CHARS
+        # bounded: sanitized preview + envelope must not exceed ~2x the cap
         assert len(capped) < _MAX_LOG_RESULT_CHARS + 500
+
+    def test_oversized_ouput_stays_bounded(self):
+        """Worst case for escaping: a result made of quotes/backslashes."""
+        dr = {"blob": '"' * (_MAX_LOG_RESULT_CHARS + 1000)}
+        capped = _cap_log_result(dr)
+
+        parsed = json.loads(capped)
+        assert parsed["truncated"] is True
+        assert len(capped) < _MAX_LOG_RESULT_CHARS + 500
+
+    def test_circular_reference_yields_bounded_json(self):
+        dr = {"status": "VERIFIED"}
+        dr["self"] = dr
+        capped = _cap_log_result(dr)
+
+        parsed = json.loads(capped)
+        assert parsed["truncated"] is True
+        assert parsed["unserializable"] is True

--- a/tests/test_pr5_sandbox_containment.py
+++ b/tests/test_pr5_sandbox_containment.py
@@ -226,29 +226,42 @@ class TestLogResultCap:
 
         assert json.loads(capped) == dr
 
-    def test_large_result_truncated_but_still_valid_json(self):
+    def test_large_string_value_bounded_inline(self):
+        """Greptile P2 on PR #351: a string value is a single iterencode
+        token — it must be truncated BEFORE encoding, not after. The output
+        keeps the document structure with the value bounded inline."""
         dr = {"status": "UNVERIFIABLE", "blob": "A" * (_MAX_LOG_RESULT_CHARS + 1000)}
         capped = _cap_log_result(dr)
 
         parsed = json.loads(capped)
+        assert parsed["blob"].endswith("...[truncated]")
+        assert len(parsed["blob"]) <= 1100
+        assert len(capped) < 2000
+
+    def test_aggregate_size_still_hits_the_truncated_document(self):
+        """Many individually-bounded strings summing past the cap produce
+        the bounded preview document."""
+        dr = {f"k{i}": "A" * 1000 for i in range(100)}
+        capped = _cap_log_result(dr)
+
+        parsed = json.loads(capped)
         assert parsed["truncated"] is True
-        # bounded: sanitized preview + envelope must not exceed ~2x the cap
         assert len(capped) < _MAX_LOG_RESULT_CHARS + 500
 
-    def test_oversized_ouput_stays_bounded(self):
+    def test_oversized_output_stays_bounded(self):
         """Worst case for escaping: a result made of quotes/backslashes."""
         dr = {"blob": '"' * (_MAX_LOG_RESULT_CHARS + 1000)}
         capped = _cap_log_result(dr)
 
         parsed = json.loads(capped)
-        assert parsed["truncated"] is True
-        assert len(capped) < _MAX_LOG_RESULT_CHARS + 500
+        assert len(capped) < 5000
 
     def test_circular_reference_yields_bounded_json(self):
+        """The bounder breaks the cycle inline; output stays small valid JSON."""
         dr = {"status": "VERIFIED"}
         dr["self"] = dr
         capped = _cap_log_result(dr)
 
         parsed = json.loads(capped)
-        assert parsed["truncated"] is True
-        assert parsed["unserializable"] is True
+        assert parsed["self"] == "...[circular]"
+        assert len(capped) < 500

--- a/tests/test_pr5_sandbox_containment.py
+++ b/tests/test_pr5_sandbox_containment.py
@@ -272,7 +272,8 @@ class TestLogResultCap:
 
         parsed = json.loads(capped)
         assert parsed["truncated"] is True
-        assert len(capped) < _MAX_LOG_RESULT_CHARS + 500
+        # envelope length reserved before slicing: strictly inside the cap
+        assert len(capped) <= _MAX_LOG_RESULT_CHARS
 
     def test_aggregate_traversal_budget_stops_cloning(self):
         """Greptile P1 on PR #351: many small values must not drive unbounded
@@ -282,6 +283,26 @@ class TestLogResultCap:
 
         assert len(capped) < _MAX_LOG_RESULT_CHARS * 3
         json.loads(capped)  # parseability
+
+    def test_printable_non_ascii_stays_bounded(self):
+        """CodeRabbit envelope follow-up: printable non-ASCII (emoji) escapes
+        to 12 chars under ensure_ascii — the fallback must still hold the
+        cap, so it encodes with ensure_ascii=False after sanitization."""
+        dr = {f"k{i}": "😀" * 2000 for i in range(100)}
+        capped = _cap_log_result(dr)
+
+        parsed = json.loads(capped)
+        assert parsed["truncated"] is True
+        assert len(capped) <= _MAX_LOG_RESULT_CHARS
+
+    def test_non_string_dict_key_does_not_discard_payload(self):
+        """CodeRabbit shared-helper note: a non-string key must not TypeError
+        the whole payload into the unserializable fallback."""
+        dr = {"status": "VERIFIED", 42: "answer"}
+        capped = _cap_log_result(dr)
+
+        parsed = json.loads(capped)
+        assert parsed["42"] == "answer"
 
     def test_oversized_output_stays_bounded(self):
         """The truncated-document path must stay bounded even when the

--- a/tests/test_pr5_sandbox_containment.py
+++ b/tests/test_pr5_sandbox_containment.py
@@ -7,6 +7,7 @@ the container wrapper, at the host read-back, in the stats verifier's
 observed_result evidence, and in the VerificationLog audit row.
 """
 
+import docker
 import json
 import os
 
@@ -28,26 +29,29 @@ def _executor_with_mock_docker():
 class TestContainerContainment:
     """#338: log_config, pids_limit, and guaranteed container removal."""
 
-    def test_run_sets_log_rotation_and_pids_limit(self):
+    def test_create_sets_log_rotation_and_pids_limit(self):
         executor = _executor_with_mock_docker()
-        executor.client.containers.run.return_value = MagicMock()
+        executor.client.containers.create.return_value = MagicMock()
 
         executor._run_in_container("/tmp/does-not-matter", "exec_1")
 
-        kwargs = executor.client.containers.run.call_args.kwargs
+        kwargs = executor.client.containers.create.call_args.kwargs
         log_config = kwargs["log_config"]
         assert log_config.config == {"max-size": "10m", "max-file": "1"}
         assert kwargs["pids_limit"] == executor.pids_limit == 128
-        # removal is explicit in the finally, not delegated to the daemon
-        assert kwargs["remove"] is False
+        # create-then-start (#351 review): the finally must cover start
+        container = executor.client.containers.create.return_value
+        container.start.assert_called_once()
+        container.remove.assert_called_once_with(force=True)
 
     def test_container_removed_after_successful_wait(self):
         executor = _executor_with_mock_docker()
         container = MagicMock()
-        executor.client.containers.run.return_value = container
+        executor.client.containers.create.return_value = container
 
         executor._run_in_container("/tmp", "exec_1")
 
+        container.start.assert_called_once()
         container.wait.assert_called_once_with(timeout=executor.timeout)
         container.remove.assert_called_once_with(force=True)
         container.kill.assert_not_called()
@@ -56,19 +60,33 @@ class TestContainerContainment:
         executor = _executor_with_mock_docker()
         container = MagicMock()
         container.wait.side_effect = Exception("read timeout")
-        executor.client.containers.run.return_value = container
+        executor.client.containers.create.return_value = container
 
         with pytest.raises(ExecutionError):
             executor._run_in_container("/tmp", "exec_1")
 
+        container.start.assert_called_once()
         container.kill.assert_called_once()
+        container.remove.assert_called_once_with(force=True)
+
+    def test_container_removed_when_start_fails(self):
+        """#351 review: run() would create-then-start, leaking the container
+        when start() raises after creation. create() + start() must not."""
+        executor = _executor_with_mock_docker()
+        container = MagicMock()
+        container.start.side_effect = docker.errors.APIError("start failed")
+        executor.client.containers.create.return_value = container
+
+        with pytest.raises(docker.errors.APIError):
+            executor._run_in_container("/tmp", "exec_1")
+
         container.remove.assert_called_once_with(force=True)
 
     def test_removal_failure_does_not_mask_successful_execution(self):
         executor = _executor_with_mock_docker()
         container = MagicMock()
         container.remove.side_effect = Exception("daemon hiccup")
-        executor.client.containers.run.return_value = container
+        executor.client.containers.create.return_value = container
 
         result = executor._run_in_container("/tmp", "exec_1")
 
@@ -172,21 +190,31 @@ class TestObservedResultCap:
         capped = _cap_observed_result(value)
 
         assert capped["truncated"] is True
-        assert capped["serialized_chars"] > 10_000
         assert len(capped["preview"]) <= 10_000
         assert len(json.dumps(capped)) < 20_000
 
+    def test_unserializable_value_falls_back_to_marker(self):
+        assert _cap_observed_result({"bad": object()}) == "<unserializable result>"
+
 
 class TestLogResultCap:
-    """#339: audit rows cannot persist an unbounded serialized result."""
+    """#339: audit rows cannot persist an unbounded serialized result.
 
-    def test_small_result_unchanged(self):
+    The audit integrity verifier decodes this field with json.loads, so the
+    output must be VALID JSON in both paths (CodeAnt on PR #351).
+    """
+
+    def test_small_result_is_valid_json(self):
         dr = {"status": "VERIFIED", "developer_fields": {"a": 1}}
-        assert _cap_log_result(dr) == str(dr)
+        capped = _cap_log_result(dr)
 
-    def test_large_result_truncated_with_marker(self):
+        assert json.loads(capped) == dr
+
+    def test_large_result_truncated_but_still_valid_json(self):
         dr = {"status": "UNVERIFIABLE", "blob": "A" * (_MAX_LOG_RESULT_CHARS + 1000)}
         capped = _cap_log_result(dr)
 
-        assert len(capped) < _MAX_LOG_RESULT_CHARS + 200
-        assert "truncated" in capped
+        parsed = json.loads(capped)
+        assert parsed["truncated"] is True
+        assert parsed["serialized_chars"] > _MAX_LOG_RESULT_CHARS
+        assert len(capped) < _MAX_LOG_RESULT_CHARS + 500

--- a/tests/test_secure_executor_coverage.py
+++ b/tests/test_secure_executor_coverage.py
@@ -117,7 +117,7 @@ class TestDangerousPatternScanner(unittest.TestCase):
         executor.docker_available = True
         executor.client = MagicMock()
         # Mock container run to raise ImageNotFound
-        executor.client.containers.run.side_effect = docker.errors.ImageNotFound("Missing image")
+        executor.client.containers.create.side_effect = docker.errors.ImageNotFound("Missing image")
         
         # We need to bypass the tempdir context manager for the run call to happen
         # or just let it run normally since we only mock the docker call
@@ -130,7 +130,7 @@ class TestDangerousPatternScanner(unittest.TestCase):
         executor = SecureCodeExecutor()
         executor.docker_available = True
         executor.client = MagicMock()
-        executor.client.containers.run.side_effect = docker.errors.ContainerError(
+        executor.client.containers.create.side_effect = docker.errors.ContainerError(
             "container", 1, "cmd", "image", b"stderr"
         )
         
@@ -143,7 +143,7 @@ class TestDangerousPatternScanner(unittest.TestCase):
         executor = SecureCodeExecutor()
         executor.docker_available = True
         executor.client = MagicMock()
-        executor.client.containers.run.side_effect = Exception("Chaos")
+        executor.client.containers.create.side_effect = Exception("Chaos")
         
         success, error, _ = executor.execute("print(1)", {})
         self.assertFalse(success)
@@ -162,7 +162,7 @@ class TestDangerousPatternScanner(unittest.TestCase):
         # kill raises exception
         mock_container.kill.side_effect = Exception("Zombie container")
         
-        executor.client.containers.run.return_value = mock_container
+        executor.client.containers.create.return_value = mock_container
         
         # Should raise ExecutionError but also catch kill exception
         with self.assertRaises(ExecutionError):
@@ -194,7 +194,7 @@ class TestDangerousPatternScanner(unittest.TestCase):
             self.assertIn("Code safety validation failed", error)
             self.assertIn("Code safety verification unavailable", error)
             self.assertIsNone(result)
-            executor.client.containers.run.assert_not_called()
+            executor.client.containers.create.assert_not_called()
 
     def test_execute_import_error_never_authorizes_execution(self):
         """The heuristic fallback is advisory only and must never authorize execution."""
@@ -208,7 +208,7 @@ class TestDangerousPatternScanner(unittest.TestCase):
             self.assertFalse(success)
             self.assertIn("Code safety verification unavailable", error)
             self.assertIsNone(result)
-            executor.client.containers.run.assert_not_called()
+            executor.client.containers.create.assert_not_called()
 
             safety = executor._is_safe_code("import os; result = os.name")
             advisory = safety.advisory_checks[0]


### PR DESCRIPTION
## **User description**
## Summary

Closes #338 and #339 (OpenVuln audit findings BUG-R2-S2-A6-H1/H2/H3, CWE-400/401).

### #338 — sandbox container leaks (CVSS 7.7)

`_run_in_container` configured memory/CPU/network but left three containment gaps:

- **Unbounded stdout logs** — the daemon's default json-file driver has no rotation, so sandbox stdout grows **on the daemon host**, outside every container resource limit (PoC: 2.3 GB in one 10 s window at ~230 MB/s while container memory stayed at ~16 MB). Now: `log_config` json-file rotation, `max-size: 10m`, `max-file: 1`.
- **Never-removed containers** — `remove=False` with zero removal sites anywhere: every execution (benign or malicious) leaked a stopped container plus its full log file indefinitely. Now: `container.remove(force=True)` in a `finally` covering all paths — successful wait, timeout kill, and removal-failure (logged, never masks the execution result). Read-back uses the mounted `result.json`, never container logs, so removal is safe.
- **No `pids_limit`** — process count was the last unbounded kernel resource (gate-passing fork bombs / `multiprocessing.Pool(99999)` allocate host PIDs up to `kernel.pid_max`). Now: `pids_limit=128`.

### #339 — result.json amplification (CVSS 6.5)

The resource contract stopped at the container boundary; the host-side `json.load()` on the container-written `result.json` had no size check. A gate-blind `['\U0001F600' * 12_000_000] * K` payload stays under the 512m container cap while its serialized form grows unboundedly (measured: ~27 OOM-kills/min of the worker in capped deployments, ~99% event-loop stall + 11.5–19.1 MB audit-DB growth per request on bare metal). Now capped at every hop:

1. **Inside the container wrapper** — serialized size checked before `json.dump`; oversized results are rejected with an error document (exit 1), so the amplifier never reaches disk.
2. **Host read-back** — `max_result_bytes` (2 MB) size check before `json.load`.
3. **`observed_result` capped at its source** in `stats_verifier` (10k-char bounded preview) — the field flows into both audit rows and response bodies.
4. **`VerificationLog.result` backstop** — all 20 log sites in `api/main.py` now serialize through a 64k-char cap, so no endpoint can persist an unbounded audit row.

## Tests

12 new regression tests in `tests/test_pr5_sandbox_containment.py`: log-rotation/pids/removal kwargs, removal on success/timeout/removal-failure paths, host read-back cap (and the normal-result pass-through), the in-container wrapper cap exercised by really executing the generated wrapper in a subprocess, observed_result cap, and the log-result cap. Full suite: **2200 passed, 102 skipped**.

## Deploy note

For defense in depth, consider daemon-wide json-file rotation (`/etc/docker/daemon.json` → `{"log-driver": "json-file", "log-opts": {"max-size": "10m", "max-file": "1"}}`) so non-sandbox containers are covered too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security & Reliability**
  - Sandbox executions now limit process counts, log output, result-file reads, and serialized result sizes.
  - Temporary execution containers are removed across successful, failed, timed-out, and interrupted runs; cleanup retries transient failures.
  - Missing sandbox images are retried automatically.
  - Large, circular, or unserializable verification results are safely bounded and recorded with valid audit previews.
  - Statistical verification evidence now handles oversized results safely.

- **Tests**
  - Added regression coverage for resource limits, cleanup guarantees, image recovery, and bounded result handling.
  - Updated execution error-path tests for the current container lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Close sandbox resource leaks and bound verification results

### What Changed
- Sandbox executions now limit host-side logs and process creation, remove containers after success or failure, and clean up containers even when startup fails.
- Oversized execution results are rejected before being written or parsed, preventing large payloads from exhausting worker memory.
- Verification responses and audit records now use valid, bounded JSON snapshots instead of unbounded result strings.
- Large, circular, non-JSON, or deeply aggregated result data is replaced with safe previews or explicit markers while small results remain unchanged.
- Missing sandbox images are pulled and retried without losing the cleanup guarantees.

### Impact
`✅ Fewer leaked sandbox containers`
`✅ Lower host disk and memory usage from oversized results`
`✅ Bounded verification audit records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
