### PR TITLE
chore(release): bump to v7.2.0 with changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Fail-closed fixes restoring intended behavior — no breaking wire changes:
 
 ### Precision advisory (new capability, #347, #348)
 
-- **Advisory flag for binary floating-point constants** in math/stats verification (`precision.advisory`).
+- **Advisory flag for binary floating-point constants** in math/stats verification — emitted as `developer_fields.advisory_checks[]` entries with `constraint_id` `"precision.float-constants"` (also mirrored at top level).
 
 ### Dependency modernization
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the QWED Protocol will be documented in this file.
 
 ## [Unreleased]
 
+## [7.2.0] - 2026-09-07
+
+### Security hardening batch
+
+Fail-closed fixes restoring intended behavior — no breaking wire changes:
+
+- **Expression & math safety (#329, #330, #344)** — `safe_parse_expr` NFKC normalization bypass and denylist bypass fixes (authenticated RCE), plus structural hardening (charset gate, AST allowlist) and a structural math-output gate with module-indirection blocklist (#346).
+- **Auth hardening (#333, #334, #345)** — pre-auth KDF removed from lookup path, bcrypt offloaded, `/auth/*` throttling, brute-force oracle closed.
+- **Sandbox containment (#335, #338, #339, #351)** — module-indirection AST gate bypass closed, container leaks fixed (log rotation, `pids_limit`, container removal, result size caps), stats sandbox result read-back bounded against host-memory amplification.
+- **Event-loop safety (#340, #341, #352, #354)** — consensus orchestration and stats verification offloaded from the event loop; consensus translator expression smuggling closed; engine-call waits bounded (sympy compute-cost gate, provider HTTP timeouts, stats upload cap); CircuitBreaker non-reentrant lock replaced with RLock (#332, #343).
+- **Metrics & deploy (#337, #349, #350)** — all-tenant metrics restricted to explicit platform operators; Prometheus scraping fixed to the `/metrics/prometheus` endpoint.
+- **Supply chain (#355–#361)** — scheduled Dependabot version updates across pip/npm/Go/Rust/Docker/Actions; esbuild dev-server CVE overridden past the patched release.
+
+### Precision advisory (new capability, #347, #348)
+
+- **Advisory flag for binary floating-point constants** in math/stats verification (`precision.advisory`).
+
+### Dependency modernization
+
+- pip: sympy 1.14, z3-solver 5.x, sqlglot 30.x, sentry-sdk 2.68, hatchling 1.32 (#359); GitHub Actions group across 15 actions (#360); Python 3.13 → 3.14 base image (#356); reqwest 0.12 → 0.13 in `sdk-rust` (`rustls-tls` renamed to `rustls`, #357); esbuild override past dev-server CVE (#361).
+
+> **Semver:** minor release — one additive capability (precision advisory) plus fail-closed fixes and dependency modernization. No breaking wire changes.
+
 ## [7.1.0] - 2026-08-16
 
 ### Verification Context v1.0 Rollout

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ## Release Update: v7.2.0 — Security Hardening Batch + Precision Advisory
 
-`v7.2.0` is a fail-closed hardening release: expression/auth/sandbox/event-loop security fixes that restore intended behavior, plus one additive capability — an advisory flag for binary floating-point constants in math/stats verification (`precision.advisory`). No breaking wire changes.
+`v7.2.0` is a fail-closed hardening release: expression/auth/sandbox/event-loop security fixes that restore intended behavior, plus one additive capability — an advisory flag for binary floating-point constants in math/stats verification (emitted as `developer_fields.advisory_checks[]` with `constraint_id: "precision.float-constants"`). No breaking wire changes.
 
 - **Expression & math safety (#329, #330, #344, #346)** — `safe_parse_expr` RCE fixes (NFKC bypass, denylist bypass), structural hardening, math-output gate
 - **Auth hardening (#333, #334, #345)** — KDF removed from pre-auth path, bcrypt offloaded, `/auth/*` throttling

--- a/README.md
+++ b/README.md
@@ -38,20 +38,18 @@
 
 ---
 
-## Release Update: v7.1.0 — Verification Context v1.0 Rollout
+## Release Update: v7.2.0 — Security Hardening Batch + Precision Advisory
 
-`v7.1.0` ships the **Verification Context (VC) v1.0** — the external, interoperable layer on top of `DiagnosticResult`. Verification methods continue to return `DiagnosticResult`; a schema-validated, canonically-encoded, tamper-evident verification document describing *what* was verified, against *what* evidence, under *which* interpretation, with *what* admission decision is produced on demand via the explicit `to_verification_context()` conversion.
+`v7.2.0` is a fail-closed hardening release: expression/auth/sandbox/event-loop security fixes that restore intended behavior, plus one additive capability — an advisory flag for binary floating-point constants in math/stats verification (`precision.advisory`). No breaking wire changes.
 
-- **VC v1.0 spec + ontology (ADR-001..005, #301–#302)** — object of verification, verification context, truth-vs-admission separation, formalization boundary, and root of trust are formally defined
-- **`VerificationContext` model + JSON schema (#308)** — 4-layer document (interpretation / proof / evidence / decision) with RFC 8785 canonical JSON encoding, UTF-16 key ordering, and fail-closed schema validation
-- **Public `proof_ref` generation / resolution (#309)** — content-bound SHA-256 reference generation and resolver exposed as public API
-- **Bridge: `verification_context_from_diagnostic_result()` (#310)** — converts `DiagnosticResult` → VC document; StatsVerifier is the first mapped verifier
-- **SDK / API / CLI exposure (#311)** — VC surfaces across the API routes, CLI, and SDK
-- **Docker action VC outputs (#313)** — the containerized GitHub Action now emits `verdict`, `admission`, `proof_ref`, and `verification_context` outputs
-- **SDK re-exports (#315)** — all VC types re-exported from `qwed_sdk`
-- **`to_verification_context()` on all 13 verifiers (#316)** — full engine coverage; conversion is explicit and returns a `VerificationContextDocument` from a `DiagnosticResult`
+- **Expression & math safety (#329, #330, #344, #346)** — `safe_parse_expr` RCE fixes (NFKC bypass, denylist bypass), structural hardening, math-output gate
+- **Auth hardening (#333, #334, #345)** — KDF removed from pre-auth path, bcrypt offloaded, `/auth/*` throttling
+- **Sandbox containment (#335, #338, #339, #351)** — AST gate bypass closed, container leaks fixed, result read-back bounded
+- **Event-loop safety (#340, #341, #352, #354)** — consensus/stats offloaded, translator smuggling closed, engine waits bounded
+- **Precision advisory (#347, #348)** — new additive flag for binary float constants
+- **Dependency modernization (#355–#361)** — scheduled Dependabot updates; z3 5.x, sqlglot 30.x, Python 3.14 image, reqwest 0.13, esbuild CVE override
 
-> This is an **additive** minor release — no breaking wire changes; existing wire contracts remain unchanged. If you're upgrading from `v7.0.0`, the new VC surface is available but nothing you relied on changed behavior.
+> This is a **minor** release — one additive capability plus fixes; existing wire contracts remain unchanged. If you're upgrading from `v7.1.0`, review the [changelog](CHANGELOG.md) for the security fixes that apply to your deployment.
 
 If you're upgrading from `v6.0.x`, review the [changelog](CHANGELOG.md) for the full migration notes.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed"
-version = "7.1.0"
+version = "7.2.0"
 description = "Open-source AI verification infrastructure for deterministic verification of LLM outputs, tool calls, code, schemas, and agent state before production execution."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/qwed_sdk/__init__.py
+++ b/qwed_sdk/__init__.py
@@ -56,7 +56,7 @@ from qwed_new.core.verification_context import (
     is_valid_document,
 )
 
-__version__ = "7.1.0"
+__version__ = "7.2.0"
 __all__ = [
     "QWEDClient",
     "QWEDAsyncClient",

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qwed"
-version = "7.1.0"
+version = "7.2.0"
 edition = "2021"
 authors = ["QWED-AI"]
 description = "Rust SDK for QWED Verification Protocol"

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -11,7 +11,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qwed = "7.1.0"
+qwed = "7.2.0"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "7.1.0",
+    "version": "7.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@qwed-ai/sdk",
-            "version": "7.1.0",
+            "version": "7.2.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/node": "^20.0.0",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qwed-ai/sdk",
-    "version": "7.1.0",
+    "version": "7.2.0",
     "description": "TypeScript SDK for QWED Verification Protocol",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/src/qwed_new/__init__.py
+++ b/src/qwed_new/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2024 QWED Team
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "7.1.0"
+__version__ = "7.2.0"

--- a/src/qwed_new/api/main.py
+++ b/src/qwed_new/api/main.py
@@ -45,7 +45,7 @@ TenantDependency = Annotated[TenantContext, Depends(get_current_tenant)]
 SessionDependency = Annotated[Session, Depends(get_session)]
 AgentTokenHeader = Annotated[str, Header(...)]
 
-APP_VERSION = "7.1.0"
+APP_VERSION = "7.2.0"
 
 app = FastAPI(
     title="QWED API",

--- a/tests/test_sdk_init.py
+++ b/tests/test_sdk_init.py
@@ -14,7 +14,7 @@ def test_sdk_init_module_executes():
         from qwed_sdk import __version__ as _  # noqa: F401
     from qwed_sdk import __all__ as sdk_all, __version__ as sdk_version
     assert sdk_all is not None
-    assert sdk_version == "7.1.0"
+    assert sdk_version == "7.2.0"
 
 
 def test_sdk_init_exports_verdict_enum():

--- a/tests/test_sdk_init.py
+++ b/tests/test_sdk_init.py
@@ -15,6 +15,10 @@ def test_sdk_init_module_executes():
     from qwed_sdk import __all__ as sdk_all, __version__ as sdk_version
     assert sdk_all is not None
     assert sdk_version == "7.2.0"
+    # CodeRabbit on the v7.2.0 release PR: qwed_sdk.__version__ is assigned
+    # independently, so pin src/qwed_new's version here too.
+    from src.qwed_new import __version__ as core_version
+    assert core_version == "7.2.0"
 
 
 def test_sdk_init_exports_verdict_enum():


### PR DESCRIPTION
Pre-release version bump: **7.1.0 → 7.2.0** (minor — one additive capability plus fail-closed fixes; no breaking wire changes).

**Version sites (all 9, single unified version):** `pyproject.toml`, `sdk-ts/package.json` + lockfile, `sdk-rust/Cargo.toml`, `sdk-rust/README.md` dep example, `qwed_sdk/__init__.py`, `src/qwed_new/__init__.py`, `api/main.py` (`APP_VERSION`), and the `test_sdk_init` pin assert (updated to `7.2.0`).

**Docs:** new `CHANGELOG.md` `## [7.2.0]` entry (security batch grouped by theme with issue/PR refs, precision advisory, dependency modernization, semver note) and a rewritten README release-update section. History entries untouched.

**Verification:** version pin + coverage-gap suites pass (18 tests); full suite 2332 passed with 2 pre-existing environmental failures in `test_pr5_sandbox_containment.py::TestWrapperCap` (confirmed failing on clean `main` too — Windows sandbox subprocess, unrelated to this change).

After merge: tag `v7.2.0`, publish the GitHub release (notes can reuse the changelog entry), and downstream publishes (PyPI, npm, crates.io) pick it up from the manifests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `precision.advisory` capability for identifying binary floating-point constants.
  * Advisory results include structured checks and the `precision.float-constants` constraint identifier.

* **Security**
  * Strengthened expression parsing, authentication, sandboxing, event-loop safety, metrics, deployment, and supply-chain protections.
  * Applied fail-closed behavior to applicable security controls.

* **Improvements**
  * Modernized project dependencies.
  * Released version 7.2.0 across supported SDKs and packages.

* **Compatibility**
  * No breaking wire-level changes are included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->